### PR TITLE
Dsm version check in council sig & replaced canTopUp

### DIFF
--- a/interfaces/TopUpGateway.json
+++ b/interfaces/TopUpGateway.json
@@ -53,11 +53,6 @@
   },
   {
     "inputs": [],
-    "name": "DuplicateValidatorIndex",
-    "type": "error"
-  },
-  {
-    "inputs": [],
     "name": "IndexOutOfRange",
     "type": "error"
   },
@@ -73,12 +68,12 @@
   },
   {
     "inputs": [],
-    "name": "InvalidSignLength",
+    "name": "InvalidSlot",
     "type": "error"
   },
   {
     "inputs": [],
-    "name": "InvalidSlot",
+    "name": "InvalidValidatorIndicesSortOrder",
     "type": "error"
   },
   {
@@ -99,6 +94,21 @@
   {
     "inputs": [],
     "name": "NotInitializing",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PauseUntilMustBeInFuture",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PausedExpected",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ResumedExpected",
     "type": "error"
   },
   {
@@ -139,6 +149,22 @@
   {
     "inputs": [],
     "name": "WrongWithdrawalCredentials",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "argument",
+        "type": "string"
+      }
+    ],
+    "name": "ZeroArgument",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroPauseDuration",
     "type": "error"
   },
   {
@@ -209,6 +235,25 @@
       }
     ],
     "name": "MinBlockDistanceChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "duration",
+        "type": "uint256"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "Resumed",
     "type": "event"
   },
   {
@@ -385,12 +430,51 @@
   },
   {
     "inputs": [],
+    "name": "PAUSE_INFINITELY",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PAUSE_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "PIVOT_SLOT",
     "outputs": [
       {
         "internalType": "uint64",
         "name": "",
         "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "RESUME_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
       }
     ],
     "stateMutability": "view",
@@ -417,25 +501,6 @@
         "internalType": "bytes32",
         "name": "",
         "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "_stakingModuleId",
-        "type": "uint256"
-      }
-    ],
-    "name": "canTopUp",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
       }
     ],
     "stateMutability": "view",
@@ -496,6 +561,19 @@
   {
     "inputs": [],
     "name": "getMinTopUpGwei",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getResumeSinceTimestamp",
     "outputs": [
       {
         "internalType": "uint256",
@@ -656,7 +734,7 @@
       },
       {
         "internalType": "uint256",
-        "name": "_minBlockDistance",
+        "name": "_minTopUpBlockDistance",
         "type": "uint256"
       },
       {
@@ -681,6 +759,58 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "isBlockDistancePassed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isPaused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_duration",
+        "type": "uint256"
+      }
+    ],
+    "name": "pauseFor",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pauseUntilInclusive",
+        "type": "uint256"
+      }
+    ],
+    "name": "pauseUntil",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",
@@ -694,6 +824,13 @@
       }
     ],
     "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "resume",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/src/blockchain/contracts/lido.py
+++ b/src/blockchain/contracts/lido.py
@@ -18,6 +18,15 @@ class LidoContract(ContractInterface):
         logger.info({'msg': 'Call `getDepositableEther()`.', 'value': response, 'block_identifier': repr(block_identifier)})
         return response
 
