### PR TITLE
Reorder middlewares

### DIFF
--- a/src/blockchain/web3_extentions/middleware.py
+++ b/src/blockchain/web3_extentions/middleware.py
@@ -51,7 +51,7 @@ def add_requests_metric_middleware(web3: Web3) -> Web3:
 
         return middleware
 
-    web3.middleware_onion.add(metrics_collector)
+    web3.middleware_onion.inject(metrics_collector, layer=0)
     return web3
 
 
@@ -67,4 +67,15 @@ def add_cache_middleware(web3: Web3) -> Web3:
         ),
         layer=0,
     )
+    return web3
+
+
+def add_middlewares(web3: Web3) -> Web3:
+    """
+    Cache middleware should go first to avoid rewriting metrics for cached requests.
+    If middleware has level = 0, the middleware will be appended to the end of the middleware list.
+    So we need [..., cache, other middlewares]
+    """
+    add_cache_middleware(web3)
+    add_requests_metric_middleware(web3)
     return web3

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,7 @@ from enum import StrEnum
 import variables
 from blockchain.typings import Web3
 from blockchain.web3_extentions.lido_contracts import LidoContracts
-from blockchain.web3_extentions.middleware import add_cache_middleware, add_requests_metric_middleware
+from blockchain.web3_extentions.middleware import add_middlewares
 from blockchain.web3_extentions.transaction import TransactionUtils
 from bots.depositor import run_depositor
 from bots.pauser import run_pauser
@@ -49,7 +49,7 @@ def main(bot_name: str):
     )
 
     logger.info({'msg': 'Add metrics to web3 requests.'})
-    add_requests_metric_middleware(add_cache_middleware(w3))
+    add_middlewares(w3)
 
     if bot_name == BotModule.DEPOSITOR:
         run_depositor(w3)

--- a/tests/fixtures/provider.py
+++ b/tests/fixtures/provider.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import pytest
 import variables
 from blockchain.web3_extentions.lido_contracts import LidoContracts
+from blockchain.web3_extentions.middleware import add_middlewares
 from blockchain.web3_extentions.transaction import TransactionUtils
 from web3 import HTTPProvider, Web3
 
@@ -33,9 +34,10 @@ def web3_provider_integration(request) -> Web3:
     anvil_path = os.getenv('ANVIL_PATH', '')
 
     with anvil_fork(anvil_path, rpc_endpoint, block_num):
-        web3 = Web3(HTTPProvider('http://127.0.0.1:8545', request_kwargs={'timeout': 3600}))
-        assert web3.is_connected(), 'Failed to connect to the Web3 provider.'
-        yield web3
+        w3 = Web3(HTTPProvider('http://127.0.0.1:8545', request_kwargs={'timeout': 3600}))
+        add_middlewares(w3)
+        assert w3.is_connected(), 'Failed to connect to the Web3 provider.'
+        yield w3
 
 
 @pytest.fixture


### PR DESCRIPTION
# What

The problem now is that despite requests are cached the metrics are still showing that requests has happened.

# Why

We want not to report cached responses in requests metrics.

# How

So the order of the [inject](https://web3py.readthedocs.io/en/stable/middleware.html#Web3.middleware_onion.inject) matters with web3 middlewares. When we inject middlewares with `level = 0` we always append to the end of the queue of middlewares. So to fail fast with cache middleware we need it to be injected first to achieve order:
`[..., cache middleware, other middlewares which we shouldn't reach after cache]`