### PR TITLE
fix: CSM recognition by type

### DIFF
--- a/src/blockchain/contracts/staking_module.py
+++ b/src/blockchain/contracts/staking_module.py
@@ -1,0 +1,16 @@
+import logging
+from functools import lru_cache
+
+from blockchain.contracts.base_interface import ContractInterface
+
+logger = logging.getLogger(__name__)
+
+
+class StakingModuleContract(ContractInterface):
+    abi_path = './interfaces/IStakingModule.json'
+
+    @lru_cache(maxsize=1)
+    def get_type(self) -> bytes:
+        result = self.functions.getType().call()
+        logger.info({'msg': 'Call `getType()`.', 'value': result, 'address': self.address})
+        return result

--- a/src/blockchain/contracts/staking_router.py
+++ b/src/blockchain/contracts/staking_router.py
@@ -1,5 +1,5 @@
 import logging
-from functools import lru_cache  # used by get_contract_version, get_staking_module_ids
+from functools import lru_cache
 from typing import TypedDict
 
 from blockchain.contracts.base_interface import ContractInterface
@@ -48,7 +48,9 @@ class StakingRouterContractV3(ContractInterface):
         return response
 
     def get_all_staking_module_digests(self, block_identifier: BlockIdentifier = 'latest') -> list[StakingModuleInfo]:
-        """Returns staking module digest for passed staking module ids"""
+        """Returns staking module digest for passed staking module ids.
+        V3 state tuple has no wc_type field — all modules default to wc_type=1.
+        """
         response = self.functions.getAllStakingModuleDigests().call(block_identifier=block_identifier)
         logger.info(
             {
@@ -57,7 +59,7 @@ class StakingRouterContractV3(ContractInterface):
                 'block_identifier': block_identifier.__repr__(),
             }
         )
-        return [StakingModuleInfo(module_id=d[2][0], address=d[2][1], wc_type=d[2][13]) for d in response]
+        return [StakingModuleInfo(module_id=d[2][0], address=d[2][1], wc_type=1) for d in response]
 
     def is_staking_module_active(
         self,
@@ -111,6 +113,18 @@ class StakingRouterContractV3(ContractInterface):
 
 class StakingRouterContractV4(StakingRouterContractV3):
     abi_path = './interfaces/StakingRouterV4.json'
+
+    def get_all_staking_module_digests(self, block_identifier: BlockIdentifier = 'latest') -> list[StakingModuleInfo]:
+        """V4 state tuple includes wc_type at index 13."""
+        response = self.functions.getAllStakingModuleDigests().call(block_identifier=block_identifier)
+        logger.info(
+            {
+                'msg': 'Call getAllStakingModuleDigests().',
+                'value': response,
+                'block_identifier': block_identifier.__repr__(),
+            }
+        )
+        return [StakingModuleInfo(module_id=d[2][0], address=d[2][1], wc_type=d[2][13]) for d in response]
 
     def get_deposit_allocations(
         self,

--- a/src/blockchain/contracts/staking_router.py
+++ b/src/blockchain/contracts/staking_router.py
@@ -1,11 +1,14 @@
 import logging
-from functools import lru_cache
+from functools import lru_cache  # used by get_contract_version, get_staking_module_ids
 from typing import TypedDict
 
 from blockchain.contracts.base_interface import ContractInterface
 from web3.types import BlockIdentifier, Wei
 
 logger = logging.getLogger(__name__)
+
+MODULE_TYPE_CMV2 = b'curated-onchain-v2'.ljust(32, b'\x00')
+MODULE_TYPE_CSM = b'community-onchain-v1'.ljust(32, b'\x00')
 
 
 class StakingModuleInfo(TypedDict):
@@ -55,18 +58,6 @@ class StakingRouterContractV3(ContractInterface):
             }
         )
         return [StakingModuleInfo(module_id=d[2][0], address=d[2][1], wc_type=d[2][13]) for d in response]
-
-    def get_staking_module_digests(self, module_ids: list[int], block_identifier: BlockIdentifier = 'latest') -> list[list]:
-        """Returns staking module digest for passed staking module ids"""
-        response = self.functions.getStakingModuleDigests(module_ids).call(block_identifier=block_identifier)
-        logger.info(
-            {
-                'msg': f'Call `getStakingModuleDigests({module_ids})`.',
-                'value': response,
-                'block_identifier': block_identifier.__repr__(),
-            }
-        )
-        return response
 
     def is_staking_module_active(
         self,

--- a/src/blockchain/contracts/staking_router.py
+++ b/src/blockchain/contracts/staking_router.py
@@ -1,10 +1,19 @@
 import logging
 from functools import lru_cache
+from typing import TypedDict
 
 from blockchain.contracts.base_interface import ContractInterface
 from web3.types import BlockIdentifier, Wei
 
 logger = logging.getLogger(__name__)
+
+
+class StakingModuleInfo(TypedDict):
+    """Parsed fields from a StakingModuleDigest tuple returned by StakingRouter."""
+
+    module_id: int
+    address: str
+    wc_type: int
 
 
 class StakingRouterContractV3(ContractInterface):
@@ -35,7 +44,7 @@ class StakingRouterContractV3(ContractInterface):
         )
         return response
 
-    def get_all_staking_module_digests(self, block_identifier: BlockIdentifier = 'latest') -> list[list]:
+    def get_all_staking_module_digests(self, block_identifier: BlockIdentifier = 'latest') -> list[StakingModuleInfo]:
         """Returns staking module digest for passed staking module ids"""
         response = self.functions.getAllStakingModuleDigests().call(block_identifier=block_identifier)
         logger.info(
@@ -45,7 +54,7 @@ class StakingRouterContractV3(ContractInterface):
                 'block_identifier': block_identifier.__repr__(),
             }
         )
-        return response
+        return [StakingModuleInfo(module_id=d[2][0], address=d[2][1], wc_type=d[2][13]) for d in response]
 
     def get_staking_module_digests(self, module_ids: list[int], block_identifier: BlockIdentifier = 'latest') -> list[list]:
         """Returns staking module digest for passed staking module ids"""

--- a/src/blockchain/deposit_strategy/base_deposit_strategy.py
+++ b/src/blockchain/deposit_strategy/base_deposit_strategy.py
@@ -102,7 +102,7 @@ class BaseDepositStrategy(DepositStrategy):
 
         keys = 0
         for i, digest in enumerate(digests):
-            if digest[2][0] == module_id:
+            if digest['module_id'] == module_id:
                 # 32 ETH per validator for 0x01 full deposits
                 keys = allocated[i] // (32 * 10**18)
                 break

--- a/src/blockchain/web3_extentions/lido_contracts.py
+++ b/src/blockchain/web3_extentions/lido_contracts.py
@@ -6,6 +6,7 @@ from blockchain.contracts.deposit import DepositContract
 from blockchain.contracts.deposit_security_module import DepositSecurityModuleContract
 from blockchain.contracts.lido import LidoContract
 from blockchain.contracts.lido_locator import LidoLocatorContract
+from blockchain.contracts.staking_module import StakingModuleContract
 from blockchain.contracts.staking_router import (
     StakingRouterContractV3,
     StakingRouterContractV4,
@@ -23,6 +24,7 @@ class LidoContracts(Module):
         super().__init__(w3)
         self.staking_router_version: int | None = None
         self.topup_gateway: TopUpGatewayContract | None = None
+        self._staking_module_cache: dict[int, StakingModuleContract] = {}
         self._load_contracts()
 
     def has_contract_address_changed(self) -> bool:
@@ -60,6 +62,7 @@ class LidoContracts(Module):
         self._load_dsm()
         if self.staking_router_version == 4:
             self._load_topup_gateway()
+        self._load_staking_modules()
 
     def _load_staking_router(self):
         staking_router_address = self.lido_locator.staking_router()
@@ -102,9 +105,28 @@ class LidoContracts(Module):
             ),
         )
 
+    def _load_staking_modules(self):
+        """Pre-load StakingModuleContract instances for all whitelisted modules."""
+        self._staking_module_cache.clear()
+        digests = self.staking_router.get_all_staking_module_digests()
+        for digest in digests:
+            module_id = digest['module_id']
+            if module_id not in variables.DEPOSIT_MODULES_WHITELIST:
+                continue
+            checksum = self.w3.to_checksum_address(digest['address'])
+            self._staking_module_cache[module_id] = cast(
+                StakingModuleContract,
+                self.w3.eth.contract(address=checksum, ContractFactoryClass=StakingModuleContract),
+            )
+        logger.debug({'msg': 'Loaded staking modules for whitelist.', 'ids': list(self._staking_module_cache.keys())})
+
+    def staking_module(self, module_id: int) -> StakingModuleContract:
+        """Returns the cached StakingModuleContract for the given module id."""
+        return self._staking_module_cache[module_id]
+
     def _load_topup_gateway(self):
         topup_gateway_address = self.lido_locator.top_up_gateway()
