### PR TITLE
Metric per module

### DIFF
--- a/src/blockchain/deposit_strategy/base_deposit_strategy.py
+++ b/src/blockchain/deposit_strategy/base_deposit_strategy.py
@@ -17,13 +17,13 @@ class BaseDepositStrategy:
     def __init__(self, w3: Web3):
         self.w3 = w3
 
-    def _depositable_ether(self, module_id: int) -> Wei:
+    def _depositable_ether(self) -> Wei:
         depositable_ether = self.w3.lido.lido.get_depositable_ether()
-        DEPOSITABLE_ETHER.labels(module_id).set(depositable_ether)
+        DEPOSITABLE_ETHER.set(depositable_ether)
         return depositable_ether
 
     def deposited_keys_amount(self, module_id: int) -> int:
-        depositable_ether = self._depositable_ether(module_id)
+        depositable_ether = self._depositable_ether()
         possible_deposits_amount = self.w3.lido.staking_router.get_staking_module_max_deposits_count(
             module_id,
             depositable_ether,
@@ -37,8 +37,8 @@ class MellowDepositStrategy(BaseDepositStrategy):
     Performs deposited keys amount check for direct deposits.
     """
 
-    def _depositable_ether(self, module_id: int) -> Wei:
-        depositable_ether = super()._depositable_ether(module_id)
+    def _depositable_ether(self) -> Wei:
+        depositable_ether = super()._depositable_ether()
         additional_ether = self.w3.lido.simple_dvt_staking_strategy.vault_balance()
         if additional_ether > 0:
             logger.info({'msg': 'Adding mellow vault balance to the depositable check', 'vault': additional_ether})

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -15,7 +15,7 @@ from metrics.metrics import (
     ACCOUNT_BALANCE,
     CURRENT_QUORUM_SIZE,
     MELLOW_VAULT_BALANCE,
-    UNEXPECTED_EXCEPTIONS,
+    UNEXPECTED_EXCEPTIONS, MODULE_TX_SEND,
 )
 from metrics.transport_message_metrics import message_metrics_filter
 from schema import Or, Schema
@@ -185,12 +185,7 @@ class DepositorBot:
 
         if is_depositable and quorum and can_deposit and gas_is_ok and is_deposit_amount_ok:
             logger.info({'msg': 'Checks passed. Prepare deposit tx.', 'is_mellow': is_mellow})
-            success = self._sender.prepare_and_send(
-                quorum,
-                self._flashbots_works,
-                is_mellow,
-            )
-            logger.info({'msg': f'Tx send. Result is {success}.'})
+            success = self.prepare_and_send_tx(quorum, is_mellow, self._flashbots_works)
             self._flashbots_works = not self._flashbots_works or success
             self._mellow_works = success
             return success
@@ -278,3 +273,14 @@ class DepositorBot:
             return True
 
         return message_filter
+
+    def prepare_and_send_tx(self, quorum: list[DepositMessage], is_mellow: bool, module_id: int) -> bool:
+        success = self._sender.prepare_and_send(
+            quorum,
+            self._flashbots_works,
+            is_mellow,
+        )
+        logger.info({'msg': f'Tx send. Result is {success}.'})
+        label = 'success' if success else 'failure'
+        MODULE_TX_SEND.labels(label, module_id).inc()
+        return success

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -15,7 +15,8 @@ from metrics.metrics import (
     ACCOUNT_BALANCE,
     CURRENT_QUORUM_SIZE,
     MELLOW_VAULT_BALANCE,
-    UNEXPECTED_EXCEPTIONS, MODULE_TX_SEND,
+    MODULE_TX_SEND,
+    UNEXPECTED_EXCEPTIONS,
 )
 from metrics.transport_message_metrics import message_metrics_filter
 from schema import Or, Schema

--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -9,6 +9,13 @@ TX_SEND = Counter('transactions_send', 'Amount of send transaction from bot.', [
 TX_SEND.labels('success').inc(0)
 TX_SEND.labels('failure').inc(0)
 
+MODULE_TX_SEND = Counter(
+    'transactions',
+    'Amount of send transaction from bot with per module distribution.',
+    ['status', 'module_id'],
+    namespace=PROMETHEUS_PREFIX
+)
+
 ACCOUNT_BALANCE = Gauge('account_balance', 'Account balance', namespace=PROMETHEUS_PREFIX)
 
 DEPOSIT_MESSAGES = Gauge(
@@ -41,7 +48,7 @@ CURRENT_QUORUM_SIZE = Gauge(
 DEPOSITABLE_ETHER = Gauge(
     'depositable_ether',
     'Depositable Ether',
-    ['module_id'],
+    [],
     namespace=PROMETHEUS_PREFIX,
 )
 

--- a/tests/blockchain/deposit_strategy/test_deposit_transaction_sender.py
+++ b/tests/blockchain/deposit_strategy/test_deposit_transaction_sender.py
@@ -1,7 +1,6 @@
 from unittest.mock import Mock
 
 import pytest
-
 from transport.msg_types.deposit import DepositMessage
 
 MODULE_ID = 1

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -20,11 +20,11 @@ from .strategy import (
     base_deposit_strategy,
     base_deposit_strategy_integration,
     deposit_transaction_sender,
+    deposit_transaction_sender_integration,
     gas_price_calculator,
     gas_price_calculator_integration,
-    deposit_transaction_sender_integration,
-    mellow_deposit_strategy_integration,
     mellow_deposit_strategy,
+    mellow_deposit_strategy_integration,
 )
 
 __all__ = [


### PR DESCRIPTION
`DEPOSITABLE_ETHER` - doesn't depend on `module_id`
`MODULE_TX_SEND` - need this metric to see distribution of transaction events per module 