### PR TITLE
feat: make balance metric source of the actual guardian addresses

### DIFF
--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -135,11 +135,16 @@ class DepositorBot:
 
         if self._onchain_transport_w3 is not None:
             providers.append(self._onchain_transport_w3)
-
+        
+        new_values = {}
         for address in guardians:
             for provider in providers:
                 balance = provider.eth.get_balance(address)
-                GUARDIAN_BALANCE.labels(address=address, chain_id=provider.eth.chain_id).set(balance)
+                new_values[(address, provider.eth.chain_id)] = balance
+
+        GUARDIAN_BALANCE.clear()
+        for (address, chain_id), balance in new_values.items():
+            GUARDIAN_BALANCE.labels(address=address, chain_id=chain_id).set(balance)
 
     def _deposit_to_module(self, module_id: int) -> bool:
         can_deposit = self.w3.lido.deposit_security_module.can_deposit(module_id)


### PR DESCRIPTION
# Summary

Clear GUARDIAN_BALANCE metric labels before re-populating them on each cycle. Previously, if a guardian address was removed from the contract, its metric series would remain stale forever. Now all balances are collected first, then `GUARDIAN_BALANCE.clear()` is called before setting the new values — ensuring only current guardian addresses are tracked.

# Test plan

Verify that removing a guardian address from the contract causes its GUARDIAN_BALANCE series to disappear on the next cycle rather than persist