-        self.topup_gateway: TopUpGatewayContract = cast(
+        self.topup_gateway = cast(
             TopUpGatewayContract,
             self.w3.eth.contract(
                 address=topup_gateway_address,

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -140,11 +140,8 @@ class DepositorBot:
         return result
 
     def _execute_actual(self) -> bool:
-        # Fetch digests first so _refresh_modules_state can populate the module-type cache.
-        digests = self.w3.lido.staking_router.get_all_staking_module_digests()
-
         # Step 0: refresh quorum + gas metrics for all whitelisted modules (also caches quorum-now per module).
-        self._refresh_modules_state(digests)
+        self._refresh_modules_state()
 
         # Read depositable ether once; if 0 — nothing to do this iteration.
         depositable_ether = self.w3.lido.lido.get_depositable_ether()
@@ -153,9 +150,10 @@ class DepositorBot:
             logger.info({'msg': 'No depositable ether — skip iteration.'})
             return False
 
-        # Compute seed allocation once; both phases use it for module ordering.
+        # Compute seed allocation + digests once; both phases use them for module ordering.
         sr_v4 = cast(StakingRouterContractV4, self.w3.lido.staking_router)
         _total, seed_allocated, seed_new = sr_v4.get_deposit_allocations(depositable_ether, is_top_up=False)
+        digests = self.w3.lido.staking_router.get_all_staking_module_digests()
         logger.info(
             {
                 'msg': 'Seed allocations computed.',
@@ -182,14 +180,8 @@ class DepositorBot:
         logger.info({'msg': 'Phase B finished.', 'done': _done, 'success': success})
         return success
 
-    def _refresh_modules_state(self, digests: list) -> None:
+    def _refresh_modules_state(self) -> None:
         """Update last-quorum heart_beat (cooldown source) and run gas-price probe for metrics, for all whitelisted modules."""
-        for digest in digests:
-            module_id = digest[2][0]
-            module_address = digest[2][1]
-            if module_id in variables.DEPOSIT_MODULES_WHITELIST and module_id not in self._module_type_cache:
-                self._module_type_cache[module_id] = self._get_module_type(module_address)
-
         now = datetime.now()
         logger.info(
             {
@@ -219,9 +211,10 @@ class DepositorBot:
           done=True  -> caller stops (we acted or hit cooldown)
           done=False -> phase produced nothing, caller continues to the next phase
         """
-        candidates: list[tuple[int, Wei]] = []
+        candidates: list[tuple[int, str, Wei]] = []
         for i, digest in enumerate(digests):
             module_id = digest[2][0]
+            module_address = digest[2][1]
             wc_type = digest[2][13]
             if wc_type != 2:
                 continue
@@ -230,22 +223,22 @@ class DepositorBot:
             if seed_allocated[i] == 0:
                 continue
             stake = Wei(seed_new[i] - seed_allocated[i])
-            candidates.append((module_id, stake))
+            candidates.append((module_id, module_address, stake))
 
-        candidates.sort(key=lambda c: c[1])
+        candidates.sort(key=lambda c: c[2])
         logger.info(
             {
                 'msg': 'Phase A (seed 0x02) candidates sorted by stake asc.',
-                'candidates': [{'module_id': c[0], 'stake': int(c[1])} for c in candidates],
+                'candidates': [{'module_id': c[0], 'stake': int(c[2])} for c in candidates],
             }
         )
 
-        for module_id, _stake in candidates:
+        for module_id, module_address, _stake in candidates:
             if not self.w3.lido.deposit_security_module.can_deposit(module_id):
                 logger.info({'msg': 'Phase A: canDeposit=False — try next module.', 'module_id': module_id})
                 continue
             if self._get_quorum(module_id):
-                return True, self._deposit_to_module(module_id)
+                return True, self._deposit_to_module(module_id, module_address)
             # No quorum right now: if cooldown is still active, stop and wait for the next bot iteration.
             if self._is_in_cooldown(module_id):
                 logger.info({'msg': 'Phase A: no quorum, cooldown active — wait next iteration.', 'module_id': module_id})
@@ -255,9 +248,10 @@ class DepositorBot:
 
     def _phase_full(self, seed_allocated: list[int], seed_new: list[int], digests: list) -> tuple[bool, bool]:
         """Full deposits to 0x01 modules using seed (is_top_up=False) allocations."""
-        candidates: list[tuple[int, Wei]] = []
+        candidates: list[tuple[int, str, Wei]] = []
         for i, digest in enumerate(digests):
             module_id = digest[2][0]
+            module_address = digest[2][1]
             wc_type = digest[2][13]
             if wc_type != 1:
                 continue
@@ -266,22 +260,22 @@ class DepositorBot:
             if seed_allocated[i] == 0:
                 continue
             stake = Wei(seed_new[i] - seed_allocated[i])
-            candidates.append((module_id, stake))
+            candidates.append((module_id, module_address, stake))
 
-        candidates.sort(key=lambda c: c[1])
+        candidates.sort(key=lambda c: c[2])
         logger.info(
             {
                 'msg': 'Phase B (full 0x01) candidates sorted by stake asc.',
-                'candidates': [{'module_id': c[0], 'stake': int(c[1])} for c in candidates],
+                'candidates': [{'module_id': c[0], 'stake': int(c[2])} for c in candidates],
             }
         )
 
-        for module_id, _stake in candidates:
+        for module_id, module_address, _stake in candidates:
             if not self.w3.lido.deposit_security_module.can_deposit(module_id):
                 logger.info({'msg': 'Phase B: canDeposit=False — try next module.', 'module_id': module_id})
                 continue
             if self._get_quorum(module_id):
-                return True, self._deposit_to_module(module_id)
+                return True, self._deposit_to_module(module_id, module_address)
             if self._is_in_cooldown(module_id):
                 logger.info({'msg': 'Phase B: no quorum, cooldown active — wait next iteration.', 'module_id': module_id})
                 return True, False
@@ -344,16 +338,16 @@ class DepositorBot:
                 logger.info({'msg': 'Phase B: canDeposit=False — try next module.', 'module_id': module_id})
                 continue
             if self._get_quorum(module_id):
-                return True, self._deposit_to_module(module_id)
+                return True, self._deposit_to_module(module_id, module_address)
             if self._is_in_cooldown(module_id):
                 logger.info({'msg': 'Phase B: no quorum, cooldown active — wait next iteration.', 'module_id': module_id})
                 return True, False
             logger.info({'msg': 'Phase B: no quorum, cooldown expired — try next module.', 'module_id': module_id})
         return False, False
 
-    def _deposit_to_module(self, module_id: int) -> bool:
+    def _deposit_to_module(self, module_id: int, module_address: str) -> bool:
         """New simplified deposit path: gas check (no keys-count) + send."""
-        strategy = self._select_strategy(module_id)
+        strategy = self._select_strategy(module_id, module_address)
         if not strategy.is_gas_price_ok(module_id):
             logger.info({'msg': 'Gas price too high — skip deposit.', 'module_id': module_id})
             return False
@@ -370,7 +364,7 @@ class DepositorBot:
 
     def _top_up_to_module(self, module_id: int, module_address: str, module_allocation: Wei) -> bool:
         """New simplified top-up path: gas check (no keys-count) + proof + send. Allocation is passed in."""
-        module_type = self._get_module_type(module_address)
+        module_type = self._get_module_type(module_id, module_address)
         strategy = self._select_topup_strategy(module_type)
         if strategy is None:
             logger.info(
@@ -425,13 +419,15 @@ class DepositorBot:
             return self._cmv2_topup_strategy
         return None
 
-    def _get_module_type(self, module_address: str) -> bytes:
-        """Call IStakingModule.getType() on the module contract."""
-        module = self.w3.eth.contract(
-            address=self.w3.to_checksum_address(module_address),
-            abi=self.GET_TYPE_ABI,
-        )
-        return module.functions.getType().call()
+    def _get_module_type(self, module_id: int, module_address: str) -> bytes:
+        """Call IStakingModule.getType() on the module contract. Result is cached by module_id."""
+        if module_id not in self._module_type_cache:
+            module = self.w3.eth.contract(
+                address=self.w3.to_checksum_address(module_address),
+                abi=self.GET_TYPE_ABI,
+            )
+            self._module_type_cache[module_id] = module.functions.getType().call()
+        return self._module_type_cache[module_id]
 
     def _check_balance(self):
         if variables.ACCOUNT:
@@ -457,8 +453,11 @@ class DepositorBot:
         for (address, chain_id), balance in new_values.items():
             GUARDIAN_BALANCE.labels(address=address, chain_id=chain_id).set(balance)
 
-    def _select_strategy(self, module_id: int) -> DepositStrategy:
-        if self._module_type_cache.get(module_id) == self.MODULE_TYPE_CSM:
+    def _select_strategy(self, module_id: int, module_address: str = '') -> DepositStrategy:
+        module_type = self._module_type_cache.get(module_id)
+        if module_type is None and module_address:
+            module_type = self._get_module_type(module_id, module_address)
+        if module_type == self.MODULE_TYPE_CSM:
             return self._csm_strategy
         return self._general_strategy
 

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -88,6 +88,7 @@ class DepositorBot:
         self._cl = cl
         now = datetime.now()
         self._module_last_heart_beat: Dict[int, datetime] = {module_id: now for module_id in variables.DEPOSIT_MODULES_WHITELIST}
+        self._module_type_cache: Dict[int, bytes] = {}
 
         transports = []
 
@@ -139,8 +140,11 @@ class DepositorBot:
         return result
 
     def _execute_actual(self) -> bool:
+        # Fetch digests first so _refresh_modules_state can populate the module-type cache.
+        digests = self.w3.lido.staking_router.get_all_staking_module_digests()
+
         # Step 0: refresh quorum + gas metrics for all whitelisted modules (also caches quorum-now per module).
-        self._refresh_modules_state()
+        self._refresh_modules_state(digests)
 
         # Read depositable ether once; if 0 — nothing to do this iteration.
         depositable_ether = self.w3.lido.lido.get_depositable_ether()
@@ -149,10 +153,9 @@ class DepositorBot:
             logger.info({'msg': 'No depositable ether — skip iteration.'})
             return False
 
-        # Compute seed allocation + digests once; both phases use them for module ordering.
+        # Compute seed allocation once; both phases use it for module ordering.
         sr_v4 = cast(StakingRouterContractV4, self.w3.lido.staking_router)
         _total, seed_allocated, seed_new = sr_v4.get_deposit_allocations(depositable_ether, is_top_up=False)
-        digests = self.w3.lido.staking_router.get_all_staking_module_digests()
         logger.info(
             {
                 'msg': 'Seed allocations computed.',
@@ -179,8 +182,14 @@ class DepositorBot:
         logger.info({'msg': 'Phase B finished.', 'done': _done, 'success': success})
         return success
 
-    def _refresh_modules_state(self) -> None:
+    def _refresh_modules_state(self, digests: list) -> None:
         """Update last-quorum heart_beat (cooldown source) and run gas-price probe for metrics, for all whitelisted modules."""
+        for digest in digests:
+            module_id = digest[2][0]
+            module_address = digest[2][1]
+            if module_id in variables.DEPOSIT_MODULES_WHITELIST and module_id not in self._module_type_cache:
+                self._module_type_cache[module_id] = self._get_module_type(module_address)
+
         now = datetime.now()
         logger.info(
             {
@@ -408,6 +417,7 @@ class DepositorBot:
         return success
 
     MODULE_TYPE_CMV2 = b'curated-onchain-v2'.ljust(32, b'\x00')
+    MODULE_TYPE_CSM = b'community-onchain-v1'.ljust(32, b'\x00')
     GET_TYPE_ABI = ContractInterface.load_abi('./interfaces/IStakingModule.json')
 
     def _select_topup_strategy(self, module_type: bytes) -> Optional[TopUpStrategy]:
@@ -447,9 +457,8 @@ class DepositorBot:
         for (address, chain_id), balance in new_values.items():
             GUARDIAN_BALANCE.labels(address=address, chain_id=chain_id).set(balance)
 
-    def _select_strategy(self, module_id) -> DepositStrategy:
-        # todo: check by getType
-        if module_id == 3:
+    def _select_strategy(self, module_id: int) -> DepositStrategy:
+        if self._module_type_cache.get(module_id) == self.MODULE_TYPE_CSM:
             return self._csm_strategy
         return self._general_strategy
 

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -140,6 +140,9 @@ class DepositorBot:
         return result
 
     def _execute_actual(self) -> bool:
+        # Populate module-type cache once at startup (no-op on subsequent iterations).
+        self._ensure_module_type_cache()
+
         # Step 0: refresh quorum + gas metrics for all whitelisted modules (also caches quorum-now per module).
         self._refresh_modules_state()
 
@@ -180,6 +183,18 @@ class DepositorBot:
         logger.info({'msg': 'Phase B finished.', 'done': _done, 'success': success})
         return success
 
+    def _ensure_module_type_cache(self) -> None:
+        """Fetch module types for all whitelisted modules that are not yet cached. Runs once at startup, no-op afterwards."""
+        uncached = [mid for mid in variables.DEPOSIT_MODULES_WHITELIST if mid not in self._module_type_cache]
+        if not uncached:
+            return
+        digests = self.w3.lido.staking_router.get_all_staking_module_digests()
+        for digest in digests:
+            module_id = digest[2][0]
+            module_address = digest[2][1]
+            if module_id in uncached:
+                self._module_type_cache[module_id] = self._get_module_type(module_address)
+
     def _refresh_modules_state(self) -> None:
         """Update last-quorum heart_beat (cooldown source) and run gas-price probe for metrics, for all whitelisted modules."""
         now = datetime.now()
@@ -211,10 +226,9 @@ class DepositorBot:
           done=True  -> caller stops (we acted or hit cooldown)
           done=False -> phase produced nothing, caller continues to the next phase
         """
-        candidates: list[tuple[int, str, Wei]] = []
+        candidates: list[tuple[int, Wei]] = []
         for i, digest in enumerate(digests):
             module_id = digest[2][0]
-            module_address = digest[2][1]
             wc_type = digest[2][13]
             if wc_type != 2:
                 continue
@@ -223,22 +237,22 @@ class DepositorBot:
             if seed_allocated[i] == 0:
                 continue
             stake = Wei(seed_new[i] - seed_allocated[i])
-            candidates.append((module_id, module_address, stake))
+            candidates.append((module_id, stake))
 
-        candidates.sort(key=lambda c: c[2])
+        candidates.sort(key=lambda c: c[1])
         logger.info(
             {
                 'msg': 'Phase A (seed 0x02) candidates sorted by stake asc.',
-                'candidates': [{'module_id': c[0], 'stake': int(c[2])} for c in candidates],
+                'candidates': [{'module_id': c[0], 'stake': int(c[1])} for c in candidates],
             }
         )
 
-        for module_id, module_address, _stake in candidates:
+        for module_id, _stake in candidates:
             if not self.w3.lido.deposit_security_module.can_deposit(module_id):
                 logger.info({'msg': 'Phase A: canDeposit=False — try next module.', 'module_id': module_id})
                 continue
             if self._get_quorum(module_id):
-                return True, self._deposit_to_module(module_id, module_address)
+                return True, self._deposit_to_module(module_id)
             # No quorum right now: if cooldown is still active, stop and wait for the next bot iteration.
             if self._is_in_cooldown(module_id):
                 logger.info({'msg': 'Phase A: no quorum, cooldown active — wait next iteration.', 'module_id': module_id})
@@ -248,10 +262,9 @@ class DepositorBot:
 
     def _phase_full(self, seed_allocated: list[int], seed_new: list[int], digests: list) -> tuple[bool, bool]:
         """Full deposits to 0x01 modules using seed (is_top_up=False) allocations."""
-        candidates: list[tuple[int, str, Wei]] = []
+        candidates: list[tuple[int, Wei]] = []
         for i, digest in enumerate(digests):
             module_id = digest[2][0]
-            module_address = digest[2][1]
             wc_type = digest[2][13]
             if wc_type != 1:
                 continue
@@ -260,22 +273,22 @@ class DepositorBot:
             if seed_allocated[i] == 0:
                 continue
             stake = Wei(seed_new[i] - seed_allocated[i])
-            candidates.append((module_id, module_address, stake))
+            candidates.append((module_id, stake))
 
-        candidates.sort(key=lambda c: c[2])
+        candidates.sort(key=lambda c: c[1])
         logger.info(
             {
                 'msg': 'Phase B (full 0x01) candidates sorted by stake asc.',
-                'candidates': [{'module_id': c[0], 'stake': int(c[2])} for c in candidates],
+                'candidates': [{'module_id': c[0], 'stake': int(c[1])} for c in candidates],
             }
         )
 
-        for module_id, module_address, _stake in candidates:
+        for module_id, _stake in candidates:
             if not self.w3.lido.deposit_security_module.can_deposit(module_id):
                 logger.info({'msg': 'Phase B: canDeposit=False — try next module.', 'module_id': module_id})
                 continue
             if self._get_quorum(module_id):
-                return True, self._deposit_to_module(module_id, module_address)
+                return True, self._deposit_to_module(module_id)
             if self._is_in_cooldown(module_id):
                 logger.info({'msg': 'Phase B: no quorum, cooldown active — wait next iteration.', 'module_id': module_id})
                 return True, False
@@ -338,16 +351,16 @@ class DepositorBot:
                 logger.info({'msg': 'Phase B: canDeposit=False — try next module.', 'module_id': module_id})
                 continue
             if self._get_quorum(module_id):
-                return True, self._deposit_to_module(module_id, module_address)
+                return True, self._deposit_to_module(module_id)
             if self._is_in_cooldown(module_id):
                 logger.info({'msg': 'Phase B: no quorum, cooldown active — wait next iteration.', 'module_id': module_id})
                 return True, False
             logger.info({'msg': 'Phase B: no quorum, cooldown expired — try next module.', 'module_id': module_id})
         return False, False
 
-    def _deposit_to_module(self, module_id: int, module_address: str) -> bool:
+    def _deposit_to_module(self, module_id: int) -> bool:
         """New simplified deposit path: gas check (no keys-count) + send."""
-        strategy = self._select_strategy(module_id, module_address)
+        strategy = self._select_strategy(module_id)
         if not strategy.is_gas_price_ok(module_id):
             logger.info({'msg': 'Gas price too high — skip deposit.', 'module_id': module_id})
             return False
@@ -364,7 +377,7 @@ class DepositorBot:
 
     def _top_up_to_module(self, module_id: int, module_address: str, module_allocation: Wei) -> bool:
         """New simplified top-up path: gas check (no keys-count) + proof + send. Allocation is passed in."""
-        module_type = self._get_module_type(module_id, module_address)
+        module_type = self._get_module_type(module_address)
         strategy = self._select_topup_strategy(module_type)
         if strategy is None:
             logger.info(
@@ -419,15 +432,13 @@ class DepositorBot:
             return self._cmv2_topup_strategy
         return None
 
-    def _get_module_type(self, module_id: int, module_address: str) -> bytes:
-        """Call IStakingModule.getType() on the module contract. Result is cached by module_id."""
-        if module_id not in self._module_type_cache:
-            module = self.w3.eth.contract(
-                address=self.w3.to_checksum_address(module_address),
-                abi=self.GET_TYPE_ABI,
-            )
-            self._module_type_cache[module_id] = module.functions.getType().call()
-        return self._module_type_cache[module_id]
+    def _get_module_type(self, module_address: str) -> bytes:
+        """Call IStakingModule.getType() on the module contract."""
+        module = self.w3.eth.contract(
+            address=self.w3.to_checksum_address(module_address),
+            abi=self.GET_TYPE_ABI,
+        )
+        return module.functions.getType().call()
 
     def _check_balance(self):
         if variables.ACCOUNT:
@@ -453,11 +464,8 @@ class DepositorBot:
         for (address, chain_id), balance in new_values.items():
             GUARDIAN_BALANCE.labels(address=address, chain_id=chain_id).set(balance)
 
-    def _select_strategy(self, module_id: int, module_address: str = '') -> DepositStrategy:
-        module_type = self._module_type_cache.get(module_id)
-        if module_type is None and module_address:
-            module_type = self._get_module_type(module_id, module_address)
-        if module_type == self.MODULE_TYPE_CSM:
+    def _select_strategy(self, module_id: int) -> DepositStrategy:
+        if self._module_type_cache.get(module_id) == self.MODULE_TYPE_CSM:
             return self._csm_strategy
         return self._general_strategy
 

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -138,8 +138,6 @@ class DepositorBot:
         return result
 
     def _execute_actual(self) -> bool:
-        digests: list[StakingModuleInfo] = self.w3.lido.staking_router.get_all_staking_module_digests()
-
         # Step 0: refresh quorum + gas metrics for all whitelisted modules.
         self._refresh_modules_state()
 
@@ -161,6 +159,7 @@ class DepositorBot:
                 'new': list(seed_new),
             }
         )
+        digests: list[StakingModuleInfo] = self.w3.lido.staking_router.get_all_staking_module_digests()
 
         # Phase A: seed deposits into 0x02 modules.
         logger.info({'msg': 'Phase A start: seed deposits to 0x02 modules.'})

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -6,7 +6,7 @@ from typing import Callable, Dict, List, Optional, cast
 
 import variables
 from blockchain.contracts.base_interface import ContractInterface
-from blockchain.contracts.staking_router import StakingRouterContractV4
+from blockchain.contracts.staking_router import StakingModuleInfo, StakingRouterContractV4
 from blockchain.deposit_strategy.base_deposit_strategy import (
     CSMDepositStrategy,
     DefaultDepositStrategy,
@@ -140,11 +140,10 @@ class DepositorBot:
         return result
 
     def _execute_actual(self) -> bool:
-        # Populate module-type cache once at startup (no-op on subsequent iterations).
-        self._ensure_module_type_cache()
+        digests: list[StakingModuleInfo] = self.w3.lido.staking_router.get_all_staking_module_digests()
 
         # Step 0: refresh quorum + gas metrics for all whitelisted modules (also caches quorum-now per module).
-        self._refresh_modules_state()
+        self._refresh_modules_state(digests)
 
         # Read depositable ether once; if 0 — nothing to do this iteration.
         depositable_ether = self.w3.lido.lido.get_depositable_ether()
@@ -153,10 +152,9 @@ class DepositorBot:
             logger.info({'msg': 'No depositable ether — skip iteration.'})
             return False
 
-        # Compute seed allocation + digests once; both phases use them for module ordering.
+        # Compute seed allocation once; both phases use it for module ordering.
         sr_v4 = cast(StakingRouterContractV4, self.w3.lido.staking_router)
         _total, seed_allocated, seed_new = sr_v4.get_deposit_allocations(depositable_ether, is_top_up=False)
-        digests = self.w3.lido.staking_router.get_all_staking_module_digests()
         logger.info(
             {
                 'msg': 'Seed allocations computed.',
@@ -183,20 +181,10 @@ class DepositorBot:
         logger.info({'msg': 'Phase B finished.', 'done': _done, 'success': success})
         return success
 
-    def _ensure_module_type_cache(self) -> None:
-        """Fetch module types for all whitelisted modules that are not yet cached. Runs once at startup, no-op afterwards."""
-        uncached = [mid for mid in variables.DEPOSIT_MODULES_WHITELIST if mid not in self._module_type_cache]
-        if not uncached:
-            return
-        digests = self.w3.lido.staking_router.get_all_staking_module_digests()
-        for digest in digests:
-            module_id = digest[2][0]
-            module_address = digest[2][1]
-            if module_id in uncached:
-                self._module_type_cache[module_id] = self._get_module_type(module_address)
-
-    def _refresh_modules_state(self) -> None:
+    def _refresh_modules_state(self, digests: list[StakingModuleInfo]) -> None:
         """Update last-quorum heart_beat (cooldown source) and run gas-price probe for metrics, for all whitelisted modules."""
+        addr_by_id: Dict[int, str] = {d['module_id']: d['address'] for d in digests}
+
         now = datetime.now()
         logger.info(
             {
@@ -205,6 +193,8 @@ class DepositorBot:
             }
         )
         for module_id in variables.DEPOSIT_MODULES_WHITELIST:
+            if module_id not in self._module_type_cache and module_id in addr_by_id:
+                self._module_type_cache[module_id] = self._get_module_type(addr_by_id[module_id])
             # Probe gas-price strategy purely for metrics — gas is re-checked right before the tx is sent.
             self._select_strategy(module_id).is_gas_price_ok(module_id)
             quorum = self._get_quorum(module_id)
@@ -219,7 +209,7 @@ class DepositorBot:
         last = self._module_last_heart_beat[module_id]
         return (datetime.now() - last) <= timedelta(minutes=variables.QUORUM_RETENTION_MINUTES)
 
-    def _phase_seed(self, seed_allocated: list[int], seed_new: list[int], digests: list) -> tuple[bool, bool]:
+    def _phase_seed(self, seed_allocated: list[int], seed_new: list[int], digests: list[StakingModuleInfo]) -> tuple[bool, bool]:
         """
         Seed deposits into 0x02 modules using is_top_up=False allocations.
         Returns (done, success):
@@ -228,8 +218,8 @@ class DepositorBot:
         """
         candidates: list[tuple[int, Wei]] = []
         for i, digest in enumerate(digests):
-            module_id = digest[2][0]
-            wc_type = digest[2][13]
+            module_id = digest['module_id']
+            wc_type = digest['wc_type']
             if wc_type != 2:
                 continue
             if module_id not in variables.DEPOSIT_MODULES_WHITELIST:
@@ -260,12 +250,12 @@ class DepositorBot:
             logger.info({'msg': 'Phase A: no quorum, cooldown expired — try next module.', 'module_id': module_id})
         return False, False
 
-    def _phase_full(self, seed_allocated: list[int], seed_new: list[int], digests: list) -> tuple[bool, bool]:
+    def _phase_full(self, seed_allocated: list[int], seed_new: list[int], digests: list[StakingModuleInfo]) -> tuple[bool, bool]:
         """Full deposits to 0x01 modules using seed (is_top_up=False) allocations."""
         candidates: list[tuple[int, Wei]] = []
         for i, digest in enumerate(digests):
-            module_id = digest[2][0]
-            wc_type = digest[2][13]
+            module_id = digest['module_id']
+            wc_type = digest['wc_type']
             if wc_type != 1:
                 continue
             if module_id not in variables.DEPOSIT_MODULES_WHITELIST:
@@ -300,7 +290,7 @@ class DepositorBot:
         depositable_ether: Wei,
         seed_allocated: list[int],
         seed_new: list[int],
-        digests: list,
+        digests: list[StakingModuleInfo],
     ) -> tuple[bool, bool]:
         """
         Full deposits to 0x01 + top-ups to 0x02.
@@ -312,9 +302,9 @@ class DepositorBot:
 
         candidates: list[tuple[int, str, int, Wei, Wei]] = []  # (module_id, address, wc_type, stake, topup_allocation)
         for i, digest in enumerate(digests):
-            module_id = digest[2][0]
-            module_address = digest[2][1]
-            wc_type = digest[2][13]
+            module_id = digest['module_id']
+            module_address = digest['address']
+            wc_type = digest['wc_type']
             if module_id not in variables.DEPOSIT_MODULES_WHITELIST:
                 continue
             if wc_type == 2:

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -5,8 +5,7 @@ from datetime import datetime, timedelta
 from typing import Callable, Dict, List, Optional, cast
 
 import variables
-from blockchain.contracts.base_interface import ContractInterface
-from blockchain.contracts.staking_router import StakingModuleInfo, StakingRouterContractV4
+from blockchain.contracts.staking_router import MODULE_TYPE_CMV2, MODULE_TYPE_CSM, StakingModuleInfo, StakingRouterContractV4
 from blockchain.deposit_strategy.base_deposit_strategy import (
     CSMDepositStrategy,
     DefaultDepositStrategy,
@@ -88,7 +87,6 @@ class DepositorBot:
         self._cl = cl
         now = datetime.now()
         self._module_last_heart_beat: Dict[int, datetime] = {module_id: now for module_id in variables.DEPOSIT_MODULES_WHITELIST}
-        self._module_type_cache: Dict[int, bytes] = {}
 
         transports = []
 
@@ -142,8 +140,8 @@ class DepositorBot:
     def _execute_actual(self) -> bool:
         digests: list[StakingModuleInfo] = self.w3.lido.staking_router.get_all_staking_module_digests()
 
-        # Step 0: refresh quorum + gas metrics for all whitelisted modules (also caches quorum-now per module).
-        self._refresh_modules_state(digests)
+        # Step 0: refresh quorum + gas metrics for all whitelisted modules.
+        self._refresh_modules_state()
 
         # Read depositable ether once; if 0 — nothing to do this iteration.
         depositable_ether = self.w3.lido.lido.get_depositable_ether()
@@ -181,10 +179,8 @@ class DepositorBot:
         logger.info({'msg': 'Phase B finished.', 'done': _done, 'success': success})
         return success
 
-    def _refresh_modules_state(self, digests: list[StakingModuleInfo]) -> None:
+    def _refresh_modules_state(self) -> None:
         """Update last-quorum heart_beat (cooldown source) and run gas-price probe for metrics, for all whitelisted modules."""
-        addr_by_id: Dict[int, str] = {d['module_id']: d['address'] for d in digests}
-
         now = datetime.now()
         logger.info(
             {
@@ -193,8 +189,6 @@ class DepositorBot:
             }
         )
         for module_id in variables.DEPOSIT_MODULES_WHITELIST:
-            if module_id not in self._module_type_cache and module_id in addr_by_id:
-                self._module_type_cache[module_id] = self._get_module_type(addr_by_id[module_id])
             # Probe gas-price strategy purely for metrics — gas is re-checked right before the tx is sent.
             self._select_strategy(module_id).is_gas_price_ok(module_id)
             quorum = self._get_quorum(module_id)
@@ -367,7 +361,7 @@ class DepositorBot:
 
     def _top_up_to_module(self, module_id: int, module_address: str, module_allocation: Wei) -> bool:
         """New simplified top-up path: gas check (no keys-count) + proof + send. Allocation is passed in."""
-        module_type = self._get_module_type(module_address)
+        module_type = self.w3.lido.staking_module(module_id).get_type()
         strategy = self._select_topup_strategy(module_type)
         if strategy is None:
             logger.info(
@@ -413,22 +407,10 @@ class DepositorBot:
         logger.info({'msg': f'Top-up tx result: {success}.', 'module_id': module_id})
         return success
 
-    MODULE_TYPE_CMV2 = b'curated-onchain-v2'.ljust(32, b'\x00')
-    MODULE_TYPE_CSM = b'community-onchain-v1'.ljust(32, b'\x00')
-    GET_TYPE_ABI = ContractInterface.load_abi('./interfaces/IStakingModule.json')
-
     def _select_topup_strategy(self, module_type: bytes) -> Optional[TopUpStrategy]:
-        if module_type == self.MODULE_TYPE_CMV2:
+        if module_type == MODULE_TYPE_CMV2:
             return self._cmv2_topup_strategy
         return None
-
-    def _get_module_type(self, module_address: str) -> bytes:
-        """Call IStakingModule.getType() on the module contract."""
-        module = self.w3.eth.contract(
-            address=self.w3.to_checksum_address(module_address),
-            abi=self.GET_TYPE_ABI,
-        )
-        return module.functions.getType().call()
 
     def _check_balance(self):
         if variables.ACCOUNT:
@@ -455,7 +437,7 @@ class DepositorBot:
             GUARDIAN_BALANCE.labels(address=address, chain_id=chain_id).set(balance)
 
     def _select_strategy(self, module_id: int) -> DepositStrategy:
-        if self._module_type_cache.get(module_id) == self.MODULE_TYPE_CSM:
+        if self.w3.lido.staking_module(module_id).get_type() == MODULE_TYPE_CSM:
             return self._csm_strategy
         return self._general_strategy
 

--- a/tests/blockchain/contracts/test_staking_router.py
+++ b/tests/blockchain/contracts/test_staking_router.py
@@ -15,7 +15,6 @@ def test_staking_router_call_v3(staking_router_v3, caplog):
                 lambda response: check_value_type(response, list) and [check_value_type(x, int) for x in response],
             ),
             ('is_staking_module_active', (1,), lambda response: check_value_type(response, bool)),
-            ('get_staking_module_digests', ([1],), lambda response: check_value_type(response, list)),
             ('get_staking_module_nonce', (1,), lambda response: check_value_type(response, int)),
             ('get_staking_module_max_deposits_count', (1, 100 * 10**18), lambda response: check_value_type(response, int)),
         ],
@@ -37,7 +36,6 @@ def test_staking_router_call_v4(staking_router_v4, caplog):
                 lambda response: check_value_type(response, list) and [check_value_type(x, int) for x in response],
             ),
             ('is_staking_module_active', (1,), lambda response: check_value_type(response, bool)),
-            ('get_staking_module_digests', ([1],), lambda response: check_value_type(response, list)),
             ('get_staking_module_nonce', (1,), lambda response: check_value_type(response, int)),
             ('get_staking_module_max_deposits_count', (1, 100 * 10**18), lambda response: check_value_type(response, int)),
             (

--- a/tests/blockchain/deposit_strategy/test_base_deposit_strategy.py
+++ b/tests/blockchain/deposit_strategy/test_base_deposit_strategy.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
+from blockchain.contracts.staking_router import StakingModuleInfo
 
 
 @pytest.mark.unit
@@ -17,8 +18,7 @@ def test_csm_deposit_strategy(csm_strategy):
 
 
 def _digest(module_id):
-    """Minimal digest where digest[2][0] is the module_id."""
-    return (0, 0, (module_id, '', 0, 0, 0, 0, '', 0, 0, 0, 0, 0, 0, 1, 0, 0), (0, 0, 0))
+    return StakingModuleInfo(module_id=module_id, address='', wc_type=1)
 
 
 def _setup_allocation(strategy, module_id, allocated_wei, depositable=100 * 10**18):
@@ -83,7 +83,7 @@ def test_allocation_calls_get_deposit_allocations_with_top_up_true(base_deposit_
 
 @pytest.mark.unit
 def test_allocation_lookup_by_module_id_not_index(base_deposit_strategy):
-    """Allocation must be picked by digest[2][0] == module_id, not by list position."""
+    """Allocation must be picked by digest['module_id'] == module_id, not by list position."""
     base_deposit_strategy.w3.lido.lido.get_depositable_ether = Mock(return_value=300 * 10**18)
     # digests=[m1, m2, m3]; allocations=[100, 200, 64] ETH → module_id=3 must get 64 ETH (2 keys)
     base_deposit_strategy.w3.lido.staking_router.get_deposit_allocations = Mock(

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -51,7 +51,7 @@ class TestRefreshModulesState(unittest.TestCase):
         self.bot._get_quorum = Mock(return_value=None)
         self.bot._select_strategy = Mock(return_value=Mock())
 
-        self.bot._refresh_modules_state([])
+        self.bot._refresh_modules_state()
 
         called_ids = sorted(c.args[0] for c in self.bot._get_quorum.call_args_list)
         self.assertEqual([1, 2, 3], called_ids)
@@ -61,7 +61,7 @@ class TestRefreshModulesState(unittest.TestCase):
         strategy = Mock()
         self.bot._select_strategy = Mock(return_value=strategy)
 
-        self.bot._refresh_modules_state([])
+        self.bot._refresh_modules_state()
 
         # is_gas_price_ok called once per whitelisted module
         self.assertEqual(3, strategy.is_gas_price_ok.call_count)
@@ -73,7 +73,7 @@ class TestRefreshModulesState(unittest.TestCase):
         old = datetime.now() - timedelta(hours=2)
         self.bot._module_last_heart_beat = {1: old, 2: old, 3: old}
 
-        self.bot._refresh_modules_state([])
+        self.bot._refresh_modules_state()
 
         for module_id in [1, 2, 3]:
             self.assertGreater(self.bot._module_last_heart_beat[module_id], old)
@@ -85,7 +85,7 @@ class TestRefreshModulesState(unittest.TestCase):
         old = datetime.now() - timedelta(hours=2)
         self.bot._module_last_heart_beat = {1: old, 2: old, 3: old}
 
-        self.bot._refresh_modules_state([])
+        self.bot._refresh_modules_state()
 
         for module_id in [1, 2, 3]:
             self.assertEqual(old, self.bot._module_last_heart_beat[module_id])
@@ -95,7 +95,7 @@ class TestRefreshModulesState(unittest.TestCase):
         self.bot._get_quorum = Mock()
         self.bot._select_strategy = Mock()
 
-        self.bot._refresh_modules_state([])
+        self.bot._refresh_modules_state()
 
         self.bot._get_quorum.assert_not_called()
         self.bot._select_strategy.assert_not_called()
@@ -107,49 +107,11 @@ class TestRefreshModulesState(unittest.TestCase):
         self.bot._get_quorum = Mock(return_value=None)
         self.bot._select_strategy = Mock(return_value=Mock())
 
-        self.bot._refresh_modules_state([])
+        self.bot._refresh_modules_state()
 
         called_ids = sorted(c.args[0] for c in self.bot._get_quorum.call_args_list)
         self.assertEqual([1, 3], called_ids)
 
-    def test_populates_module_type_cache_from_digests(self):
-        self.bot._get_quorum = Mock(return_value=None)
-        self.bot._select_strategy = Mock(return_value=Mock())
-        cmv2_type = DepositorBot.MODULE_TYPE_CMV2
-        self.bot._get_module_type = Mock(return_value=cmv2_type)
-
-        digests = [_make_digest(1, '0xAddr1', 2), _make_digest(2, '0xAddr2', 1)]
-        self.bot._refresh_modules_state(digests)
-
-        self.assertEqual(cmv2_type, self.bot._module_type_cache[1])
-        self.assertEqual(cmv2_type, self.bot._module_type_cache[2])
-
-    def test_module_type_cache_not_refetched_if_already_present(self):
-        self.bot._get_quorum = Mock(return_value=None)
-        self.bot._select_strategy = Mock(return_value=Mock())
-        existing_type = b'some-other-type'.ljust(32, b'\x00')
-        self.bot._module_type_cache[1] = existing_type
-        self.bot._get_module_type = Mock(return_value=DepositorBot.MODULE_TYPE_CMV2)
-
-        self.bot._refresh_modules_state([_make_digest(1, '0xAddr1', 2)])
-
-        # Cache entry for module 1 must not be overwritten.
-        self.assertEqual(existing_type, self.bot._module_type_cache[1])
-        self.bot._get_module_type.assert_not_called()
-
-    def test_type_cache_only_populated_for_whitelisted(self):
-        variables.DEPOSIT_MODULES_WHITELIST = [1]
-        self.bot._module_last_heart_beat = {1: datetime.now()}
-        self.bot._get_quorum = Mock(return_value=None)
-        self.bot._select_strategy = Mock(return_value=Mock())
-        self.bot._get_module_type = Mock(return_value=DepositorBot.MODULE_TYPE_CMV2)
-
-        # module 2 is not whitelisted
-        digests = [_make_digest(1, '0xAddr1', 2), _make_digest(2, '0xAddr2', 2)]
-        self.bot._refresh_modules_state(digests)
-
-        self.assertIn(1, self.bot._module_type_cache)
-        self.assertNotIn(2, self.bot._module_type_cache)
 
 
 # ─── _is_in_cooldown ───────────────────────────────────────────────
@@ -205,7 +167,7 @@ class TestPhaseSeed(unittest.TestCase):
         self.bot._get_quorum = Mock(return_value=['msg'])
         # module 1: allocated=0 → skipped; module 2: allocated=50 → deposits
         self.bot._phase_seed([0, 50], [0, 100], digests)
-        self.bot._deposit_to_module.assert_called_once_with(2)
+        self.bot._deposit_to_module.assert_called_once_with(2, '0xA2')
 
     def test_filters_non_whitelisted(self):
         digests = [_make_digest(4, '0xA4', 2)]
@@ -225,7 +187,7 @@ class TestPhaseSeed(unittest.TestCase):
 
         self.assertEqual((True, True), (done, success))
         # Lowest-stake module (id=2) is tried first.
-        self.bot._deposit_to_module.assert_called_once_with(2)
+        self.bot._deposit_to_module.assert_called_once_with(2, '0xA2')
 
     def test_index_alignment_with_subset_whitelist(self):
         # SR returns 4 modules; WHITELIST = [1, 3]. Allocations are indexed by SR list.
@@ -240,7 +202,7 @@ class TestPhaseSeed(unittest.TestCase):
         self.bot._get_quorum = Mock(return_value=['msg'])
         # m1 stake = 70-50 = 20 (lowest); m3 stake = 80-30 = 50
         self.bot._phase_seed([50, 999, 30, 999], [70, 999, 80, 999], digests)
-        self.bot._deposit_to_module.assert_called_once_with(1)
+        self.bot._deposit_to_module.assert_called_once_with(1, '0xA1')
 
     def test_empty_digests_returns_done_false(self):
         done, success = self.bot._phase_seed([], [], [])
@@ -255,7 +217,7 @@ class TestPhaseSeed(unittest.TestCase):
         self.bot._get_quorum = Mock(return_value=['msg'])
 
         self.bot._phase_seed([10, 50], [110, 70], digests)
-        self.bot._deposit_to_module.assert_called_once_with(1)
+        self.bot._deposit_to_module.assert_called_once_with(1, '0xA1')
 
     def test_single_with_quorum_deposits(self):
         digests = [_make_digest(1, '0xA1', 2)]
@@ -264,7 +226,7 @@ class TestPhaseSeed(unittest.TestCase):
         done, success = self.bot._phase_seed([50], [100], digests)
 
         self.assertEqual((True, True), (done, success))
-        self.bot._deposit_to_module.assert_called_once_with(1)
+        self.bot._deposit_to_module.assert_called_once_with(1, '0xA1')
 
     def test_cooldown_active_no_quorum_stops_phase(self):
         # Cooldown active (fresh heartbeat) + no quorum → stop phase, don't proceed.
@@ -283,7 +245,7 @@ class TestPhaseSeed(unittest.TestCase):
         self.bot._get_quorum = Mock(side_effect=lambda mid: ['msg'] if mid == 1 else None)
 
         self.bot._phase_seed([10, 50], [110, 70], digests)
-        self.bot._deposit_to_module.assert_called_once_with(1)
+        self.bot._deposit_to_module.assert_called_once_with(1, '0xA1')
 
     def test_all_cooldowns_expired_returns_done_false(self):
         digests = [_make_digest(1, '0xA1', 2), _make_digest(2, '0xA2', 2)]
@@ -333,7 +295,7 @@ class TestPhaseFull(unittest.TestCase):
         digests = [_make_digest(1, '0xA1', 1), _make_digest(2, '0xA2', 1)]
         self.bot._get_quorum = Mock(return_value=['msg'])
         self.bot._phase_full([0, 50], [0, 100], digests)
-        self.bot._deposit_to_module.assert_called_once_with(2)
+        self.bot._deposit_to_module.assert_called_once_with(2, '0xA2')
 
     def test_filters_non_whitelisted(self):
         digests = [_make_digest(4, '0xA4', 1)]
@@ -346,14 +308,14 @@ class TestPhaseFull(unittest.TestCase):
         self.bot._get_quorum = Mock(return_value=['msg'])
         # m2 stake = 70-50 = 20 (lowest)
         self.bot._phase_full([10, 50, 30], [110, 70, 80], digests)
-        self.bot._deposit_to_module.assert_called_once_with(2)
+        self.bot._deposit_to_module.assert_called_once_with(2, '0xA2')
 
     def test_can_deposit_false_moves_to_next(self):
         digests = [_make_digest(1, '0xA1', 1), _make_digest(2, '0xA2', 1)]
         self.bot.w3.lido.deposit_security_module.can_deposit.side_effect = lambda mid: mid != 2
         self.bot._get_quorum = Mock(return_value=['msg'])
         self.bot._phase_full([10, 50], [110, 70], digests)
-        self.bot._deposit_to_module.assert_called_once_with(1)
+        self.bot._deposit_to_module.assert_called_once_with(1, '0xA1')
 
     def test_quorum_active_deposits(self):
         digests = [_make_digest(1, '0xA1', 1)]
@@ -362,7 +324,7 @@ class TestPhaseFull(unittest.TestCase):
         done, success = self.bot._phase_full([50], [100], digests)
 
         self.assertEqual((True, True), (done, success))
-        self.bot._deposit_to_module.assert_called_once_with(1)
+        self.bot._deposit_to_module.assert_called_once_with(1, '0xA1')
 
     def test_cooldown_active_stops_phase(self):
         digests = [_make_digest(1, '0xA1', 1)]
@@ -379,7 +341,7 @@ class TestPhaseFull(unittest.TestCase):
         self.bot._get_quorum = Mock(side_effect=lambda mid: ['msg'] if mid == 1 else None)
 
         self.bot._phase_full([10, 50], [110, 70], digests)
-        self.bot._deposit_to_module.assert_called_once_with(1)
+        self.bot._deposit_to_module.assert_called_once_with(1, '0xA1')
 
     def test_empty_digests_returns_done_false(self):
         done, success = self.bot._phase_full([], [], [])
@@ -463,7 +425,7 @@ class TestPhaseFullAndTopup(unittest.TestCase):
         self.bot._phase_full_and_topup(100, [999, 50], [999, 60], digests)
 
         # m2 (0x01) tried first because stake is lower
-        self.bot._deposit_to_module.assert_called_once_with(2)
+        self.bot._deposit_to_module.assert_called_once_with(2, '0xA2')
         self.bot._top_up_to_module.assert_not_called()
 
     # ─── 0x02 branch ───────────────────────────────────────────
@@ -479,7 +441,7 @@ class TestPhaseFullAndTopup(unittest.TestCase):
         self.bot._phase_full_and_topup(100, [0, 50], [0, 60], digests)
 
         self.bot._top_up_to_module.assert_not_called()
-        self.bot._deposit_to_module.assert_called_once_with(2)
+        self.bot._deposit_to_module.assert_called_once_with(2, '0xA2')
 
     def test_block_distance_not_passed_stops_phase(self):
         digests = [_make_digest(1, '0xA1', 2)]
@@ -510,7 +472,7 @@ class TestPhaseFullAndTopup(unittest.TestCase):
 
         # Both 0x01, both have seed alloc. m1 stake = 10, m2 stake = 50 → m1 tried first
         self.bot._phase_full_and_topup(100, [50, 50], [60, 100], digests)
-        self.bot._deposit_to_module.assert_called_once_with(2)
+        self.bot._deposit_to_module.assert_called_once_with(2, '0xA2')
 
     def test_0x01_with_quorum_deposits(self):
         digests = [_make_digest(1, '0xA1', 1)]
@@ -520,7 +482,7 @@ class TestPhaseFullAndTopup(unittest.TestCase):
         done, success = self.bot._phase_full_and_topup(100, [50], [100], digests)
 
         self.assertEqual((True, True), (done, success))
-        self.bot._deposit_to_module.assert_called_once_with(1)
+        self.bot._deposit_to_module.assert_called_once_with(1, '0xA1')
 
     def test_0x01_cooldown_active_stops_phase(self):
         digests = [_make_digest(1, '0xA1', 1)]
@@ -541,7 +503,7 @@ class TestPhaseFullAndTopup(unittest.TestCase):
 
         # m1 stake 10, m2 stake 50 → m1 first, cooldown expired → next; m2 has quorum
         self.bot._phase_full_and_topup(100, [50, 50], [60, 100], digests)
-        self.bot._deposit_to_module.assert_called_once_with(2)
+        self.bot._deposit_to_module.assert_called_once_with(2, '0xA2')
 
     # ─── Mixed ─────────────────────────────────────────────────
 
@@ -720,7 +682,7 @@ def test_deposit_to_module_gas_too_high_returns_false(depositor_bot):
     depositor_bot._get_quorum = Mock()
     depositor_bot.prepare_and_send_tx = Mock()
 
-    assert depositor_bot._deposit_to_module(1) is False
+    assert depositor_bot._deposit_to_module(1, '0xAddr') is False
     depositor_bot._get_quorum.assert_not_called()
     depositor_bot.prepare_and_send_tx.assert_not_called()
 
@@ -733,7 +695,7 @@ def test_deposit_to_module_quorum_disappeared_returns_false(depositor_bot):
     depositor_bot._get_quorum = Mock(return_value=None)
     depositor_bot.prepare_and_send_tx = Mock()
 
-    assert depositor_bot._deposit_to_module(1) is False
+    assert depositor_bot._deposit_to_module(1, '0xAddr') is False
     depositor_bot.prepare_and_send_tx.assert_not_called()
 
 
@@ -746,7 +708,7 @@ def test_deposit_to_module_happy_path_sends_tx(depositor_bot):
     depositor_bot._get_quorum = Mock(return_value=quorum)
     depositor_bot.prepare_and_send_tx = Mock(return_value=True)
 
-    assert depositor_bot._deposit_to_module(1) is True
+    assert depositor_bot._deposit_to_module(1, '0xAddr') is True
     depositor_bot.prepare_and_send_tx.assert_called_once_with(1, quorum)
 
 
@@ -757,7 +719,7 @@ def test_deposit_to_module_csm_strategy_for_csm_module_type(depositor_bot):
     depositor_bot._csm_strategy.is_gas_price_ok = Mock(return_value=False)
     depositor_bot._general_strategy.is_gas_price_ok = Mock(return_value=False)
 
-    depositor_bot._deposit_to_module(4)
+    depositor_bot._deposit_to_module(4, '0xCSMAddr')
 
     depositor_bot._csm_strategy.is_gas_price_ok.assert_called_once_with(4)
     depositor_bot._general_strategy.is_gas_price_ok.assert_not_called()
@@ -770,7 +732,7 @@ def test_deposit_to_module_general_strategy_for_non_csm_module_type(depositor_bo
     depositor_bot._csm_strategy.is_gas_price_ok = Mock(return_value=False)
     depositor_bot._general_strategy.is_gas_price_ok = Mock(return_value=False)
 
-    depositor_bot._deposit_to_module(1)
+    depositor_bot._deposit_to_module(1, '0xNORAddr')
 
     depositor_bot._general_strategy.is_gas_price_ok.assert_called_once_with(1)
     depositor_bot._csm_strategy.is_gas_price_ok.assert_not_called()
@@ -912,7 +874,7 @@ def test_get_module_type_calls_get_type_on_checksum_address(depositor_bot):
     mock_contract.functions.getType.return_value.call.return_value = expected_type
     depositor_bot.w3.eth.contract = Mock(return_value=mock_contract)
 
-    result = depositor_bot._get_module_type(raw_address)
+    result = depositor_bot._get_module_type(99, raw_address)
 
     assert result == expected_type
     depositor_bot.w3.to_checksum_address.assert_called_once_with(raw_address)
@@ -921,6 +883,19 @@ def test_get_module_type_calls_get_type_on_checksum_address(depositor_bot):
         abi=DepositorBot.GET_TYPE_ABI,
     )
     mock_contract.functions.getType.return_value.call.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_get_module_type_returns_cached_without_rpc():
+    """Second call for the same module_id must not make a new RPC call."""
+    bot = _make_bot()
+    cached_type = b'community-onchain-v1'.ljust(32, b'\x00')
+    bot._module_type_cache[7] = cached_type
+
+    result = bot._get_module_type(7, '0xAnyAddress')
+
+    assert result == cached_type
+    bot.w3.eth.contract.assert_not_called()
 
 
 # ─── Message actualizer / quorum (unchanged) ───────────────────────

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, Mock
 
 import pytest
 import variables
+from blockchain.contracts.staking_router import StakingModuleInfo
 from bots.depositor import DepositorBot
 
 from tests.conftest import COUNCIL_ADDRESS_1, COUNCIL_ADDRESS_2, COUNCIL_PK_1, COUNCIL_PK_2
@@ -13,14 +14,9 @@ from tests.utils.protocol_utils import get_deposit_message
 # ─── Shared helpers ────────────────────────────────────────────────
 
 
-def _make_digest(module_id, address, wc_type):
-    """digest[2] = StakingModule tuple: (id, address, ..., wc_type@13, ...)."""
-    return (
-        10,
-        5,
-        (module_id, address, 500, 500, 1000, 0, f'module{module_id}', 0, 0, 0, 0, 150, 25, wc_type, 0, 0),
-        (0, 100, 10),
-    )
+def _make_digest(module_id, address, wc_type) -> StakingModuleInfo:
+    """Build a StakingModuleInfo as produced by the parsing step in _execute_actual."""
+    return StakingModuleInfo(module_id=module_id, address=address, wc_type=wc_type)
 
 
 def _make_bot():
@@ -51,7 +47,7 @@ class TestRefreshModulesState(unittest.TestCase):
         self.bot._get_quorum = Mock(return_value=None)
         self.bot._select_strategy = Mock(return_value=Mock())
 
-        self.bot._refresh_modules_state()
+        self.bot._refresh_modules_state([])
 
         called_ids = sorted(c.args[0] for c in self.bot._get_quorum.call_args_list)
         self.assertEqual([1, 2, 3], called_ids)
@@ -61,7 +57,7 @@ class TestRefreshModulesState(unittest.TestCase):
         strategy = Mock()
         self.bot._select_strategy = Mock(return_value=strategy)
 
-        self.bot._refresh_modules_state()
+        self.bot._refresh_modules_state([])
 
         # is_gas_price_ok called once per whitelisted module
         self.assertEqual(3, strategy.is_gas_price_ok.call_count)
@@ -73,7 +69,7 @@ class TestRefreshModulesState(unittest.TestCase):
         old = datetime.now() - timedelta(hours=2)
         self.bot._module_last_heart_beat = {1: old, 2: old, 3: old}
 
-        self.bot._refresh_modules_state()
+        self.bot._refresh_modules_state([])
 
         for module_id in [1, 2, 3]:
             self.assertGreater(self.bot._module_last_heart_beat[module_id], old)
@@ -85,7 +81,7 @@ class TestRefreshModulesState(unittest.TestCase):
         old = datetime.now() - timedelta(hours=2)
         self.bot._module_last_heart_beat = {1: old, 2: old, 3: old}
 
-        self.bot._refresh_modules_state()
+        self.bot._refresh_modules_state([])
 
         for module_id in [1, 2, 3]:
             self.assertEqual(old, self.bot._module_last_heart_beat[module_id])
@@ -95,7 +91,7 @@ class TestRefreshModulesState(unittest.TestCase):
         self.bot._get_quorum = Mock()
         self.bot._select_strategy = Mock()
 
-        self.bot._refresh_modules_state()
+        self.bot._refresh_modules_state([])
 
         self.bot._get_quorum.assert_not_called()
         self.bot._select_strategy.assert_not_called()
@@ -107,7 +103,7 @@ class TestRefreshModulesState(unittest.TestCase):
         self.bot._get_quorum = Mock(return_value=None)
         self.bot._select_strategy = Mock(return_value=Mock())
 
-        self.bot._refresh_modules_state()
+        self.bot._refresh_modules_state([])
 
         called_ids = sorted(c.args[0] for c in self.bot._get_quorum.call_args_list)
         self.assertEqual([1, 3], called_ids)
@@ -547,8 +543,8 @@ def depositor_bot(
 @pytest.mark.unit
 def test_execute_actual_zero_depositable_ether_short_circuits(depositor_bot):
     """If buffer is empty, skip iteration without computing allocations."""
-    depositor_bot._ensure_module_type_cache = Mock()
     depositor_bot._refresh_modules_state = Mock()
+    depositor_bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(return_value=[])
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=0)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock()
     depositor_bot._phase_seed = Mock()
@@ -565,7 +561,6 @@ def test_execute_actual_zero_depositable_ether_short_circuits(depositor_bot):
 @pytest.mark.unit
 def test_execute_actual_phase_a_deposit_short_circuits(depositor_bot):
     """Phase A returns (True, True) → return True, phase B not called."""
-    depositor_bot._ensure_module_type_cache = Mock()
     depositor_bot._refresh_modules_state = Mock()
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
@@ -582,7 +577,6 @@ def test_execute_actual_phase_a_deposit_short_circuits(depositor_bot):
 @pytest.mark.unit
 def test_execute_actual_phase_a_failure_does_not_call_phase_b(depositor_bot):
     """Phase A returns (True, False) — e.g. deposit attempt failed — phase B not called."""
-    depositor_bot._ensure_module_type_cache = Mock()
     depositor_bot._refresh_modules_state = Mock()
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
@@ -600,7 +594,6 @@ def test_execute_actual_phase_a_failure_does_not_call_phase_b(depositor_bot):
 def test_execute_actual_phase_a_cooldown_does_not_call_phase_b(depositor_bot):
     """Same as failure: cooldown returns (True, False) — phase B still not called.
     Documented separately because the algorithm treats cooldown explicitly."""
-    depositor_bot._ensure_module_type_cache = Mock()
     depositor_bot._refresh_modules_state = Mock()
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
@@ -618,23 +611,21 @@ def test_execute_actual_phase_a_cooldown_does_not_call_phase_b(depositor_bot):
 def test_execute_actual_phase_a_empty_falls_through_to_phase_b(depositor_bot):
     """Phase A returns (False, False) → continue to phase B."""
     variables.ENABLE_TOP_UP = False
-    depositor_bot._ensure_module_type_cache = Mock()
     depositor_bot._refresh_modules_state = Mock()
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [10, 20], [50, 50]))
-    depositor_bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(return_value=['d1', 'd2'])
+    depositor_bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(return_value=[])
     depositor_bot._phase_seed = Mock(return_value=(False, False))
     depositor_bot._phase_full = Mock(return_value=(True, True))
 
     assert depositor_bot._execute_actual() is True
-    # phase_full receives the seed allocations + digests
-    depositor_bot._phase_full.assert_called_once_with([10, 20], [50, 50], ['d1', 'd2'])
+    # phase_full receives the seed allocations and the parsed (empty) digests list
+    depositor_bot._phase_full.assert_called_once_with([10, 20], [50, 50], [])
 
 
 @pytest.mark.unit
 def test_execute_actual_routes_to_phase_full_when_top_up_disabled(depositor_bot):
     variables.ENABLE_TOP_UP = False
-    depositor_bot._ensure_module_type_cache = Mock()
     depositor_bot._refresh_modules_state = Mock()
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
@@ -651,7 +642,6 @@ def test_execute_actual_routes_to_phase_full_when_top_up_disabled(depositor_bot)
 @pytest.mark.unit
 def test_execute_actual_routes_to_phase_full_and_topup_when_top_up_enabled(depositor_bot):
     variables.ENABLE_TOP_UP = True
-    depositor_bot._ensure_module_type_cache = Mock()
     depositor_bot._refresh_modules_state = Mock()
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
@@ -668,7 +658,6 @@ def test_execute_actual_routes_to_phase_full_and_topup_when_top_up_enabled(depos
 @pytest.mark.unit
 def test_execute_actual_both_phases_return_false(depositor_bot):
     variables.ENABLE_TOP_UP = False
-    depositor_bot._ensure_module_type_cache = Mock()
     depositor_bot._refresh_modules_state = Mock()
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
@@ -893,57 +882,55 @@ def test_get_module_type_calls_get_type_on_checksum_address(depositor_bot):
     mock_contract.functions.getType.return_value.call.assert_called_once_with()
 
 
-# ─── _ensure_module_type_cache ─────────────────────────────────────
+# ─── _refresh_modules_state: type-cache population ─────────────────
 
 
 @pytest.mark.unit
-def test_ensure_module_type_cache_populates_for_whitelisted():
-    """Fetches digests and caches the type for every whitelisted module on first call."""
+def test_refresh_modules_state_populates_type_cache_for_whitelisted():
+    """On first call, fetches digests and caches the type for every whitelisted module."""
     bot = _make_bot()
     variables.DEPOSIT_MODULES_WHITELIST = [1, 4]
     bot._module_last_heart_beat = {1: datetime.now(), 4: datetime.now()}
     csm_type = DepositorBot.MODULE_TYPE_CSM
     nor_type = b'curated-onchain-v1'.ljust(32, b'\x00')
     bot._get_module_type = Mock(side_effect=lambda addr: csm_type if addr == '0xCSM' else nor_type)
-    bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(
-        return_value=[_make_digest(1, '0xNOR', 1), _make_digest(4, '0xCSM', 1)]
-    )
+    bot._get_quorum = Mock(return_value=None)
 
-    bot._ensure_module_type_cache()
+    bot._refresh_modules_state([_make_digest(1, '0xNOR', 1), _make_digest(4, '0xCSM', 1)])
 
     assert bot._module_type_cache[1] == nor_type
     assert bot._module_type_cache[4] == csm_type
 
 
 @pytest.mark.unit
-def test_ensure_module_type_cache_skips_non_whitelisted():
+def test_refresh_modules_state_type_cache_skips_non_whitelisted():
     """Modules not in the whitelist are not cached even if returned by SR."""
     bot = _make_bot()
     variables.DEPOSIT_MODULES_WHITELIST = [1]
     bot._module_last_heart_beat = {1: datetime.now()}
     bot._get_module_type = Mock(return_value=DepositorBot.MODULE_TYPE_CMV2)
-    bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(
-        return_value=[_make_digest(1, '0xA1', 1), _make_digest(2, '0xA2', 1)]
-    )
+    bot._get_quorum = Mock(return_value=None)
 
-    bot._ensure_module_type_cache()
+    bot._refresh_modules_state([_make_digest(1, '0xA1', 1), _make_digest(2, '0xA2', 1)])
 
     assert 1 in bot._module_type_cache
     assert 2 not in bot._module_type_cache
 
 
 @pytest.mark.unit
-def test_ensure_module_type_cache_noop_when_all_cached():
-    """No RPC call is made when every whitelisted module is already in the cache."""
+def test_refresh_modules_state_cache_not_overwritten_if_already_present():
+    """Existing cache entries are not overwritten when digests are passed."""
     bot = _make_bot()
     variables.DEPOSIT_MODULES_WHITELIST = [1, 4]
     bot._module_last_heart_beat = {1: datetime.now(), 4: datetime.now()}
     bot._module_type_cache[1] = DepositorBot.MODULE_TYPE_CMV2
     bot._module_type_cache[4] = DepositorBot.MODULE_TYPE_CSM
+    bot._get_module_type = Mock()
+    bot._get_quorum = Mock(return_value=None)
 
-    bot._ensure_module_type_cache()
+    bot._refresh_modules_state([_make_digest(1, '0xA1', 1), _make_digest(4, '0xA4', 1)])
 
-    bot.w3.lido.staking_router.get_all_staking_module_digests.assert_not_called()
+    bot._get_module_type.assert_not_called()
 
 
 # ─── Message actualizer / quorum (unchanged) ───────────────────────

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, Mock
 
 import pytest
 import variables
-from blockchain.contracts.staking_router import StakingModuleInfo
+from blockchain.contracts.staking_router import MODULE_TYPE_CMV2, MODULE_TYPE_CSM, StakingModuleInfo
 from bots.depositor import DepositorBot
 
 from tests.conftest import COUNCIL_ADDRESS_1, COUNCIL_ADDRESS_2, COUNCIL_PK_1, COUNCIL_PK_2
@@ -47,7 +47,7 @@ class TestRefreshModulesState(unittest.TestCase):
         self.bot._get_quorum = Mock(return_value=None)
         self.bot._select_strategy = Mock(return_value=Mock())
 
-        self.bot._refresh_modules_state([])
+        self.bot._refresh_modules_state()
 
         called_ids = sorted(c.args[0] for c in self.bot._get_quorum.call_args_list)
         self.assertEqual([1, 2, 3], called_ids)
@@ -57,7 +57,7 @@ class TestRefreshModulesState(unittest.TestCase):
         strategy = Mock()
         self.bot._select_strategy = Mock(return_value=strategy)
 
-        self.bot._refresh_modules_state([])
+        self.bot._refresh_modules_state()
 
         # is_gas_price_ok called once per whitelisted module
         self.assertEqual(3, strategy.is_gas_price_ok.call_count)
@@ -69,7 +69,7 @@ class TestRefreshModulesState(unittest.TestCase):
         old = datetime.now() - timedelta(hours=2)
         self.bot._module_last_heart_beat = {1: old, 2: old, 3: old}
 
-        self.bot._refresh_modules_state([])
+        self.bot._refresh_modules_state()
 
         for module_id in [1, 2, 3]:
             self.assertGreater(self.bot._module_last_heart_beat[module_id], old)
@@ -81,7 +81,7 @@ class TestRefreshModulesState(unittest.TestCase):
         old = datetime.now() - timedelta(hours=2)
         self.bot._module_last_heart_beat = {1: old, 2: old, 3: old}
 
-        self.bot._refresh_modules_state([])
+        self.bot._refresh_modules_state()
 
         for module_id in [1, 2, 3]:
             self.assertEqual(old, self.bot._module_last_heart_beat[module_id])
@@ -91,7 +91,7 @@ class TestRefreshModulesState(unittest.TestCase):
         self.bot._get_quorum = Mock()
         self.bot._select_strategy = Mock()
 
-        self.bot._refresh_modules_state([])
+        self.bot._refresh_modules_state()
 
         self.bot._get_quorum.assert_not_called()
         self.bot._select_strategy.assert_not_called()
@@ -103,7 +103,7 @@ class TestRefreshModulesState(unittest.TestCase):
         self.bot._get_quorum = Mock(return_value=None)
         self.bot._select_strategy = Mock(return_value=Mock())
 
-        self.bot._refresh_modules_state([])
+        self.bot._refresh_modules_state()
 
         called_ids = sorted(c.args[0] for c in self.bot._get_quorum.call_args_list)
         self.assertEqual([1, 3], called_ids)
@@ -711,8 +711,10 @@ def test_deposit_to_module_happy_path_sends_tx(depositor_bot):
 
 @pytest.mark.unit
 def test_deposit_to_module_csm_strategy_for_csm_module_type(depositor_bot):
-    """_select_strategy returns CSM strategy when the module type is MODULE_TYPE_CSM."""
-    depositor_bot._module_type_cache[4] = DepositorBot.MODULE_TYPE_CSM
+    """_select_strategy returns CSM strategy when staking_module.get_type() returns MODULE_TYPE_CSM."""
+    mock_module = Mock()
+    mock_module.get_type.return_value = MODULE_TYPE_CSM
+    depositor_bot.w3.lido.staking_module = Mock(return_value=mock_module)
     depositor_bot._csm_strategy.is_gas_price_ok = Mock(return_value=False)
     depositor_bot._general_strategy.is_gas_price_ok = Mock(return_value=False)
 
@@ -724,8 +726,10 @@ def test_deposit_to_module_csm_strategy_for_csm_module_type(depositor_bot):
 
 @pytest.mark.unit
 def test_deposit_to_module_general_strategy_for_non_csm_module_type(depositor_bot):
-    """_select_strategy returns general strategy when the module type is not MODULE_TYPE_CSM."""
-    depositor_bot._module_type_cache[1] = b'curated-onchain-v1'.ljust(32, b'\x00')
+    """_select_strategy returns general strategy when staking_module.get_type() returns a non-CSM type."""
+    mock_module = Mock()
+    mock_module.get_type.return_value = b'curated-onchain-v1'.ljust(32, b'\x00')
+    depositor_bot.w3.lido.staking_module = Mock(return_value=mock_module)
     depositor_bot._csm_strategy.is_gas_price_ok = Mock(return_value=False)
     depositor_bot._general_strategy.is_gas_price_ok = Mock(return_value=False)
 
@@ -740,7 +744,9 @@ def test_deposit_to_module_general_strategy_for_non_csm_module_type(depositor_bo
 
 @pytest.mark.unit
 def test_top_up_to_module_unknown_type_returns_false(depositor_bot):
-    depositor_bot._get_module_type = Mock(return_value=b'unknown-type'.ljust(32, b'\x00'))
+    mock_module = Mock()
+    mock_module.get_type.return_value = b'unknown-type'.ljust(32, b'\x00')
+    depositor_bot.w3.lido.staking_module = Mock(return_value=mock_module)
     depositor_bot._select_topup_strategy = Mock(return_value=None)
 
     assert depositor_bot._top_up_to_module(1, '0xAddr', 50) is False
@@ -748,7 +754,9 @@ def test_top_up_to_module_unknown_type_returns_false(depositor_bot):
 
 @pytest.mark.unit
 def test_top_up_to_module_gas_too_high_returns_false(depositor_bot):
-    depositor_bot._get_module_type = Mock(return_value=DepositorBot.MODULE_TYPE_CMV2)
+    mock_module = Mock()
+    mock_module.get_type.return_value = MODULE_TYPE_CMV2
+    depositor_bot.w3.lido.staking_module = Mock(return_value=mock_module)
     strategy = Mock()
     strategy.is_gas_price_ok = Mock(return_value=False)
     strategy.get_topup_candidates = Mock()
@@ -760,7 +768,9 @@ def test_top_up_to_module_gas_too_high_returns_false(depositor_bot):
 
 @pytest.mark.unit
 def test_top_up_to_module_no_proof_data_returns_false(depositor_bot):
-    depositor_bot._get_module_type = Mock(return_value=DepositorBot.MODULE_TYPE_CMV2)
+    mock_module = Mock()
+    mock_module.get_type.return_value = MODULE_TYPE_CMV2
+    depositor_bot.w3.lido.staking_module = Mock(return_value=mock_module)
     strategy = Mock()
     strategy.is_gas_price_ok = Mock(return_value=True)
     strategy.get_topup_candidates = Mock(return_value=None)
@@ -784,7 +794,9 @@ def test_top_up_to_module_max_validators_uses_min(depositor_bot, config_limit, g
     original = variables.MAX_VALIDATORS_PER_TOP_UP
     variables.MAX_VALIDATORS_PER_TOP_UP = config_limit
     try:
-        depositor_bot._get_module_type = Mock(return_value=DepositorBot.MODULE_TYPE_CMV2)
+        mock_module = Mock()
+        mock_module.get_type.return_value = MODULE_TYPE_CMV2
+        depositor_bot.w3.lido.staking_module = Mock(return_value=mock_module)
         strategy = Mock()
         strategy.is_gas_price_ok = Mock(return_value=True)
         strategy.get_topup_candidates = Mock(return_value=['proof'])
@@ -807,7 +819,9 @@ def test_top_up_to_module_happy_path_calls_top_up_check_send(depositor_bot):
     proof_data = ['proof']
     tx = Mock(name='tx')
 
-    depositor_bot._get_module_type = Mock(return_value=DepositorBot.MODULE_TYPE_CMV2)
+    mock_module = Mock()
+    mock_module.get_type.return_value = MODULE_TYPE_CMV2
+    depositor_bot.w3.lido.staking_module = Mock(return_value=mock_module)
     strategy = Mock()
     strategy.is_gas_price_ok = Mock(return_value=True)
     strategy.get_topup_candidates = Mock(return_value=proof_data)
@@ -827,7 +841,9 @@ def test_top_up_to_module_happy_path_calls_top_up_check_send(depositor_bot):
 @pytest.mark.unit
 def test_top_up_to_module_passes_module_allocation_through_to_strategy(depositor_bot):
     """The allocation is forwarded to get_topup_candidates, not re-queried."""
-    depositor_bot._get_module_type = Mock(return_value=DepositorBot.MODULE_TYPE_CMV2)
+    mock_module = Mock()
+    mock_module.get_type.return_value = MODULE_TYPE_CMV2
+    depositor_bot.w3.lido.staking_module = Mock(return_value=mock_module)
     strategy = Mock()
     strategy.is_gas_price_ok = Mock(return_value=True)
     strategy.get_topup_candidates = Mock(return_value=['proof'])
@@ -845,12 +861,12 @@ def test_top_up_to_module_passes_module_allocation_through_to_strategy(depositor
     depositor_bot.w3.lido.staking_router.get_deposit_allocations.assert_not_called()
 
 
-# ─── _select_topup_strategy / _get_module_type (unchanged) ─────────
+# ─── _select_topup_strategy ────────────────────────────────────────
 
 
 @pytest.mark.unit
 def test_select_topup_strategy_cmv2_returns_cmv2_strategy(depositor_bot):
-    strategy = depositor_bot._select_topup_strategy(DepositorBot.MODULE_TYPE_CMV2)
+    strategy = depositor_bot._select_topup_strategy(MODULE_TYPE_CMV2)
     assert strategy is depositor_bot._cmv2_topup_strategy
 
 
@@ -858,79 +874,6 @@ def test_select_topup_strategy_cmv2_returns_cmv2_strategy(depositor_bot):
 def test_select_topup_strategy_unknown_returns_none(depositor_bot):
     unknown_type = b'something-else'.ljust(32, b'\x00')
     assert depositor_bot._select_topup_strategy(unknown_type) is None
-
-
-@pytest.mark.unit
-def test_get_module_type_calls_get_type_on_checksum_address(depositor_bot):
-    raw_address = '0xabc1234567890abcdef1234567890abcdef12345'
-    checksum_address = '0xAbC1234567890aBcdEf1234567890AbCdEF12345'
-    expected_type = b'curated-onchain-v2'.ljust(32, b'\x00')
-
-    depositor_bot.w3.to_checksum_address = Mock(return_value=checksum_address)
-    mock_contract = Mock()
-    mock_contract.functions.getType.return_value.call.return_value = expected_type
-    depositor_bot.w3.eth.contract = Mock(return_value=mock_contract)
-
-    result = depositor_bot._get_module_type(raw_address)
-
-    assert result == expected_type
-    depositor_bot.w3.to_checksum_address.assert_called_once_with(raw_address)
-    depositor_bot.w3.eth.contract.assert_called_once_with(
-        address=checksum_address,
-        abi=DepositorBot.GET_TYPE_ABI,
-    )
-    mock_contract.functions.getType.return_value.call.assert_called_once_with()
-
-
-# ─── _refresh_modules_state: type-cache population ─────────────────
-
-
-@pytest.mark.unit
-def test_refresh_modules_state_populates_type_cache_for_whitelisted():
-    """On first call, fetches digests and caches the type for every whitelisted module."""
-    bot = _make_bot()
-    variables.DEPOSIT_MODULES_WHITELIST = [1, 4]
-    bot._module_last_heart_beat = {1: datetime.now(), 4: datetime.now()}
-    csm_type = DepositorBot.MODULE_TYPE_CSM
-    nor_type = b'curated-onchain-v1'.ljust(32, b'\x00')
-    bot._get_module_type = Mock(side_effect=lambda addr: csm_type if addr == '0xCSM' else nor_type)
-    bot._get_quorum = Mock(return_value=None)
-
-    bot._refresh_modules_state([_make_digest(1, '0xNOR', 1), _make_digest(4, '0xCSM', 1)])
-
-    assert bot._module_type_cache[1] == nor_type
-    assert bot._module_type_cache[4] == csm_type
-
-
-@pytest.mark.unit
-def test_refresh_modules_state_type_cache_skips_non_whitelisted():
-    """Modules not in the whitelist are not cached even if returned by SR."""
-    bot = _make_bot()
-    variables.DEPOSIT_MODULES_WHITELIST = [1]
-    bot._module_last_heart_beat = {1: datetime.now()}
-    bot._get_module_type = Mock(return_value=DepositorBot.MODULE_TYPE_CMV2)
-    bot._get_quorum = Mock(return_value=None)
-
-    bot._refresh_modules_state([_make_digest(1, '0xA1', 1), _make_digest(2, '0xA2', 1)])
-
-    assert 1 in bot._module_type_cache
-    assert 2 not in bot._module_type_cache
-
-
-@pytest.mark.unit
-def test_refresh_modules_state_cache_not_overwritten_if_already_present():
-    """Existing cache entries are not overwritten when digests are passed."""
-    bot = _make_bot()
-    variables.DEPOSIT_MODULES_WHITELIST = [1, 4]
-    bot._module_last_heart_beat = {1: datetime.now(), 4: datetime.now()}
-    bot._module_type_cache[1] = DepositorBot.MODULE_TYPE_CMV2
-    bot._module_type_cache[4] = DepositorBot.MODULE_TYPE_CSM
-    bot._get_module_type = Mock()
-    bot._get_quorum = Mock(return_value=None)
-
-    bot._refresh_modules_state([_make_digest(1, '0xA1', 1), _make_digest(4, '0xA4', 1)])
-
-    bot._get_module_type.assert_not_called()
 
 
 # ─── Message actualizer / quorum (unchanged) ───────────────────────

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -167,7 +167,7 @@ class TestPhaseSeed(unittest.TestCase):
         self.bot._get_quorum = Mock(return_value=['msg'])
         # module 1: allocated=0 → skipped; module 2: allocated=50 → deposits
         self.bot._phase_seed([0, 50], [0, 100], digests)
-        self.bot._deposit_to_module.assert_called_once_with(2, '0xA2')
+        self.bot._deposit_to_module.assert_called_once_with(2)
 
     def test_filters_non_whitelisted(self):
         digests = [_make_digest(4, '0xA4', 2)]
@@ -187,7 +187,7 @@ class TestPhaseSeed(unittest.TestCase):
 
         self.assertEqual((True, True), (done, success))
         # Lowest-stake module (id=2) is tried first.
-        self.bot._deposit_to_module.assert_called_once_with(2, '0xA2')
+        self.bot._deposit_to_module.assert_called_once_with(2)
 
     def test_index_alignment_with_subset_whitelist(self):
         # SR returns 4 modules; WHITELIST = [1, 3]. Allocations are indexed by SR list.
@@ -202,7 +202,7 @@ class TestPhaseSeed(unittest.TestCase):
         self.bot._get_quorum = Mock(return_value=['msg'])
         # m1 stake = 70-50 = 20 (lowest); m3 stake = 80-30 = 50
         self.bot._phase_seed([50, 999, 30, 999], [70, 999, 80, 999], digests)
-        self.bot._deposit_to_module.assert_called_once_with(1, '0xA1')
+        self.bot._deposit_to_module.assert_called_once_with(1)
 
     def test_empty_digests_returns_done_false(self):
         done, success = self.bot._phase_seed([], [], [])
@@ -217,7 +217,7 @@ class TestPhaseSeed(unittest.TestCase):
         self.bot._get_quorum = Mock(return_value=['msg'])
 
         self.bot._phase_seed([10, 50], [110, 70], digests)
-        self.bot._deposit_to_module.assert_called_once_with(1, '0xA1')
+        self.bot._deposit_to_module.assert_called_once_with(1)
 
     def test_single_with_quorum_deposits(self):
         digests = [_make_digest(1, '0xA1', 2)]
@@ -226,7 +226,7 @@ class TestPhaseSeed(unittest.TestCase):
         done, success = self.bot._phase_seed([50], [100], digests)
 
         self.assertEqual((True, True), (done, success))
-        self.bot._deposit_to_module.assert_called_once_with(1, '0xA1')
+        self.bot._deposit_to_module.assert_called_once_with(1)
 
     def test_cooldown_active_no_quorum_stops_phase(self):
         # Cooldown active (fresh heartbeat) + no quorum → stop phase, don't proceed.
@@ -245,7 +245,7 @@ class TestPhaseSeed(unittest.TestCase):
         self.bot._get_quorum = Mock(side_effect=lambda mid: ['msg'] if mid == 1 else None)
 
         self.bot._phase_seed([10, 50], [110, 70], digests)
-        self.bot._deposit_to_module.assert_called_once_with(1, '0xA1')
+        self.bot._deposit_to_module.assert_called_once_with(1)
 
     def test_all_cooldowns_expired_returns_done_false(self):
         digests = [_make_digest(1, '0xA1', 2), _make_digest(2, '0xA2', 2)]
@@ -295,7 +295,7 @@ class TestPhaseFull(unittest.TestCase):
         digests = [_make_digest(1, '0xA1', 1), _make_digest(2, '0xA2', 1)]
         self.bot._get_quorum = Mock(return_value=['msg'])
         self.bot._phase_full([0, 50], [0, 100], digests)
-        self.bot._deposit_to_module.assert_called_once_with(2, '0xA2')
+        self.bot._deposit_to_module.assert_called_once_with(2)
 
     def test_filters_non_whitelisted(self):
         digests = [_make_digest(4, '0xA4', 1)]
@@ -308,14 +308,14 @@ class TestPhaseFull(unittest.TestCase):
         self.bot._get_quorum = Mock(return_value=['msg'])
         # m2 stake = 70-50 = 20 (lowest)
         self.bot._phase_full([10, 50, 30], [110, 70, 80], digests)
-        self.bot._deposit_to_module.assert_called_once_with(2, '0xA2')
+        self.bot._deposit_to_module.assert_called_once_with(2)
 
     def test_can_deposit_false_moves_to_next(self):
         digests = [_make_digest(1, '0xA1', 1), _make_digest(2, '0xA2', 1)]
         self.bot.w3.lido.deposit_security_module.can_deposit.side_effect = lambda mid: mid != 2
         self.bot._get_quorum = Mock(return_value=['msg'])
         self.bot._phase_full([10, 50], [110, 70], digests)
-        self.bot._deposit_to_module.assert_called_once_with(1, '0xA1')
+        self.bot._deposit_to_module.assert_called_once_with(1)
 
     def test_quorum_active_deposits(self):
         digests = [_make_digest(1, '0xA1', 1)]
@@ -324,7 +324,7 @@ class TestPhaseFull(unittest.TestCase):
         done, success = self.bot._phase_full([50], [100], digests)
 
         self.assertEqual((True, True), (done, success))
-        self.bot._deposit_to_module.assert_called_once_with(1, '0xA1')
+        self.bot._deposit_to_module.assert_called_once_with(1)
 
     def test_cooldown_active_stops_phase(self):
         digests = [_make_digest(1, '0xA1', 1)]
@@ -341,7 +341,7 @@ class TestPhaseFull(unittest.TestCase):
         self.bot._get_quorum = Mock(side_effect=lambda mid: ['msg'] if mid == 1 else None)
 
         self.bot._phase_full([10, 50], [110, 70], digests)
-        self.bot._deposit_to_module.assert_called_once_with(1, '0xA1')
+        self.bot._deposit_to_module.assert_called_once_with(1)
 
     def test_empty_digests_returns_done_false(self):
         done, success = self.bot._phase_full([], [], [])
@@ -425,7 +425,7 @@ class TestPhaseFullAndTopup(unittest.TestCase):
         self.bot._phase_full_and_topup(100, [999, 50], [999, 60], digests)
 
         # m2 (0x01) tried first because stake is lower
-        self.bot._deposit_to_module.assert_called_once_with(2, '0xA2')
+        self.bot._deposit_to_module.assert_called_once_with(2)
         self.bot._top_up_to_module.assert_not_called()
 
     # ─── 0x02 branch ───────────────────────────────────────────
@@ -441,7 +441,7 @@ class TestPhaseFullAndTopup(unittest.TestCase):
         self.bot._phase_full_and_topup(100, [0, 50], [0, 60], digests)
 
         self.bot._top_up_to_module.assert_not_called()
-        self.bot._deposit_to_module.assert_called_once_with(2, '0xA2')
+        self.bot._deposit_to_module.assert_called_once_with(2)
 
     def test_block_distance_not_passed_stops_phase(self):
         digests = [_make_digest(1, '0xA1', 2)]
@@ -472,7 +472,7 @@ class TestPhaseFullAndTopup(unittest.TestCase):
 
         # Both 0x01, both have seed alloc. m1 stake = 10, m2 stake = 50 → m1 tried first
         self.bot._phase_full_and_topup(100, [50, 50], [60, 100], digests)
-        self.bot._deposit_to_module.assert_called_once_with(2, '0xA2')
+        self.bot._deposit_to_module.assert_called_once_with(2)
 
     def test_0x01_with_quorum_deposits(self):
         digests = [_make_digest(1, '0xA1', 1)]
@@ -482,7 +482,7 @@ class TestPhaseFullAndTopup(unittest.TestCase):
         done, success = self.bot._phase_full_and_topup(100, [50], [100], digests)
 
         self.assertEqual((True, True), (done, success))
-        self.bot._deposit_to_module.assert_called_once_with(1, '0xA1')
+        self.bot._deposit_to_module.assert_called_once_with(1)
 
     def test_0x01_cooldown_active_stops_phase(self):
         digests = [_make_digest(1, '0xA1', 1)]
@@ -503,7 +503,7 @@ class TestPhaseFullAndTopup(unittest.TestCase):
 
         # m1 stake 10, m2 stake 50 → m1 first, cooldown expired → next; m2 has quorum
         self.bot._phase_full_and_topup(100, [50, 50], [60, 100], digests)
-        self.bot._deposit_to_module.assert_called_once_with(2, '0xA2')
+        self.bot._deposit_to_module.assert_called_once_with(2)
 
     # ─── Mixed ─────────────────────────────────────────────────
 
@@ -547,6 +547,7 @@ def depositor_bot(
 @pytest.mark.unit
 def test_execute_actual_zero_depositable_ether_short_circuits(depositor_bot):
     """If buffer is empty, skip iteration without computing allocations."""
+    depositor_bot._ensure_module_type_cache = Mock()
     depositor_bot._refresh_modules_state = Mock()
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=0)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock()
@@ -564,6 +565,7 @@ def test_execute_actual_zero_depositable_ether_short_circuits(depositor_bot):
 @pytest.mark.unit
 def test_execute_actual_phase_a_deposit_short_circuits(depositor_bot):
     """Phase A returns (True, True) → return True, phase B not called."""
+    depositor_bot._ensure_module_type_cache = Mock()
     depositor_bot._refresh_modules_state = Mock()
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
@@ -580,6 +582,7 @@ def test_execute_actual_phase_a_deposit_short_circuits(depositor_bot):
 @pytest.mark.unit
 def test_execute_actual_phase_a_failure_does_not_call_phase_b(depositor_bot):
     """Phase A returns (True, False) — e.g. deposit attempt failed — phase B not called."""
+    depositor_bot._ensure_module_type_cache = Mock()
     depositor_bot._refresh_modules_state = Mock()
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
@@ -597,6 +600,7 @@ def test_execute_actual_phase_a_failure_does_not_call_phase_b(depositor_bot):
 def test_execute_actual_phase_a_cooldown_does_not_call_phase_b(depositor_bot):
     """Same as failure: cooldown returns (True, False) — phase B still not called.
     Documented separately because the algorithm treats cooldown explicitly."""
+    depositor_bot._ensure_module_type_cache = Mock()
     depositor_bot._refresh_modules_state = Mock()
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
@@ -614,6 +618,7 @@ def test_execute_actual_phase_a_cooldown_does_not_call_phase_b(depositor_bot):
 def test_execute_actual_phase_a_empty_falls_through_to_phase_b(depositor_bot):
     """Phase A returns (False, False) → continue to phase B."""
     variables.ENABLE_TOP_UP = False
+    depositor_bot._ensure_module_type_cache = Mock()
     depositor_bot._refresh_modules_state = Mock()
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [10, 20], [50, 50]))
@@ -629,6 +634,7 @@ def test_execute_actual_phase_a_empty_falls_through_to_phase_b(depositor_bot):
 @pytest.mark.unit
 def test_execute_actual_routes_to_phase_full_when_top_up_disabled(depositor_bot):
     variables.ENABLE_TOP_UP = False
+    depositor_bot._ensure_module_type_cache = Mock()
     depositor_bot._refresh_modules_state = Mock()
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
@@ -645,6 +651,7 @@ def test_execute_actual_routes_to_phase_full_when_top_up_disabled(depositor_bot)
 @pytest.mark.unit
 def test_execute_actual_routes_to_phase_full_and_topup_when_top_up_enabled(depositor_bot):
     variables.ENABLE_TOP_UP = True
+    depositor_bot._ensure_module_type_cache = Mock()
     depositor_bot._refresh_modules_state = Mock()
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
@@ -661,6 +668,7 @@ def test_execute_actual_routes_to_phase_full_and_topup_when_top_up_enabled(depos
 @pytest.mark.unit
 def test_execute_actual_both_phases_return_false(depositor_bot):
     variables.ENABLE_TOP_UP = False
+    depositor_bot._ensure_module_type_cache = Mock()
     depositor_bot._refresh_modules_state = Mock()
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
@@ -682,7 +690,7 @@ def test_deposit_to_module_gas_too_high_returns_false(depositor_bot):
     depositor_bot._get_quorum = Mock()
     depositor_bot.prepare_and_send_tx = Mock()
 
-    assert depositor_bot._deposit_to_module(1, '0xAddr') is False
+    assert depositor_bot._deposit_to_module(1) is False
     depositor_bot._get_quorum.assert_not_called()
     depositor_bot.prepare_and_send_tx.assert_not_called()
 
@@ -695,7 +703,7 @@ def test_deposit_to_module_quorum_disappeared_returns_false(depositor_bot):
     depositor_bot._get_quorum = Mock(return_value=None)
     depositor_bot.prepare_and_send_tx = Mock()
 
-    assert depositor_bot._deposit_to_module(1, '0xAddr') is False
+    assert depositor_bot._deposit_to_module(1) is False
     depositor_bot.prepare_and_send_tx.assert_not_called()
 
 
@@ -708,7 +716,7 @@ def test_deposit_to_module_happy_path_sends_tx(depositor_bot):
     depositor_bot._get_quorum = Mock(return_value=quorum)
     depositor_bot.prepare_and_send_tx = Mock(return_value=True)
 
-    assert depositor_bot._deposit_to_module(1, '0xAddr') is True
+    assert depositor_bot._deposit_to_module(1) is True
     depositor_bot.prepare_and_send_tx.assert_called_once_with(1, quorum)
 
 
@@ -719,7 +727,7 @@ def test_deposit_to_module_csm_strategy_for_csm_module_type(depositor_bot):
     depositor_bot._csm_strategy.is_gas_price_ok = Mock(return_value=False)
     depositor_bot._general_strategy.is_gas_price_ok = Mock(return_value=False)
 
-    depositor_bot._deposit_to_module(4, '0xCSMAddr')
+    depositor_bot._deposit_to_module(4)
 
     depositor_bot._csm_strategy.is_gas_price_ok.assert_called_once_with(4)
     depositor_bot._general_strategy.is_gas_price_ok.assert_not_called()
@@ -732,7 +740,7 @@ def test_deposit_to_module_general_strategy_for_non_csm_module_type(depositor_bo
     depositor_bot._csm_strategy.is_gas_price_ok = Mock(return_value=False)
     depositor_bot._general_strategy.is_gas_price_ok = Mock(return_value=False)
 
-    depositor_bot._deposit_to_module(1, '0xNORAddr')
+    depositor_bot._deposit_to_module(1)
 
     depositor_bot._general_strategy.is_gas_price_ok.assert_called_once_with(1)
     depositor_bot._csm_strategy.is_gas_price_ok.assert_not_called()
@@ -874,7 +882,7 @@ def test_get_module_type_calls_get_type_on_checksum_address(depositor_bot):
     mock_contract.functions.getType.return_value.call.return_value = expected_type
     depositor_bot.w3.eth.contract = Mock(return_value=mock_contract)
 
-    result = depositor_bot._get_module_type(99, raw_address)
+    result = depositor_bot._get_module_type(raw_address)
 
     assert result == expected_type
     depositor_bot.w3.to_checksum_address.assert_called_once_with(raw_address)
@@ -885,17 +893,57 @@ def test_get_module_type_calls_get_type_on_checksum_address(depositor_bot):
     mock_contract.functions.getType.return_value.call.assert_called_once_with()
 
 
+# ─── _ensure_module_type_cache ─────────────────────────────────────
+
+
 @pytest.mark.unit
-def test_get_module_type_returns_cached_without_rpc():
-    """Second call for the same module_id must not make a new RPC call."""
+def test_ensure_module_type_cache_populates_for_whitelisted():
+    """Fetches digests and caches the type for every whitelisted module on first call."""
     bot = _make_bot()
-    cached_type = b'community-onchain-v1'.ljust(32, b'\x00')
-    bot._module_type_cache[7] = cached_type
+    variables.DEPOSIT_MODULES_WHITELIST = [1, 4]
+    bot._module_last_heart_beat = {1: datetime.now(), 4: datetime.now()}
+    csm_type = DepositorBot.MODULE_TYPE_CSM
+    nor_type = b'curated-onchain-v1'.ljust(32, b'\x00')
+    bot._get_module_type = Mock(side_effect=lambda addr: csm_type if addr == '0xCSM' else nor_type)
+    bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(
+        return_value=[_make_digest(1, '0xNOR', 1), _make_digest(4, '0xCSM', 1)]
+    )
 
-    result = bot._get_module_type(7, '0xAnyAddress')
+    bot._ensure_module_type_cache()
 
-    assert result == cached_type
-    bot.w3.eth.contract.assert_not_called()
+    assert bot._module_type_cache[1] == nor_type
+    assert bot._module_type_cache[4] == csm_type
+
+
+@pytest.mark.unit
+def test_ensure_module_type_cache_skips_non_whitelisted():
+    """Modules not in the whitelist are not cached even if returned by SR."""
+    bot = _make_bot()
+    variables.DEPOSIT_MODULES_WHITELIST = [1]
+    bot._module_last_heart_beat = {1: datetime.now()}
+    bot._get_module_type = Mock(return_value=DepositorBot.MODULE_TYPE_CMV2)
+    bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(
+        return_value=[_make_digest(1, '0xA1', 1), _make_digest(2, '0xA2', 1)]
+    )
+
+    bot._ensure_module_type_cache()
+
+    assert 1 in bot._module_type_cache
+    assert 2 not in bot._module_type_cache
+
+
+@pytest.mark.unit
+def test_ensure_module_type_cache_noop_when_all_cached():
+    """No RPC call is made when every whitelisted module is already in the cache."""
+    bot = _make_bot()
+    variables.DEPOSIT_MODULES_WHITELIST = [1, 4]
+    bot._module_last_heart_beat = {1: datetime.now(), 4: datetime.now()}
+    bot._module_type_cache[1] = DepositorBot.MODULE_TYPE_CMV2
+    bot._module_type_cache[4] = DepositorBot.MODULE_TYPE_CSM
+
+    bot._ensure_module_type_cache()
+
+    bot.w3.lido.staking_router.get_all_staking_module_digests.assert_not_called()
 
 
 # ─── Message actualizer / quorum (unchanged) ───────────────────────

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -51,7 +51,7 @@ class TestRefreshModulesState(unittest.TestCase):
         self.bot._get_quorum = Mock(return_value=None)
         self.bot._select_strategy = Mock(return_value=Mock())
 
-        self.bot._refresh_modules_state()
+        self.bot._refresh_modules_state([])
 
         called_ids = sorted(c.args[0] for c in self.bot._get_quorum.call_args_list)
         self.assertEqual([1, 2, 3], called_ids)
@@ -61,7 +61,7 @@ class TestRefreshModulesState(unittest.TestCase):
         strategy = Mock()
         self.bot._select_strategy = Mock(return_value=strategy)
 
-        self.bot._refresh_modules_state()
+        self.bot._refresh_modules_state([])
 
         # is_gas_price_ok called once per whitelisted module
         self.assertEqual(3, strategy.is_gas_price_ok.call_count)
@@ -73,7 +73,7 @@ class TestRefreshModulesState(unittest.TestCase):
         old = datetime.now() - timedelta(hours=2)
         self.bot._module_last_heart_beat = {1: old, 2: old, 3: old}
 
-        self.bot._refresh_modules_state()
+        self.bot._refresh_modules_state([])
 
         for module_id in [1, 2, 3]:
             self.assertGreater(self.bot._module_last_heart_beat[module_id], old)
@@ -85,7 +85,7 @@ class TestRefreshModulesState(unittest.TestCase):
         old = datetime.now() - timedelta(hours=2)
         self.bot._module_last_heart_beat = {1: old, 2: old, 3: old}
 
-        self.bot._refresh_modules_state()
+        self.bot._refresh_modules_state([])
 
         for module_id in [1, 2, 3]:
             self.assertEqual(old, self.bot._module_last_heart_beat[module_id])
@@ -95,7 +95,7 @@ class TestRefreshModulesState(unittest.TestCase):
         self.bot._get_quorum = Mock()
         self.bot._select_strategy = Mock()
 
-        self.bot._refresh_modules_state()
+        self.bot._refresh_modules_state([])
 
         self.bot._get_quorum.assert_not_called()
         self.bot._select_strategy.assert_not_called()
@@ -107,10 +107,49 @@ class TestRefreshModulesState(unittest.TestCase):
         self.bot._get_quorum = Mock(return_value=None)
         self.bot._select_strategy = Mock(return_value=Mock())
 
-        self.bot._refresh_modules_state()
+        self.bot._refresh_modules_state([])
 
         called_ids = sorted(c.args[0] for c in self.bot._get_quorum.call_args_list)
         self.assertEqual([1, 3], called_ids)
+
+    def test_populates_module_type_cache_from_digests(self):
+        self.bot._get_quorum = Mock(return_value=None)
+        self.bot._select_strategy = Mock(return_value=Mock())
+        cmv2_type = DepositorBot.MODULE_TYPE_CMV2
+        self.bot._get_module_type = Mock(return_value=cmv2_type)
+
+        digests = [_make_digest(1, '0xAddr1', 2), _make_digest(2, '0xAddr2', 1)]
+        self.bot._refresh_modules_state(digests)
+
+        self.assertEqual(cmv2_type, self.bot._module_type_cache[1])
+        self.assertEqual(cmv2_type, self.bot._module_type_cache[2])
+
+    def test_module_type_cache_not_refetched_if_already_present(self):
+        self.bot._get_quorum = Mock(return_value=None)
+        self.bot._select_strategy = Mock(return_value=Mock())
+        existing_type = b'some-other-type'.ljust(32, b'\x00')
+        self.bot._module_type_cache[1] = existing_type
+        self.bot._get_module_type = Mock(return_value=DepositorBot.MODULE_TYPE_CMV2)
+
+        self.bot._refresh_modules_state([_make_digest(1, '0xAddr1', 2)])
+
+        # Cache entry for module 1 must not be overwritten.
+        self.assertEqual(existing_type, self.bot._module_type_cache[1])
+        self.bot._get_module_type.assert_not_called()
+
+    def test_type_cache_only_populated_for_whitelisted(self):
+        variables.DEPOSIT_MODULES_WHITELIST = [1]
+        self.bot._module_last_heart_beat = {1: datetime.now()}
+        self.bot._get_quorum = Mock(return_value=None)
+        self.bot._select_strategy = Mock(return_value=Mock())
+        self.bot._get_module_type = Mock(return_value=DepositorBot.MODULE_TYPE_CMV2)
+
+        # module 2 is not whitelisted
+        digests = [_make_digest(1, '0xAddr1', 2), _make_digest(2, '0xAddr2', 2)]
+        self.bot._refresh_modules_state(digests)
+
+        self.assertIn(1, self.bot._module_type_cache)
+        self.assertNotIn(2, self.bot._module_type_cache)
 
 
 # ─── _is_in_cooldown ───────────────────────────────────────────────
@@ -712,15 +751,29 @@ def test_deposit_to_module_happy_path_sends_tx(depositor_bot):
 
 
 @pytest.mark.unit
-def test_deposit_to_module_csm_strategy_for_module_3(depositor_bot):
-    """_select_strategy returns CSM strategy for module_id == 3."""
+def test_deposit_to_module_csm_strategy_for_csm_module_type(depositor_bot):
+    """_select_strategy returns CSM strategy when the module type is MODULE_TYPE_CSM."""
+    depositor_bot._module_type_cache[4] = DepositorBot.MODULE_TYPE_CSM
     depositor_bot._csm_strategy.is_gas_price_ok = Mock(return_value=False)
     depositor_bot._general_strategy.is_gas_price_ok = Mock(return_value=False)
 
-    depositor_bot._deposit_to_module(3)
+    depositor_bot._deposit_to_module(4)
 
-    depositor_bot._csm_strategy.is_gas_price_ok.assert_called_once_with(3)
+    depositor_bot._csm_strategy.is_gas_price_ok.assert_called_once_with(4)
     depositor_bot._general_strategy.is_gas_price_ok.assert_not_called()
+
+
+@pytest.mark.unit
+def test_deposit_to_module_general_strategy_for_non_csm_module_type(depositor_bot):
+    """_select_strategy returns general strategy when the module type is not MODULE_TYPE_CSM."""
+    depositor_bot._module_type_cache[1] = b'curated-onchain-v1'.ljust(32, b'\x00')
+    depositor_bot._csm_strategy.is_gas_price_ok = Mock(return_value=False)
+    depositor_bot._general_strategy.is_gas_price_ok = Mock(return_value=False)
+
+    depositor_bot._deposit_to_module(1)
+
+    depositor_bot._general_strategy.is_gas_price_ok.assert_called_once_with(1)
+    depositor_bot._csm_strategy.is_gas_price_ok.assert_not_called()
 
 
 # ─── _top_up_to_module ─────────────────────────────────────────────

--- a/tests/fixtures/contracts.py
+++ b/tests/fixtures/contracts.py
@@ -2,7 +2,6 @@ from typing import cast
 
 import pytest
 import variables
-from blockchain.contracts.base_interface import ContractInterface
 from blockchain.contracts.cmv2 import CMV2Contract
 from blockchain.contracts.deposit import DepositContract
 from blockchain.contracts.deposit_security_module import DepositSecurityModuleContract
@@ -92,15 +91,12 @@ def cmv2_contract(web3_lido_integration):
     if web3_lido_integration.eth.chain_id != 32382:
         pytest.skip('CMV2 contract test is supported currently only on chainId 32382.')
 
-    module_ids = web3_lido_integration.lido.staking_router.get_staking_module_ids()
-    module_digests = web3_lido_integration.lido.staking_router.get_staking_module_digests(module_ids)
-    module_type_abi = ContractInterface.load_abi('./interfaces/IStakingModule.json')
+    module_digests = web3_lido_integration.lido.staking_router.get_all_staking_module_digests()
     cmv2_type = b'curated-onchain-v2'.ljust(32, b'\x00')
 
     for digest in module_digests:
-        module_address = digest[2][1]
-        module = web3_lido_integration.eth.contract(address=module_address, abi=module_type_abi)
-        if module.functions.getType().call() == cmv2_type:
+        module_address = digest['address']
+        if web3_lido_integration.lido.staking_module(digest['module_id']).get_type() == cmv2_type:
             yield cast(
                 CMV2Contract,
                 web3_lido_integration.eth.contract(


### PR DESCRIPTION
# fix: use getType() to detect CSM modules instead of hardcoded module ID
  
 ## Problem

  _select_strategy() was selecting CSMDepositStrategy by a hardcoded check if module_id == 3 (with a # todo: check by getType comment). This is fragile: module IDs are environment-specific (CSM is module 4 on Hoodi), and it conflated the CMv2 type constant with CSM detection.

  Additionally, on-chain data confirms that the getType() value for the Community Staking Module is community-onchain-v1, which is entirely distinct from curated-onchain-v2 (CMv2). Using MODULE_TYPE_CMV2 to gate the CSM strategy would have silently applied the wrong strategy on networks where CSM is module 3.

  Module types on Hoodi testnet:

  ```  ┌───────────┬─────────────────────────┬──────────────────────┐
  │ Module ID │          Name           │      getType()       │
  ├───────────┼─────────────────────────┼──────────────────────┤
  │ 1         │ curated-onchain-v1      │ curated-onchain-v1   │
  ├───────────┼─────────────────────────┼──────────────────────┤
  │ 2         │ SimpleDVT               │ curated-onchain-v1   │
  ├───────────┼─────────────────────────┼──────────────────────┤
  │ 3         │ Sandbox                 │ curated-onchain-v1   │
  ├───────────┼─────────────────────────┼──────────────────────┤
  │ 4         │ Community Staking (CSM) │ community-onchain-v1 │
  ├───────────┼─────────────────────────┼──────────────────────┤
  │ 5         │ curated-onchain-v2      │ curated-onchain-v2   │
  └───────────┴─────────────────────────┴──────────────────────┘
  ```