+    def can_deposit(self, block_identifier: BlockIdentifier = 'latest') -> bool:
+        """
+        Check that Lido allows depositing buffered ether to the Consensus Layer.
+        Depends on the bunker mode and protocol pause state
+        """
+        response = self.functions.canDeposit().call(block_identifier=block_identifier)
+        logger.info({'msg': 'Call `canDeposit()`.', 'value': response, 'block_identifier': repr(block_identifier)})
+        return response
+
     def get_buffered_ether(self, block_identifier: BlockIdentifier = 'latest') -> Wei:
         """
         Get the amount of Ether temporary buffered on this contract balance.

--- a/src/blockchain/contracts/staking_router.py
+++ b/src/blockchain/contracts/staking_router.py
@@ -112,6 +112,14 @@ class StakingRouterContractV3(ContractInterface):
 class StakingRouterContractV4(StakingRouterContractV3):
     abi_path = './interfaces/StakingRouterV4.json'
 
+    def can_deposit(self, staking_module_id: int, block_identifier: BlockIdentifier = 'latest') -> bool:
+        """
+        Check module exits and active
+        """
+        response = self.functions.canDeposit(staking_module_id).call(block_identifier=block_identifier)
+        logger.info({'msg': f'Call `canDeposit({staking_module_id})`.', 'value': response, 'block_identifier': repr(block_identifier)})
+        return response
+
     def get_deposit_allocations(
         self,
         deposit_amount: Wei,

--- a/src/blockchain/contracts/topup_gateway.py
+++ b/src/blockchain/contracts/topup_gateway.py
@@ -18,28 +18,15 @@ class TopUpGatewayContract(ContractInterface):
         logger.info({'msg': 'Call `getMaxValidatorsPerTopUp()`.', 'value': response, 'block_identifier': repr(block_identifier)})
         return response
 
-    def can_top_up(self, staking_module_id: int, block_identifier: BlockIdentifier = 'latest') -> bool:
-        response = self.functions.canTopUp(staking_module_id).call(block_identifier=block_identifier)
-        logger.info(
-            {
-                'msg': f'Call `canTopUp({staking_module_id})`.',
-                'value': response,
-                'block_identifier': repr(block_identifier),
-            }
-        )
+    def is_paused(self, block_identifier: BlockIdentifier = 'latest') -> bool:
+        response = self.functions.isPaused().call(block_identifier=block_identifier)
+        logger.info({'msg': 'Call `isPaused()`.', 'value': response, 'block_identifier': repr(block_identifier)})
         return response
 
-    def is_block_distance_passed(self, staking_module_id: int, block_identifier: BlockIdentifier = 'latest') -> bool:
-        # TODO: isBlockDistancePassed is not yet deployed on Hoodi. Returning True with a warning
-        # until the contract is updated; then switch to the real on-chain call.
-        logger.warning(
-            {
-                'msg': f'`isBlockDistancePassed({staking_module_id})` not yet deployed — stubbing to True.',
-                'module_id': staking_module_id,
-                'block_identifier': repr(block_identifier),
-            }
-        )
-        return True
+    def is_block_distance_passed(self, block_identifier: BlockIdentifier = 'latest') -> bool:
+        response = self.functions.isBlockDistancePassed().call(block_identifier=block_identifier)
+        logger.info({'msg': 'Call `isBlockDistancePassed()`.', 'value': response, 'block_identifier': repr(block_identifier)})
+        return response
 
     def top_up(self, module_id: int, proof_data: 'TopUpProofData') -> ContractFunction:
         top_up_data = (

--- a/src/blockchain/web3_extentions/lido_contracts.py
+++ b/src/blockchain/web3_extentions/lido_contracts.py
@@ -6,10 +6,7 @@ from blockchain.contracts.deposit import DepositContract
 from blockchain.contracts.deposit_security_module import DepositSecurityModuleContract
 from blockchain.contracts.lido import LidoContract
 from blockchain.contracts.lido_locator import LidoLocatorContract
-from blockchain.contracts.staking_router import (
-    StakingRouterContractV3,
-    StakingRouterContractV4,
-)
+from blockchain.contracts.staking_router import StakingRouterContractV4
 from blockchain.contracts.topup_gateway import TopUpGatewayContract
 from web3 import Web3
 from web3.contract.contract import Contract
@@ -17,12 +14,12 @@ from web3.module import Module
 
 logger = logging.getLogger(__name__)
 
+SUPPORTED_DSM_VERSION = 4
+
 
 class LidoContracts(Module):
     def __init__(self, w3: Web3):
         super().__init__(w3)
-        self.staking_router_version: int | None = None
-        self.topup_gateway: TopUpGatewayContract | None = None
         self._load_contracts()
 
     def has_contract_address_changed(self) -> bool:
@@ -58,38 +55,17 @@ class LidoContracts(Module):
         )
         self._load_staking_router()
         self._load_dsm()
-        if self.staking_router_version == 4:
-            self._load_topup_gateway()
+        self._load_topup_gateway()
 
     def _load_staking_router(self):
-        staking_router_address = self.lido_locator.staking_router()
-
-        # Read version using V3 ABI (getContractVersion signature is the same across versions)
-        sr = cast(
-            StakingRouterContractV3,
+        self.staking_router = cast(
+            StakingRouterContractV4,
             self.w3.eth.contract(
-                address=staking_router_address,
-                ContractFactoryClass=StakingRouterContractV3,
+                address=self.lido_locator.staking_router(),
+                ContractFactoryClass=StakingRouterContractV4,
                 decode_tuples=True,
             ),
         )
-        self.staking_router_version = sr.get_contract_version()
-
-        if self.staking_router_version == 4:
-            logger.debug({'msg': 'Use staking router V4.'})
-            self.staking_router = cast(
-                StakingRouterContractV4,
-                self.w3.eth.contract(
-                    address=staking_router_address,
-                    ContractFactoryClass=StakingRouterContractV4,
-                    decode_tuples=True,
-                ),
-            )
-        elif self.staking_router_version == 3:
-            logger.debug({'msg': 'Use staking router V3.'})
-            self.staking_router = sr
-        else:
-            raise ValueError(f'Unsupported StakingRouter version: {self.staking_router_version}')
 
     def _load_dsm(self):
         dsm_address = self.lido_locator.deposit_security_module()
@@ -101,6 +77,10 @@ class LidoContracts(Module):
                 ContractFactoryClass=DepositSecurityModuleContract,
             ),
         )
+
+        self.dsm_version = self.deposit_security_module.version()
+        if self.dsm_version != SUPPORTED_DSM_VERSION:
+            raise ValueError(f'Unsupported DSM version: {self.dsm_version} (expected {SUPPORTED_DSM_VERSION})')
 
     def _load_topup_gateway(self):
         topup_gateway_address = self.lido_locator.top_up_gateway()

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -132,8 +132,6 @@ class DepositorBot:
         logger.info({'msg': 'Depositor iteration start.', 'block_number': block.get('number')})
         self._check_balance()
 
-        sr_version = self.w3.lido.staking_router.get_contract_version()
-        logger.info({'msg': 'SR version.', 'value': sr_version})
         result = self._execute_actual()
         logger.info({'msg': 'Depositor iteration finished.', 'value': result})
         return result
@@ -322,11 +320,17 @@ class DepositorBot:
 
         for module_id, module_address, wc_type, _stake, topup_alloc in candidates:
             if wc_type == 2:
-                # Top-up path: canTopUp + is_block_distance_passed (no quorum check for top-ups).
-                if not self.w3.lido.topup_gateway.can_top_up(module_id):
-                    logger.info({'msg': 'Phase B: canTopUp=False — try next module.', 'module_id': module_id})
+                # Top-up path: inlined canTopUp checks (no quorum check for top-ups). WC type already verified above.
+                if self.w3.lido.topup_gateway.is_paused():
+                    logger.info({'msg': 'Phase B: TopUpGateway is paused — try next module.', 'module_id': module_id})
                     continue
-                if not self.w3.lido.topup_gateway.is_block_distance_passed(module_id):
+                if not sr_v4.can_deposit(module_id):
+                    logger.info({'msg': 'Phase B: StakingRouter.canDeposit=False — try next module.', 'module_id': module_id})
+                    continue
+                if not self.w3.lido.lido.can_deposit():
+                    logger.info({'msg': 'Phase B: Lido.canDeposit=False — try next module.', 'module_id': module_id})
+                    continue
+                if not self.w3.lido.topup_gateway.is_block_distance_passed():
                     logger.info({'msg': 'Phase B: top-up block distance not passed — wait next iteration.', 'module_id': module_id})
                     return True, False
                 return True, self._top_up_to_module(module_id, module_address, topup_alloc)
@@ -536,6 +540,6 @@ class DepositorBot:
         # Fetch messages and apply filters
         actualize_filter = self._get_message_actualize_filter()
         prefix = self.w3.lido.deposit_security_module.get_attest_message_prefix()
-        sign_filter = get_messages_sign_filter(prefix)
+        sign_filter = get_messages_sign_filter(prefix, self.w3.lido.dsm_version)
 
         return self.message_storage.get_messages_and_actualize(lambda x: sign_filter(x) and actualize_filter(x))

--- a/src/bots/pauser.py
+++ b/src/bots/pauser.py
@@ -9,7 +9,7 @@ from blockchain.typings import Web3
 from metrics.metrics import UNEXPECTED_EXCEPTIONS
 from metrics.transport_message_metrics import message_metrics_filter
 from schema import Or, Schema
-from transport.msg_providers.onchain_transport import OnchainTransportProvider, PauseV2Parser, PauseV3Parser, PingParser
+from transport.msg_providers.onchain_transport import OnchainTransportProvider, PauseV3Parser, PingParser
 from transport.msg_providers.rabbit import MessageType, RabbitProvider
 from transport.msg_storage import MessageStorage
 from transport.msg_types.common import get_messages_sign_filter
@@ -54,7 +54,7 @@ class PauserBot:
                     w3=OnchainTransportProvider.create_onchain_transport_w3(),
                     onchain_address=variables.ONCHAIN_TRANSPORT_ADDRESS,
                     message_schema=Schema(Or(PauseMessageSchema, PingMessageSchema)),
-                    parsers_providers=[PauseV2Parser, PauseV3Parser, PingParser],
+                    parsers_providers=[PauseV3Parser, PingParser],
                     allowed_guardians_provider=self.w3.lido.deposit_security_module.get_guardians,
                 )
             )
@@ -119,4 +119,4 @@ class PauserBot:
 
     def _sign_filter(self) -> Callable:
         prefix = self.w3.lido.deposit_security_module.get_pause_message_prefix()
-        return get_messages_sign_filter(prefix)
+        return get_messages_sign_filter(prefix, self.w3.lido.dsm_version)

--- a/src/bots/unvetter.py
+++ b/src/bots/unvetter.py
@@ -90,7 +90,7 @@ class UnvetterBot:
 
         actualize_filter = self._get_message_actualize_filter()
         prefix = self.w3.lido.deposit_security_module.get_unvet_message_prefix()
-        sign_filter = get_messages_sign_filter(prefix)
+        sign_filter = get_messages_sign_filter(prefix, self.w3.lido.dsm_version)
         return self.message_storage.get_messages_and_actualize(lambda x: sign_filter(x) and actualize_filter(x))
 
     def _get_message_actualize_filter(self) -> Callable[[UnvetMessage], bool]:
@@ -154,7 +154,7 @@ class UnvetterBot:
 
     def _clear_outdated_messages_for_module(self, module_id: int, nonce: int):
         prefix = self.w3.lido.deposit_security_module.get_unvet_message_prefix()
-        is_message_signed_filter = get_messages_sign_filter(prefix)
+        is_message_signed_filter = get_messages_sign_filter(prefix, self.w3.lido.dsm_version)
 
         def is_unvet_message_relevant(msg: TypedDict) -> bool:
             is_message_relevant = msg['stakingModuleId'] != module_id or int(msg['nonce']) >= nonce

--- a/src/transport/msg_providers/onchain_transport.py
+++ b/src/transport/msg_providers/onchain_transport.py
@@ -236,32 +236,6 @@ class PingParser(EventParser):
         )
 
 
-# event MessagePauseV2(address indexed guardianAddress, (uint256 blockNumber, bytes32 blockHash, (bytes32 r, bytes32 vs) signature,
-# uint256 stakingModuleId, (bytes32 version) app) data)
-class PauseV2Parser(EventParser):
-    PAUSE_V2_DATA_SCHEMA = '(uint256,bytes32,(bytes32,bytes32),uint256,(bytes32))'
-    message_abi = f'MessagePauseV2(address,{PAUSE_V2_DATA_SCHEMA})'
-
-    def __init__(self, w3: Web3):
-        super().__init__(w3, self.PAUSE_V2_DATA_SCHEMA)
-
-    def _create_message(self, parsed_data: tuple, guardian: str) -> dict:
-        block_number, block_hash, (r, vs), staking_module_id, (version,) = parsed_data
-        return PauseMessage(
-            type=MessageType.PAUSE,
-            blockNumber=block_number,
-            guardianAddress=guardian,
-            stakingModuleId=staking_module_id,
-            signature={
-                'r': bytes_to_hex_string(r),
-                '_vs': bytes_to_hex_string(vs),
-            },
-            app={
-                'version': _decode_version(version),
-            },
-        )
-
-
 # event MessagePauseV3(address indexed guardianAddress, (uint256 blockNumber, bytes32 blockHash, (bytes32 r, bytes32 vs) signature,
 # (bytes32 version) app) data)
 class PauseV3Parser(EventParser):

--- a/src/transport/msg_types/common.py
+++ b/src/transport/msg_types/common.py
@@ -16,12 +16,12 @@ logger = logging.getLogger(__name__)
 BotMessage = DepositMessage | PauseMessage | UnvetMessage | PingMessage
 
 
-def get_messages_sign_filter(prefix) -> Callable:
+def get_messages_sign_filter(prefix: bytes, contract_version: int) -> Callable:
     """Returns filter that checks message validity"""
 
     def check_messages(msg: DepositMessage | PauseMessage | UnvetMessage) -> bool:
         v, r, s = _vrs(msg)
-        data, abi = _verification_data(prefix, msg)
+        data, abi = _verification_data(prefix, contract_version, msg)
 
         is_valid = verify_message_with_signature(
             data=data,
@@ -59,37 +59,34 @@ def _select_label(msg: DepositMessage | PauseMessage | UnvetMessage) -> str:
         raise ValueError('Unsupported message type')
 
 
-def _verification_data(prefix: bytes, msg: BotMessage) -> tuple[List[Any], List[str]]:
+def _verification_data(prefix: bytes, contract_version: int, msg: BotMessage) -> tuple[List[Any], List[str]]:
     t = msg['type']
     if t == MessageType.PAUSE:
-        return _verification_data_pause(prefix, cast(PauseMessage, msg))
+        return _verification_data_pause(prefix, contract_version, cast(PauseMessage, msg))
     elif t == MessageType.UNVET:
-        return _verification_data_unvet(prefix, cast(UnvetMessage, msg))
+        return _verification_data_unvet(prefix, contract_version, cast(UnvetMessage, msg))
     elif t == MessageType.DEPOSIT:
-        return _verification_data_deposit(prefix, cast(DepositMessage, msg))
+        return _verification_data_deposit(prefix, contract_version, cast(DepositMessage, msg))
     else:
         raise ValueError('Unsupported message type')
 
 
-def _verification_data_deposit(prefix: bytes, msg: DepositMessage) -> tuple[List[Any], List[str]]:
-    data = [prefix, msg['blockNumber'], msg['blockHash'], msg['depositRoot'], msg['stakingModuleId'], msg['nonce']]
-    abi = ['bytes32', 'uint256', 'bytes32', 'bytes32', 'uint256', 'uint256']
+def _verification_data_deposit(prefix: bytes, contract_version: int, msg: DepositMessage) -> tuple[List[Any], List[str]]:
+    data = [prefix, contract_version, msg['blockNumber'], msg['blockHash'], msg['depositRoot'], msg['stakingModuleId'], msg['nonce']]
+    abi = ['bytes32', 'uint256', 'uint256', 'bytes32', 'bytes32', 'uint256', 'uint256']
     return data, abi
 
 
-def _verification_data_pause(prefix: bytes, msg: PauseMessage) -> tuple[List[Any], List[str]]:
-    if 'stakingModuleId' in msg:
-        data = [prefix, msg['blockNumber'], msg['stakingModuleId']]
-        abi = ['bytes32', 'uint256', 'uint256']
-    else:
-        data = [prefix, msg['blockNumber']]
-        abi = ['bytes32', 'uint256']
+def _verification_data_pause(prefix: bytes, contract_version: int, msg: PauseMessage) -> tuple[List[Any], List[str]]:
+    data = [prefix, contract_version, msg['blockNumber']]
+    abi = ['bytes32', 'uint256', 'uint256']
     return data, abi
 
 
-def _verification_data_unvet(prefix: bytes, msg: UnvetMessage) -> tuple[List[Any], List[str]]:
+def _verification_data_unvet(prefix: bytes, contract_version: int, msg: UnvetMessage) -> tuple[List[Any], List[str]]:
     data = [
         prefix,
+        contract_version,
         msg['blockNumber'],
         msg['blockHash'],
         msg['stakingModuleId'],
@@ -97,5 +94,5 @@ def _verification_data_unvet(prefix: bytes, msg: UnvetMessage) -> tuple[List[Any
         from_hex_string_to_bytes(msg['operatorIds']),
         from_hex_string_to_bytes(msg['vettedKeysByOperator']),
     ]
-    abi = ['bytes32', 'uint256', 'bytes32', 'uint256', 'uint256', 'bytes', 'bytes']
+    abi = ['bytes32', 'uint256', 'uint256', 'bytes32', 'uint256', 'uint256', 'bytes', 'bytes']
     return data, abi

--- a/src/transport/msg_types/pause.py
+++ b/src/transport/msg_types/pause.py
@@ -28,7 +28,6 @@ PauseMessageSchema = Schema(
         'blockNumber': int,
         'guardianAddress': And(str, ADDRESS_REGREX.validate),
         'signature': SignatureSchema,
-        # 'stakingModuleId': int
     },
     ignore_extra_keys=True,
 )
@@ -38,4 +37,3 @@ class PauseMessage(Metadata):
     blockNumber: int
     guardianAddress: str
     signature: Signature
-    stakingModuleId: int

--- a/tests/blockchain/contracts/test_topup_gateway.py
+++ b/tests/blockchain/contracts/test_topup_gateway.py
@@ -9,7 +9,8 @@ def test_topup_gateway_call(topup_gateway, caplog):
     check_contract(
         topup_gateway,
         [
-            ('can_top_up', (1,), lambda response: check_value_type(response, bool)),
+            ('is_paused', None, lambda response: check_value_type(response, bool)),
+            ('is_block_distance_passed', None, lambda response: check_value_type(response, bool)),
             ('get_max_validators_per_top_up', None, lambda response: check_value_type(response, int)),
         ],
         caplog,

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -357,7 +357,9 @@ class TestPhaseFullAndTopup(unittest.TestCase):
         variables.DEPOSIT_MODULES_WHITELIST = [1, 2, 3]
         self.bot._module_last_heart_beat = {m: datetime.now() for m in [1, 2, 3]}
         self.bot.w3.lido.deposit_security_module.can_deposit.return_value = True
-        self.bot.w3.lido.topup_gateway.can_top_up.return_value = True
+        self.bot.w3.lido.topup_gateway.is_paused.return_value = False
+        self.bot.w3.lido.staking_router.can_deposit.return_value = True
+        self.bot.w3.lido.lido.can_deposit.return_value = True
         self.bot.w3.lido.topup_gateway.is_block_distance_passed.return_value = True
         self.bot._get_quorum = Mock(return_value=None)
         self.bot._deposit_to_module = Mock(return_value=True)
@@ -429,14 +431,38 @@ class TestPhaseFullAndTopup(unittest.TestCase):
 
     # ─── 0x02 branch ───────────────────────────────────────────
 
-    def test_can_top_up_false_skips_to_next(self):
-        # m1 (0x02) can_top_up=False → skipped. m2 (0x01) succeeds.
+    def test_gateway_paused_skips_to_next(self):
+        # m1 (0x02) TopUpGateway paused → skipped. m2 (0x01) succeeds.
         digests = [_make_digest(1, '0xA1', 2), _make_digest(2, '0xA2', 1)]
         self._set_topup_allocation([50, 0], [100, 0])
-        self.bot.w3.lido.topup_gateway.can_top_up.return_value = False
+        self.bot.w3.lido.topup_gateway.is_paused.return_value = True
         self.bot._get_quorum = Mock(return_value=['msg'])
 
         # Ensure m1 has lower stake → tried first
+        self.bot._phase_full_and_topup(100, [0, 50], [0, 60], digests)
+
+        self.bot._top_up_to_module.assert_not_called()
+        self.bot._deposit_to_module.assert_called_once_with(2)
+
+    def test_staking_router_cannot_deposit_skips_to_next(self):
+        # m1 (0x02) StakingRouter.canDeposit=False → skipped. m2 (0x01) succeeds.
+        digests = [_make_digest(1, '0xA1', 2), _make_digest(2, '0xA2', 1)]
+        self._set_topup_allocation([50, 0], [100, 0])
+        self.bot.w3.lido.staking_router.can_deposit.return_value = False
+        self.bot._get_quorum = Mock(return_value=['msg'])
+
+        self.bot._phase_full_and_topup(100, [0, 50], [0, 60], digests)
+
+        self.bot._top_up_to_module.assert_not_called()
+        self.bot._deposit_to_module.assert_called_once_with(2)
+
+    def test_lido_cannot_deposit_skips_to_next(self):
+        # m1 (0x02) Lido.canDeposit=False → skipped. m2 (0x01) succeeds.
+        digests = [_make_digest(1, '0xA1', 2), _make_digest(2, '0xA2', 1)]
+        self._set_topup_allocation([50, 0], [100, 0])
+        self.bot.w3.lido.lido.can_deposit.return_value = False
+        self.bot._get_quorum = Mock(return_value=['msg'])
+
         self.bot._phase_full_and_topup(100, [0, 50], [0, 60], digests)
 
         self.bot._top_up_to_module.assert_not_called()

--- a/tests/bots/test_pauser.py
+++ b/tests/bots/test_pauser.py
@@ -31,7 +31,6 @@ def pause_message():
         'blockNumber': 10,
         'guardianAddress': COUNCIL_ADDRESS,
         'guardianIndex': 0,
-        'stakingModuleId': 1,
         'signature': {
             '_vs': '0xd4933925f5f97a9632b4b1bc621a1c2771d58eaf6eee27dcf915eac8af010537',
             'r': '0xbaa668505cd496caaf7117dd074338197200175057909ab73a04463656bdb0fa',
@@ -57,39 +56,15 @@ def add_account_to_guardian(web3_lido_integration, set_integration_account):
     yield COUNCIL_ADDRESS
 
 
-def get_pause_message(web3, module_id):
-    latest = web3.eth.get_block('latest')
-
-    prefix = web3.lido.deposit_security_module.get_pause_message_prefix()
-
-    block_number = latest.number
-
-    msg_hash = web3.solidity_keccak(['bytes32', 'uint256', 'uint256'], [prefix, block_number, module_id])
-    signed = web3.eth.account._sign_hash(msg_hash, private_key=COUNCIL_PK)
-
-    return {
-        'blockHash': latest.hash.hex(),
-        'blockNumber': latest.number,
-        'guardianAddress': COUNCIL_ADDRESS,
-        'stakingModuleId': module_id,
-        'signature': {
-            'r': '0x' + signed.r.to_bytes(32, 'big').hex(),
-            's': '0x' + signed.s.to_bytes(32, 'big').hex(),
-            'v': signed.v,
-            '_vs': compute_vs(signed.v, '0x' + signed.s.to_bytes(32, 'big').hex()),
-        },
-        'type': 'pause',
-    }
-
-
 def get_pause_message_v3(web3):
     latest = web3.eth.get_block('latest')
 
     prefix = web3.lido.deposit_security_module.get_pause_message_prefix()
+    contract_version = web3.lido.dsm_version
 
     block_number = latest.number
 
-    msg_hash = web3.solidity_keccak(['bytes32', 'uint256'], [prefix, block_number])
+    msg_hash = web3.solidity_keccak(['bytes32', 'uint256', 'uint256'], [prefix, contract_version, block_number])
     signed = web3.eth.account._sign_hash(msg_hash, private_key=COUNCIL_PK)
 
     return PauseV3Parser.build_message(
@@ -140,11 +115,11 @@ def test_pause_bot_clean_messages(pause_bot, block_data, pause_message):
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    'web3_provider_integration,module_id',
-    [[{'block': None}, 1], [{'block': None}, 2]],
+    'web3_provider_integration',
+    [{'block': None}],
     indirect=['web3_provider_integration'],
 )
-def test_pauser_bot(web3_lido_integration, web3_provider_integration, add_account_to_guardian, module_id, caplog):
+def test_pauser_bot(web3_lido_integration, web3_provider_integration, add_account_to_guardian, caplog):
     caplog.set_level(logging.INFO)
     latest = web3_lido_integration.eth.get_block('latest')
 

--- a/tests/bots/test_unvetter.py
+++ b/tests/bots/test_unvetter.py
@@ -19,15 +19,17 @@ def get_unvet_message(web3) -> UnvetMessage:
     block_number = latest.number
 
     prefix = web3.lido.deposit_security_module.get_unvet_message_prefix()
+    contract_version = web3.lido.dsm_version
     nonce = web3.lido.staking_router.functions.getStakingModuleNonce(1).call()
 
     operator_ids = from_hex_string_to_bytes('0x1234')
     vetted_keys_by_operator = from_hex_string_to_bytes('0001')
 
     msg_hash = web3.solidity_keccak(
-        ['bytes32', 'uint256', 'bytes32', 'uint256', 'uint256', 'bytes', 'bytes'],
+        ['bytes32', 'uint256', 'uint256', 'bytes32', 'uint256', 'uint256', 'bytes', 'bytes'],
         [
             prefix,
+            contract_version,
             block_number,
             latest.hash,
             1,
@@ -51,7 +53,7 @@ def get_unvet_message(web3) -> UnvetMessage:
         version=b'0x1',
     )
     prefix = web3.lido.deposit_security_module.get_unvet_message_prefix()
-    assert list(filter(get_messages_sign_filter(prefix), [unvet_message]))
+    assert list(filter(get_messages_sign_filter(prefix, contract_version), [unvet_message]))
 
     return unvet_message
 

--- a/tests/transport/onchain_sender.py
+++ b/tests/transport/onchain_sender.py
@@ -1,7 +1,6 @@
 from blockchain.contracts.data_bus import DataBusContract
 from transport.msg_providers.onchain_transport import (
     DepositParser,
-    PauseV2Parser,
     PauseV3Parser,
     PingParser,
     UnvetParser,
@@ -38,20 +37,6 @@ class OnchainTransportSender:
         mes = self._w3.codec.encode(
             types=[DepositParser.DEPOSIT_V1_DATA_SCHEMA],
             args=[(block_number, block_hash, deposit_root, staking_module_id, nonce, self._DEFAULT_SIGNATURE, app)],
-        )
-        tx = self._data_bus.functions.sendMessage(event_id, mes)
-        return tx.transact()
-
-    def send_pause_v2(self, pause_mes: PauseMessage):
-        event_id = self._w3.keccak(text=PauseV2Parser.message_abi)
-        block_number, staking_module_id, app = (
-            pause_mes['blockNumber'],
-            pause_mes['stakingModuleId'],
-            ((1).to_bytes(32),),
-        )
-        mes = self._w3.codec.encode(
-            types=[PauseV2Parser.PAUSE_V2_DATA_SCHEMA],
-            args=[(block_number, self._DEFAULT_BLOCK_HASH, self._DEFAULT_SIGNATURE, staking_module_id, app)],
         )
         tx = self._data_bus.functions.sendMessage(event_id, mes)
         return tx.transact()

--- a/tests/transport/test_data_bus.py
+++ b/tests/transport/test_data_bus.py
@@ -10,7 +10,6 @@ from schema import Or, Schema
 from transport.msg_providers.onchain_transport import (
     DepositParser,
     OnchainTransportProvider,
-    PauseV2Parser,
     PauseV3Parser,
     PingParser,
     UnvetParser,
@@ -129,57 +128,6 @@ def test_data_bus_provider_unvet(
     [{'endpoint': variables.ONCHAIN_TRANSPORT_RPC_ENDPOINTS[0]}],
     indirect=['web3_provider_integration'],
 )
-def test_data_bus_provider_pause_v2(
-    web3_transaction_integration,
-):
-    """
-    Utilise this function for an adhoc testing of data bus transport
-    """
-    variables.ONCHAIN_TRANSPORT_ADDRESS = ChecksumAddress(HexAddress(HexStr('0x37De961D6bb5865867aDd416be07189D2Dd960e6')))
-    data_bus_contract = cast(
-        DataBusContract,
-        web3_transaction_integration.eth.contract(
-            address=variables.ONCHAIN_TRANSPORT_ADDRESS,
-            ContractFactoryClass=DataBusContract,
-        ),
-    )
-    onchain_sender = OnchainTransportSender(w3=web3_transaction_integration, data_bus_contract=data_bus_contract)
-    onchain_sender.send_pause_v2(
-        pause_mes=PauseMessage(
-            type='pause',
-            blockNumber=2,
-            guardianAddress=_ANVIL_GUARDIAN,
-            stakingModuleId=1,
-            app={'version': b'3.2.0'.rjust(32, b'\0')},
-        )
-    )
-    provider = OnchainTransportProvider(
-        w3=web3_transaction_integration,
-        onchain_address=variables.ONCHAIN_TRANSPORT_ADDRESS,
-        message_schema=Schema(Or(PauseMessageSchema)),
-        parsers_providers=[PauseV2Parser],
-        allowed_guardians_provider=lambda: [Web3.to_checksum_address(_ANVIL_GUARDIAN[:-1] + '7')],
-    )
-    messages = provider.get_messages()
-    assert not messages
-    web3_transaction_integration.provider.make_request('anvil_mine', [10])
-    provider = OnchainTransportProvider(
-        w3=web3_transaction_integration,
-        onchain_address=variables.ONCHAIN_TRANSPORT_ADDRESS,
-        message_schema=Schema(Or(PauseMessageSchema)),
-        parsers_providers=[PauseV2Parser],
-        allowed_guardians_provider=lambda: [Web3.to_checksum_address(_ANVIL_GUARDIAN)],
-    )
-    messages = provider.get_messages()
-    assert len(messages) == 1
-
-
-@pytest.mark.integration
-@pytest.mark.parametrize(
-    'web3_provider_integration',
-    [{'endpoint': variables.ONCHAIN_TRANSPORT_RPC_ENDPOINTS[0]}],
-    indirect=['web3_provider_integration'],
-)
 def test_data_bus_provider_pause_v3(
     web3_transaction_integration,
 ):
@@ -200,7 +148,6 @@ def test_data_bus_provider_pause_v3(
             type='pause',
             blockNumber=2,
             guardianAddress=_ANVIL_GUARDIAN,
-            stakingModuleId=1,
             app={'version': b'3.2.0'.rjust(32, b'\0')},
         )
     )


### PR DESCRIPTION
- Updated guardian signature verification to account for the addition of the DSM contract version
- Replaced the canTopUp TopUpGateway method call with separate checks from the Lido and SR contracts and the Top Up Gateway