### PR TITLE
Cache chain-id

### DIFF
--- a/src/blockchain/web3_extentions/middleware.py
+++ b/src/blockchain/web3_extentions/middleware.py
@@ -11,7 +11,7 @@ from web3.types import RPCEndpoint, RPCResponse
 logger = logging.getLogger(__name__)
 
 
-def add_requests_metric_middleware(web3: Web3):
+def add_requests_metric_middleware(web3: Web3) -> Web3:
     """
     Works correctly with MultiProvider and vanilla Providers.
 
@@ -21,6 +21,7 @@ def add_requests_metric_middleware(web3: Web3):
 
     def metrics_collector(make_request: Callable[[RPCEndpoint, Any], RPCResponse], w3: Web3) -> Callable[[RPCEndpoint, Any], RPCResponse]:
         """Constructs a middleware which measure requests parameters"""
+        chain_id = w3.eth.chain_id
 
         def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
             try:
@@ -32,6 +33,7 @@ def add_requests_metric_middleware(web3: Web3):
                     method=method,
                     code=failed.status_code,
                     domain=urlparse(web3.provider.endpoint_uri).netloc,  # pyright: ignore
+                    chain_id=chain_id,
                 ).inc()
                 raise
 
@@ -46,12 +48,14 @@ def add_requests_metric_middleware(web3: Web3):
                 method=method,
                 code=code,
                 domain=urlparse(web3.provider.endpoint_uri).netloc,  # pyright: ignore
+                chain_id=chain_id,
             ).inc()
             return response
 
         return middleware
 
     web3.middleware_onion.add(metrics_collector)
+    return web3
 
 
 def add_cache_middleware(web3: Web3) -> Web3:

--- a/src/blockchain/web3_extentions/middleware.py
+++ b/src/blockchain/web3_extentions/middleware.py
@@ -51,6 +51,10 @@ def add_requests_metric_middleware(web3: Web3):
 
         return middleware
 
+    web3.middleware_onion.add(metrics_collector)
+
+
+def add_cache_middleware(web3: Web3) -> Web3:
     web3.middleware_onion.inject(
         construct_simple_cache_middleware(
             rpc_whitelist=cast(
@@ -62,4 +66,4 @@ def add_requests_metric_middleware(web3: Web3):
         ),
         layer=0,
     )
-    web3.middleware_onion.add(metrics_collector)
+    return web3

--- a/src/blockchain/web3_extentions/requests_metric_middleware.py
+++ b/src/blockchain/web3_extentions/requests_metric_middleware.py
@@ -1,10 +1,11 @@
 import logging
-from typing import Any, Callable
+from typing import Any, Callable, Set, cast
 from urllib.parse import urlparse
 
 from metrics.metrics import ETH_RPC_REQUESTS, ETH_RPC_REQUESTS_DURATION
 from requests import HTTPError, Response
 from web3 import Web3
+from web3.middleware import construct_simple_cache_middleware
 from web3.types import RPCEndpoint, RPCResponse
 
 logger = logging.getLogger(__name__)
@@ -50,4 +51,15 @@ def add_requests_metric_middleware(web3: Web3):
 
         return middleware
 
+    web3.middleware_onion.inject(
+        construct_simple_cache_middleware(
+            rpc_whitelist=cast(
+                Set[RPCEndpoint],
+                {
+                    'eth_chainId',
+                },
+            )
+        ),
+        layer=0,
+    )
     web3.middleware_onion.add(metrics_collector)

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -83,7 +83,6 @@ class DepositorBot:
             )
 
         self._onchain_transport_w3 = None
-        self._transport_chain_id = None
         if TransportType.ONCHAIN_TRANSPORT in variables.MESSAGE_TRANSPORTS:
             self._onchain_transport_w3 = OnchainTransportProvider.create_ochain_transport_w3()
             transports.append(

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -11,7 +11,6 @@ from blockchain.deposit_strategy.gas_price_calculator import GasPriceCalculator
 from blockchain.deposit_strategy.strategy import DepositStrategy
 from blockchain.executor import Executor
 from blockchain.typings import Web3
-from blockchain.web3_extentions.middleware import add_cache_middleware
 from metrics.metrics import (
     ACCOUNT_BALANCE,
     CURRENT_QUORUM_SIZE,
@@ -30,7 +29,6 @@ from transport.msg_types.deposit import DepositMessage, DepositMessageSchema
 from transport.msg_types.ping import PingMessageSchema, to_check_sum_address
 from transport.types import TransportType
 from web3.types import BlockData
-from web3_multi_provider import FallbackProvider
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +85,7 @@ class DepositorBot:
         self._onchain_transport_w3 = None
         self._transport_chain_id = None
         if TransportType.ONCHAIN_TRANSPORT in variables.MESSAGE_TRANSPORTS:
-            self._onchain_transport_w3 = add_cache_middleware(Web3(FallbackProvider(variables.ONCHAIN_TRANSPORT_RPC_ENDPOINTS)))
+            self._onchain_transport_w3 = OnchainTransportProvider.create_ochain_transport_w3()
             transports.append(
                 OnchainTransportProvider(
                     w3=self._onchain_transport_w3,

--- a/src/bots/pauser.py
+++ b/src/bots/pauser.py
@@ -17,7 +17,6 @@ from transport.msg_types.pause import PauseMessage, PauseMessageSchema
 from transport.msg_types.ping import PingMessageSchema, to_check_sum_address
 from transport.types import TransportType
 from web3.types import BlockData
-from web3_multi_provider import FallbackProvider
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +50,7 @@ class PauserBot:
         if TransportType.ONCHAIN_TRANSPORT in variables.MESSAGE_TRANSPORTS:
             transports.append(
                 OnchainTransportProvider(
-                    w3=Web3(FallbackProvider(variables.ONCHAIN_TRANSPORT_RPC_ENDPOINTS)),
+                    w3=OnchainTransportProvider.create_ochain_transport_w3(),
                     onchain_address=variables.ONCHAIN_TRANSPORT_ADDRESS,
                     message_schema=Schema(Or(PauseMessageSchema, PingMessageSchema)),
                     parsers_providers=[PauseV2Parser, PauseV3Parser, PingParser],

--- a/src/bots/unvetter.py
+++ b/src/bots/unvetter.py
@@ -16,7 +16,6 @@ from transport.msg_types.unvet import UnvetMessage, UnvetMessageSchema
 from transport.types import TransportType
 from utils.bytes import from_hex_string_to_bytes
 from web3.types import BlockData
-from web3_multi_provider import FallbackProvider
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +55,7 @@ class UnvetterBot:
         if TransportType.ONCHAIN_TRANSPORT in variables.MESSAGE_TRANSPORTS:
             transports.append(
                 OnchainTransportProvider(
-                    w3=Web3(FallbackProvider(variables.ONCHAIN_TRANSPORT_RPC_ENDPOINTS)),
+                    w3=OnchainTransportProvider.create_ochain_transport_w3(),
                     onchain_address=variables.ONCHAIN_TRANSPORT_ADDRESS,
                     message_schema=Schema(Or(UnvetMessageSchema, PingMessageSchema)),
                     parsers_providers=[UnvetParser, PingParser],

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,7 @@ from enum import StrEnum
 import variables
 from blockchain.typings import Web3
 from blockchain.web3_extentions.lido_contracts import LidoContracts
-from blockchain.web3_extentions.requests_metric_middleware import add_requests_metric_middleware
+from blockchain.web3_extentions.middleware import add_cache_middleware, add_requests_metric_middleware
 from blockchain.web3_extentions.transaction import TransactionUtils
 from bots.depositor import run_depositor
 from bots.pauser import run_pauser
@@ -24,13 +24,7 @@ class BotModule(StrEnum):
 
 
 def main(bot_name: str):
-    logger.info(
-        {
-            'msg': 'Bot env variables',
-            'value': variables.PUBLIC_ENV_VARS,
-            'bot_name': bot_name
-        }
-    )
+    logger.info({'msg': 'Bot env variables', 'value': variables.PUBLIC_ENV_VARS, 'bot_name': bot_name})
     if bot_name not in list(BotModule):
         msg = f'Last arg should be one of {[str(item) for item in BotModule]}, received {BotModule}.'
         logger.error({'msg': msg})
@@ -55,7 +49,7 @@ def main(bot_name: str):
     )
 
     logger.info({'msg': 'Add metrics to web3 requests.'})
-    add_requests_metric_middleware(w3)
+    add_requests_metric_middleware(add_cache_middleware(w3))
 
     if bot_name == BotModule.DEPOSITOR:
         run_depositor(w3)

--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -110,7 +110,7 @@ ETH_RPC_REQUESTS_DURATION = Histogram(
 ETH_RPC_REQUESTS = Counter(
     'eth_rpc_requests',
     'Total count of requests to ETH1 RPC',
-    ['method', 'code', 'domain'],
+    ['method', 'code', 'domain', 'chain_id'],
     namespace=PROMETHEUS_PREFIX,
 )
 

--- a/src/transport/msg_providers/onchain_transport.py
+++ b/src/transport/msg_providers/onchain_transport.py
@@ -2,6 +2,8 @@ import abc
 import logging
 from typing import Callable, List, Optional
 
+import variables
+from blockchain.web3_extentions.middleware import add_cache_middleware, add_requests_metric_middleware
 from eth_typing import ChecksumAddress
 from eth_utils import to_bytes
 from schema import Schema
@@ -16,6 +18,7 @@ from web3 import Web3
 from web3._utils.events import get_event_data
 from web3.exceptions import BlockNotFound
 from web3.types import EventData, FilterParams, LogReceipt
+from web3_multi_provider import FallbackProvider
 
 logger = logging.getLogger(__name__)
 
@@ -320,3 +323,7 @@ class OnchainTransportProvider(BaseMessageProvider):
                     }
                 )
         return None
+
+    @staticmethod
+    def create_ochain_transport_w3() -> Web3:
+        return add_requests_metric_middleware(add_cache_middleware(Web3(FallbackProvider(variables.ONCHAIN_TRANSPORT_RPC_ENDPOINTS))))

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -1,5 +1,6 @@
 import unittest
 from datetime import datetime, timedelta
+from unittest import mock
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -125,11 +126,12 @@ def depositor_bot(
     block_data,
     csm_strategy,
 ):
-    variables.MESSAGE_TRANSPORTS = ''
-    variables.DEPOSIT_MODULES_WHITELIST = [1, 2]
-    web3_lido_unit.lido.staking_router.get_staking_module_ids = Mock(return_value=[1, 2])
-    web3_lido_unit.eth.get_block = Mock(return_value=block_data)
-    yield DepositorBot(web3_lido_unit, deposit_transaction_sender, base_deposit_strategy, csm_strategy)
+    with mock.patch('web3.eth.Eth.chain_id', new_callable=mock.PropertyMock) as _:
+        variables.MESSAGE_TRANSPORTS = ''
+        variables.DEPOSIT_MODULES_WHITELIST = [1, 2]
+        web3_lido_unit.lido.staking_router.get_staking_module_ids = Mock(return_value=[1, 2])
+        web3_lido_unit.eth.get_block = Mock(return_value=block_data)
+        yield DepositorBot(web3_lido_unit, deposit_transaction_sender, base_deposit_strategy, csm_strategy)
 
 
 @pytest.fixture


### PR DESCRIPTION
# What
According to the dashboards `chain_id` calls significantly increased in last 2 months, it is increasing usage of the provider node resources. It has huge effect because of the number of the environments we have.

# Why

Decrease usage of the provider resources

# How

Cache `chain_id`

See https://github.com/ethers-io/ethers.js/discussions/2689 for reference, a lot of providers force client to do `chainId` before fetching the block number

