### PR TITLE
chore: update curl version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends -qq \
     gcc=4:12.2.0-3 \
     libffi-dev=3.4.4-1 \
     g++=4:12.2.0-3 \
-    curl=7.88.1-10+deb12u7 \
+    curl=7.88.1-10+deb12u8 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
To avoid: 

```
Dockerfile:3
--------------------
   2 |
   3 | >>> RUN apt-get update && apt-get install -y --no-install-recommends -qq \
   4 | >>>     gcc=4:12.2.0-3 \
   5 | >>>     libffi-dev=3.4.4-1 \
   6 | >>>     g++=4:12.2.0-3 \
   7 | >>>     curl=7.88.1-10+deb12u7 \
   8 | >>>  && apt-get clean \
   9 | >>>  && rm -rf /var/lib/apt/lists/*
  10 |
--------------------
ERROR: failed to solve: : process "/bin/sh -c apt-get update && apt-get install -y --no-install-recommends -qq     gcc=4:12.2.0-3     libffi-dev=3.4.4-1     g++=4:12.2.0-3     curl=7.88.1-10+deb12u7...
```

Details:
```
$ apt-get install -y --no-install-recommends -qq gcc=4:12.2.0-3 libffi-dev=3.4.4-1 g++=4:12.2.0-3 curl=7.88.1-10+deb12u7
> E: Version '7.88.1-10+deb12u7' for 'curl' was not found
```