### PR TITLE
Run metrics filter on fetch only

### DIFF
--- a/src/transport/msg_storage.py
+++ b/src/transport/msg_storage.py
@@ -46,8 +46,9 @@ class MessageStorage:
         """
         messages = self.messages
         for transport in self._transports:
-            messages.extend(transport.get_messages())
-        self.messages = list(filter(lambda x: self._filter(x) and actualize_filter(x), messages))
+            filtered_messages = list(filter(lambda x: self._filter(x), transport.get_messages()))
+            messages.extend(filtered_messages)
+        self.messages = list(filter(lambda x: actualize_filter(x), messages))
         return self.messages
 
     def clear(self):


### PR DESCRIPTION
# What? 

We are observing an unusual amount of metrics being submitted.


# Why?

The order of applying filters has been changed in https://github.com/lidofinance/depositor-bot/commit/d2268ba65c09b1dbc09844be4c63992a135ccbbb#diff-ef4d808e54a170faa7957fe1afe2583169c4678cbe9861a3936274ce09c5a31cR50 Instead of applying the metrics filter only on fetching messages `MessageStorage` applies them to all the messages in the buffer each time messages are requested.

# How?

Apply initial filters only on fetching messages.