### PR TITLE
fix: deposit distance cooldown & refactoring

### DIFF
--- a/src/blockchain/consolidation/indexer.py
+++ b/src/blockchain/consolidation/indexer.py
@@ -46,25 +46,23 @@ class ConsolidationIndexer:
         self.store = store
         self.deploy_block = deploy_block
         self.chunk = chunk
-        self.is_ready = False
 
     # ---- lifecycle ----
     def cold_start(self) -> None:
-        """Full backfill (deploy -> finalized) at bot init."""
-        try:
-            finalized = self.sync_base_to_finalized()
-            self.is_ready = True
-            logger.info(
-                {
-                    'msg': 'Consolidation indexer ready.',
-                    'finalized': finalized,
-                    'pending_batches': self.store.pending_batch_count(),
-                    'pending_pubkeys': self.store.pending_pubkey_count(),
-                }
-            )
-        except Exception as e:
-            self.is_ready = False
-            logger.error({'msg': 'Consolidation indexer cold start failed — top-up will be skipped.', 'err': repr(e)})
+        """Full backfill (deploy -> finalized) at bot init.
+
+        Raises on failure — the caller must NOT run a half-initialized indexer (it would skip every
+        top-up until restart). The bot fails fast at startup instead.
+        """
+        finalized = self.sync_base_to_finalized()
+        logger.info(
+            {
+                'msg': 'Consolidation indexer ready.',
+                'finalized': finalized,
+                'pending_batches': self.store.pending_batch_count(),
+                'pending_pubkeys': self.store.pending_pubkey_count(),
+            }
+        )
 
     # ---- base (up to finalized) ----
     def sync_base_to_finalized(self) -> int:

--- a/src/blockchain/contracts/deposit_security_module.py
+++ b/src/blockchain/contracts/deposit_security_module.py
@@ -44,6 +44,24 @@ class DepositSecurityModuleContract(ContractInterface):
         CAN_DEPOSIT.labels(staking_module_id).set(int(response))
         return response
 
+    def is_min_deposit_distance_passed(self, staking_module_id: int, block_identifier: BlockIdentifier = 'latest') -> bool:
+        """Whether the global min deposit block distance has passed since the last deposit.
+
+        Standalone view of just the distance condition inside `canDeposit` (point 5 of
+        `depositBufferedEther`): `block.number - getLastDepositBlock() >= minDepositBlockDistance`.
+        The last deposit block is global (a deposit to any module advances it), so this gates every
+        module. Used to tell a transient distance block apart from a permanent one.
+        """
+        response = self.functions.isMinDepositDistancePassed(staking_module_id).call(block_identifier=block_identifier)
+        logger.info(
+            {
+                'msg': f'Call `isMinDepositDistancePassed({staking_module_id})`.',
+                'value': response,
+                'block_identifier': repr(block_identifier),
+            }
+        )
+        return response
+
     def deposit_buffered_ether(
         self,
         block_number: int,

--- a/src/blockchain/contracts/lido.py
+++ b/src/blockchain/contracts/lido.py
@@ -25,3 +25,9 @@ class LidoContract(ContractInterface):
         response = self.functions.getBufferedEther().call(block_identifier=block_identifier)
         logger.info({'msg': 'Call `getBufferedEther()`.', 'value': response, 'block_identifier': repr(block_identifier)})
         return response
+
+    def can_deposit(self, block_identifier: BlockIdentifier = 'latest') -> bool:
+        """Whether Lido currently allows deposits (not stopped / not bunker, etc.)."""
+        response = self.functions.canDeposit().call(block_identifier=block_identifier)
+        logger.info({'msg': 'Call `canDeposit()`.', 'value': response, 'block_identifier': repr(block_identifier)})
+        return response

--- a/src/blockchain/contracts/staking_router.py
+++ b/src/blockchain/contracts/staking_router.py
@@ -17,6 +17,7 @@ class StakingModuleInfo(TypedDict):
     module_id: int
     address: str
     wc_type: int
+    status: int  # StakingModuleStatus: 0=Active, 1=DepositsPaused, 2=Stopped
 
 
 class StakingRouterContractV3(ContractInterface):
@@ -59,7 +60,7 @@ class StakingRouterContractV3(ContractInterface):
                 'block_identifier': block_identifier.__repr__(),
             }
         )
-        return [StakingModuleInfo(module_id=d[2][0], address=d[2][1], wc_type=1) for d in response]
+        return [StakingModuleInfo(module_id=d[2][0], address=d[2][1], wc_type=1, status=d[2][5]) for d in response]
 
     def is_staking_module_active(
         self,
@@ -124,7 +125,7 @@ class StakingRouterContractV4(StakingRouterContractV3):
                 'block_identifier': block_identifier.__repr__(),
             }
         )
-        return [StakingModuleInfo(module_id=d[2][0], address=d[2][1], wc_type=d[2][13]) for d in response]
+        return [StakingModuleInfo(module_id=d[2][0], address=d[2][1], wc_type=d[2][13], status=d[2][5]) for d in response]
 
     def get_deposit_allocations(
         self,

--- a/src/blockchain/contracts/topup_gateway.py
+++ b/src/blockchain/contracts/topup_gateway.py
@@ -41,6 +41,12 @@ class TopUpGatewayContract(ContractInterface):
         )
         return True
 
+    def is_paused(self, block_identifier: BlockIdentifier = 'latest') -> bool:
+        # TODO: isPaused is not yet in the deployed TopUpGateway ABI. Returning False (not paused)
+        # with a warning until the contract exposes it; then switch to the real on-chain call.
+        logger.warning({'msg': '`isPaused()` not yet deployed — stubbing to False.', 'block_identifier': repr(block_identifier)})
+        return False
+
     def top_up(self, module_id: int, proof_data: 'TopUpProofData') -> ContractFunction:
         top_up_data = (
             module_id,

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -3,7 +3,8 @@ import logging
 from collections import defaultdict
 from collections.abc import Callable
 from datetime import datetime, timedelta
-from typing import cast
+from enum import Enum
+from typing import NamedTuple, cast
 
 import variables
 from blockchain.consolidation.indexer import ConsolidationIndexer
@@ -47,6 +48,43 @@ from transport.types import TransportType
 from web3.types import BlockData, Wei
 
 logger = logging.getLogger(__name__)
+
+
+class ModuleCandidate(NamedTuple):
+    """Module candidate selected for a deposit/top-up in one bot iteration."""
+
+    digest_index: int  # position in the digests list; stable tie-break for equal-stake candidates
+    module_id: int
+    wc_type: int
+    stake: Wei  # new - allocated: module's allocation level before this round; lower stake → deposit first
+    address: str
+    # Amount the StakingRouter (SR-lib) allocation algorithm decided should be allocated to this module
+    # from the depositable buffer sum. Needed only for top-up; unused for deposits.
+    allocation: Wei
+
+
+class QuorumState(Enum):
+    READY = 'ready'  # a guardian quorum exists now → deposit
+    RETAINED = 'retained'  # no quorum now, but one existed within QUORUM_RETENTION_MINUTES → wait
+    STALE = 'stale'  # no quorum and none recently → try the next module
+
+
+class PhaseOutcome(Enum):
+    SENT = 'sent'  # deposit/top-up tx sent ok
+    TX_FAILED = 'tx_failed'  # deposit/top-up tx failed
+    WAIT_DISTANCE = 'wait_distance'  # blocked by min deposit / top-up block distance
+    WAIT_QUORUM = 'wait_quorum'  # quorum absent now but retained
+    SKIPPED = 'skipped'  # nothing actionable in this phase → caller tries the next phase
+
+    @property
+    def is_backoff(self) -> bool:
+        """Executor scheduling signal: True → +BLOCKS_BETWEEN_EXECUTION (back off), False → +1 (poll next block).
+
+        Back off after a sent tx (give it time) and on a distance wait (the min deposit / top-up block
+        distance won't clear for a while, so polling every block is wasteful). A quorum-retention wait
+        polls every block instead — a quorum can re-form on any block and we want to catch it fast.
+        """
+        return self in (PhaseOutcome.SENT, PhaseOutcome.WAIT_DISTANCE)
 
 
 def run_depositor(w3, keys_api: KeysAPIClient, cl: ConsensusClient):
@@ -142,6 +180,21 @@ class DepositorBot:
         logger.info({'msg': 'Depositor iteration finished.', 'value': result})
         return result
 
+    def _common_preconditions(self) -> bool:
+        """Common gates required for ANY deposit/top-up this iteration, checked before module selection.
+
+        On a miss the protocol state is abnormal, so the caller returns False — the Executor then
+        re-checks on the very next block (+1), not the BBE backoff: we want to resume the moment the
+        state recovers. Logs the failed condition.
+        """
+        if not self.w3.lido.lido.can_deposit():
+            logger.info({'msg': 'Lido.canDeposit() is false.'})
+            return False
+        if self.w3.lido.deposit_security_module.get_guardian_quorum() == 0:
+            logger.info({'msg': 'Guardian quorum is not set in DSM contract (quorum == 0).'})
+            return False
+        return True
+
     def _execute_actual(self) -> bool:
         # Step 0: refresh quorum + gas metrics for all whitelisted modules.
         self._refresh_modules_state()
@@ -152,6 +205,17 @@ class DepositorBot:
         if depositable_ether == 0:
             logger.info({'msg': 'No depositable ether — skip iteration.'})
             return False
+
+        # Abnormal protocol state — restart immediately: return False so the Executor re-checks
+        # on the next block (not a backoff), to resume as soon as the state recovers.
+        if not self._common_preconditions():
+            return False
+
+        # isDepositsPaused gates only deposits (depositBufferedEther), not top-ups — read once and use
+        # it to drop deposit candidates this iteration while top-ups keep flowing (no need to wait it out).
+        deposits_paused = self.w3.lido.deposit_security_module.is_deposits_paused()
+        if deposits_paused:
+            logger.info({'msg': 'Deposits are paused in DSM contract — only top-ups this iteration.'})
 
         # Compute seed allocation once; both phases use it for module ordering.
         sr_v4 = cast(StakingRouterContractV4, self.w3.lido.staking_router)
@@ -166,22 +230,28 @@ class DepositorBot:
         )
         digests: list[StakingModuleInfo] = self.w3.lido.staking_router.get_all_staking_module_digests()
 
-        # Phase A: seed deposits into 0x02 modules.
-        logger.info({'msg': 'Phase A start: seed deposits to 0x02 modules.'})
-        done, success = self._phase_seed(seed_allocated, seed_new, digests)
-        logger.info({'msg': 'Phase A finished.', 'done': done, 'success': success})
-        if done:
-            return success
+        # Phase A: seed deposits into 0x02 modules (deposits only — skipped while deposits are paused).
+        if not deposits_paused:
+            logger.info({'msg': 'Phase A start: seed deposits to 0x02 modules.'})
+            outcome = self._phase_seed(seed_allocated, seed_new, digests)
+            logger.info({'msg': 'Phase A finished.', 'outcome': outcome.value})
+            if outcome is not PhaseOutcome.SKIPPED:
+                return outcome.is_backoff
 
-        # Phase B: top-ups (0x02) and full deposits (0x01).
-        if not variables.ENABLE_TOP_UP:
-            logger.info({'msg': 'Phase B start: full deposits to 0x01 (top-up disabled).'})
-            _done, success = self._phase_full(seed_allocated, seed_new, digests)
+        # Phase B: top-ups (0x02) and full deposits (0x01). A paused TopUpGateway disables top-ups for
+        # this iteration — same effect as ENABLE_TOP_UP=False (deposits still flow via _phase_full).
+        top_up_enabled = variables.ENABLE_TOP_UP and not self.w3.lido.topup_gateway.is_paused()
+        if not top_up_enabled:
+            if deposits_paused:
+                logger.info({'msg': 'Deposits paused and top-up disabled/paused — nothing to do.'})
+                return False
+            logger.info({'msg': 'Phase B start: full deposits to 0x01 (top-up disabled/paused).'})
+            outcome = self._phase_full(seed_allocated, seed_new, digests)
         else:
             logger.info({'msg': 'Phase B start: full deposits to 0x01 + top-up to 0x02.'})
-            _done, success = self._phase_full_and_topup(depositable_ether, seed_allocated, seed_new, digests)
-        logger.info({'msg': 'Phase B finished.', 'done': _done, 'success': success})
-        return success
+            outcome = self._phase_full_and_topup(depositable_ether, seed_allocated, seed_new, digests, deposits_paused)
+        logger.info({'msg': 'Phase B finished.', 'outcome': outcome.value})
+        return outcome.is_backoff
 
     def _refresh_modules_state(self) -> None:
         """Update last-quorum heart_beat (cooldown source) and run gas-price probe for metrics, for all whitelisted modules."""
@@ -202,86 +272,108 @@ class DepositorBot:
             else:
                 logger.info({'msg': 'Module has no quorum right now.', 'module_id': module_id})
 
-    def _is_in_cooldown(self, module_id: int) -> bool:
-        """Quorum-retention cooldown for deposits: we had a quorum within the retention window."""
+    def _resolve_quorum(self, module_id: int) -> QuorumState:
+        """Read the guardian quorum and apply the retention window (replaces _is_in_cooldown)."""
+        if self._get_quorum(module_id):
+            return QuorumState.READY
         last = self._module_last_heart_beat[module_id]
-        return (datetime.now() - last) <= timedelta(minutes=variables.QUORUM_RETENTION_MINUTES)
+        if datetime.now() - last <= timedelta(minutes=variables.QUORUM_RETENTION_MINUTES):
+            return QuorumState.RETAINED
+        return QuorumState.STALE
 
-    def _phase_seed(self, seed_allocated: list[int], seed_new: list[int], digests: list[StakingModuleInfo]) -> tuple[bool, bool]:
+    def _try_deposit(self, module_id: int, phase: str) -> PhaseOutcome:
+        """One seed/full deposit attempt on a module. SKIPPED → caller tries the next candidate."""
+        if not self.w3.lido.deposit_security_module.is_min_deposit_distance_passed(module_id):
+            logger.info({'msg': f'{phase}: min deposit distance not passed — wait next iteration.', 'module_id': module_id})
+            return PhaseOutcome.WAIT_DISTANCE
+        state = self._resolve_quorum(module_id)
+        if state is QuorumState.READY:
+            return PhaseOutcome.SENT if self._deposit_to_module(module_id) else PhaseOutcome.TX_FAILED
+        if state is QuorumState.RETAINED:
+            logger.info({'msg': f'{phase}: no quorum, retention active — wait next iteration.', 'module_id': module_id})
+            return PhaseOutcome.WAIT_QUORUM
+        logger.info({'msg': f'{phase}: no quorum, retention expired — try next module.', 'module_id': module_id})
+        return PhaseOutcome.SKIPPED
+
+    def _try_top_up(self, candidate: ModuleCandidate, phase: str) -> PhaseOutcome:
+        """One top-up attempt on a 0x02 module (no quorum needed). SKIPPED → caller tries the next candidate."""
+        module_id = candidate.module_id
+        if not self.w3.lido.topup_gateway.can_top_up(module_id):
+            logger.info({'msg': f'{phase}: canTopUp=False — try next module.', 'module_id': module_id})
+            return PhaseOutcome.SKIPPED
+        if not self.w3.lido.topup_gateway.is_block_distance_passed(module_id):
+            logger.info({'msg': f'{phase}: top-up block distance not passed — wait next iteration.', 'module_id': module_id})
+            return PhaseOutcome.WAIT_DISTANCE
+        sent = self._top_up_to_module(module_id, candidate.address, candidate.allocation)
+        return PhaseOutcome.SENT if sent else PhaseOutcome.TX_FAILED
+
+    def _collect_candidates(
+        self, digests: list[StakingModuleInfo], wc_type: int, allocated: list[int], new: list[int]
+    ) -> list[ModuleCandidate]:
+        """Select whitelisted modules of one wc_type that have a non-zero allocation, and build their
+        candidate entries (stake = new - allocated, used for ordering).
+
+        Single type per call — the mixed (full + top-up) phase calls it once per type and merges.
+        Sorting and logging stay in the caller.
         """
-        Seed deposits into 0x02 modules using is_top_up=False allocations.
-        Returns (done, success):
-          done=True  -> caller stops (we acted or hit cooldown)
-          done=False -> phase produced nothing, caller continues to the next phase
-        """
-        candidates: list[tuple[int, Wei]] = []
+        candidates: list[ModuleCandidate] = []
         for i, digest in enumerate(digests):
-            module_id = digest['module_id']
-            wc_type = digest['wc_type']
-            if wc_type != 2:
+            if digest['wc_type'] != wc_type:
                 continue
-            if module_id not in variables.DEPOSIT_MODULES_WHITELIST:
+            if digest['module_id'] not in variables.DEPOSIT_MODULES_WHITELIST:
                 continue
-            if seed_allocated[i] == 0:
+            if digest['status'] != 0:  # only Active modules (replaces SR.canDeposit activity check)
                 continue
-            stake = Wei(seed_new[i] - seed_allocated[i])
-            candidates.append((module_id, stake))
+            if allocated[i] == 0:
+                continue
+            candidates.append(
+                ModuleCandidate(
+                    digest_index=i,
+                    module_id=digest['module_id'],
+                    wc_type=wc_type,
+                    stake=Wei(new[i] - allocated[i]),
+                    address=digest['address'],
+                    allocation=Wei(allocated[i]),
+                )
+            )
+        return candidates
 
-        candidates.sort(key=lambda c: c[1])
+    def _phase_seed(self, seed_allocated: list[int], seed_new: list[int], digests: list[StakingModuleInfo]) -> PhaseOutcome:
+        """Seed deposits into 0x02 modules using is_top_up=False allocations.
+
+        SKIPPED -> nothing actionable here, caller continues to the next phase.
+        """
+        candidates = self._collect_candidates(digests, 2, seed_allocated, seed_new)
+        candidates.sort(key=lambda c: (c.stake, c.digest_index))
         logger.info(
             {
                 'msg': 'Phase A (seed 0x02) candidates sorted by stake asc.',
-                'candidates': [{'module_id': c[0], 'stake': int(c[1])} for c in candidates],
+                'candidates': [{'module_id': c.module_id, 'stake': int(c.stake)} for c in candidates],
             }
         )
 
-        for module_id, _stake in candidates:
-            if not self.w3.lido.deposit_security_module.can_deposit(module_id):
-                logger.info({'msg': 'Phase A: canDeposit=False — try next module.', 'module_id': module_id})
-                continue
-            if self._get_quorum(module_id):
-                return True, self._deposit_to_module(module_id)
-            # No quorum right now: if cooldown is still active, stop and wait for the next bot iteration.
-            if self._is_in_cooldown(module_id):
-                logger.info({'msg': 'Phase A: no quorum, cooldown active — wait next iteration.', 'module_id': module_id})
-                return True, False
-            logger.info({'msg': 'Phase A: no quorum, cooldown expired — try next module.', 'module_id': module_id})
-        return False, False
+        for candidate in candidates:
+            outcome = self._try_deposit(candidate.module_id, 'Phase A')
+            if outcome is not PhaseOutcome.SKIPPED:
+                return outcome
+        return PhaseOutcome.SKIPPED
 
-    def _phase_full(self, seed_allocated: list[int], seed_new: list[int], digests: list[StakingModuleInfo]) -> tuple[bool, bool]:
+    def _phase_full(self, seed_allocated: list[int], seed_new: list[int], digests: list[StakingModuleInfo]) -> PhaseOutcome:
         """Full deposits to 0x01 modules using seed (is_top_up=False) allocations."""
-        candidates: list[tuple[int, Wei]] = []
-        for i, digest in enumerate(digests):
-            module_id = digest['module_id']
-            wc_type = digest['wc_type']
-            if wc_type != 1:
-                continue
-            if module_id not in variables.DEPOSIT_MODULES_WHITELIST:
-                continue
-            if seed_allocated[i] == 0:
-                continue
-            stake = Wei(seed_new[i] - seed_allocated[i])
-            candidates.append((module_id, stake))
-
-        candidates.sort(key=lambda c: c[1])
+        candidates = self._collect_candidates(digests, 1, seed_allocated, seed_new)
+        candidates.sort(key=lambda c: (c.stake, c.digest_index))
         logger.info(
             {
                 'msg': 'Phase B (full 0x01) candidates sorted by stake asc.',
-                'candidates': [{'module_id': c[0], 'stake': int(c[1])} for c in candidates],
+                'candidates': [{'module_id': c.module_id, 'stake': int(c.stake)} for c in candidates],
             }
         )
 
-        for module_id, _stake in candidates:
-            if not self.w3.lido.deposit_security_module.can_deposit(module_id):
-                logger.info({'msg': 'Phase B: canDeposit=False — try next module.', 'module_id': module_id})
-                continue
-            if self._get_quorum(module_id):
-                return True, self._deposit_to_module(module_id)
-            if self._is_in_cooldown(module_id):
-                logger.info({'msg': 'Phase B: no quorum, cooldown active — wait next iteration.', 'module_id': module_id})
-                return True, False
-            logger.info({'msg': 'Phase B: no quorum, cooldown expired — try next module.', 'module_id': module_id})
-        return False, False
+        for candidate in candidates:
+            outcome = self._try_deposit(candidate.module_id, 'Phase B')
+            if outcome is not PhaseOutcome.SKIPPED:
+                return outcome
+        return PhaseOutcome.SKIPPED
 
     def _phase_full_and_topup(
         self,
@@ -289,7 +381,8 @@ class DepositorBot:
         seed_allocated: list[int],
         seed_new: list[int],
         digests: list[StakingModuleInfo],
-    ) -> tuple[bool, bool]:
+        deposits_paused: bool = False,
+    ) -> PhaseOutcome:
         """
         Full deposits to 0x01 + top-ups to 0x02.
         - 0x02 (top-up) candidates: from is_top_up=True allocations (top-up uses its own capacity).
@@ -298,58 +391,29 @@ class DepositorBot:
         sr_v4 = cast(StakingRouterContractV4, self.w3.lido.staking_router)
         _total, topup_allocated, topup_new = sr_v4.get_deposit_allocations(depositable_ether, is_top_up=True)
 
-        candidates: list[tuple[int, str, int, Wei, Wei]] = []  # (module_id, address, wc_type, stake, topup_allocation)
-        for i, digest in enumerate(digests):
-            module_id = digest['module_id']
-            module_address = digest['address']
-            wc_type = digest['wc_type']
-            if module_id not in variables.DEPOSIT_MODULES_WHITELIST:
-                continue
-            if wc_type == 2:
-                if topup_allocated[i] == 0:
-                    continue
-                stake = Wei(topup_new[i] - topup_allocated[i])
-                candidates.append((module_id, module_address, wc_type, stake, Wei(topup_allocated[i])))
-            elif wc_type == 1:
-                if seed_allocated[i] == 0:
-                    continue
-                stake = Wei(seed_new[i] - seed_allocated[i])
-                candidates.append((module_id, module_address, wc_type, stake, Wei(0)))
-
-        candidates.sort(key=lambda c: c[3])
+        # Top-ups (0x02) from is_top_up=True allocations always; full deposits (0x01) from seed
+        # (is_top_up=False) allocations only while deposits are not paused.
+        candidates = self._collect_candidates(digests, 2, topup_allocated, topup_new)
+        if not deposits_paused:
+            candidates += self._collect_candidates(digests, 1, seed_allocated, seed_new)
+        candidates.sort(key=lambda c: (c.stake, c.digest_index))
         logger.info(
             {
                 'msg': 'Phase B (full 0x01 + top-up 0x02) candidates sorted by stake asc.',
-                'candidates': [{'module_id': c[0], 'wc_type': c[2], 'stake': int(c[3])} for c in candidates],
+                'candidates': [{'module_id': c.module_id, 'wc_type': c.wc_type, 'stake': int(c.stake)} for c in candidates],
             }
         )
 
-        for module_id, module_address, wc_type, _stake, topup_alloc in candidates:
-            if wc_type == 2:
-                # Top-up path: canTopUp + is_block_distance_passed (no quorum check for top-ups).
-                # Top-up requires a ready consolidation indexer; if not, skip this module so 0x01
-                # full deposits can still proceed.
-                if self._consolidation_indexer is None or not self._consolidation_indexer.is_ready:
-                    logger.info({'msg': 'Phase B: consolidation indexer not ready — skip top-up module.', 'module_id': module_id})
-                    continue
-                if not self.w3.lido.topup_gateway.can_top_up(module_id):
-                    logger.info({'msg': 'Phase B: canTopUp=False — try next module.', 'module_id': module_id})
-                    continue
-                if not self.w3.lido.topup_gateway.is_block_distance_passed(module_id):
-                    logger.info({'msg': 'Phase B: top-up block distance not passed — wait next iteration.', 'module_id': module_id})
-                    return True, False
-                return True, self._top_up_to_module(module_id, module_address, topup_alloc)
-            # 0x01 full deposit path
-            if not self.w3.lido.deposit_security_module.can_deposit(module_id):
-                logger.info({'msg': 'Phase B: canDeposit=False — try next module.', 'module_id': module_id})
-                continue
-            if self._get_quorum(module_id):
-                return True, self._deposit_to_module(module_id)
-            if self._is_in_cooldown(module_id):
-                logger.info({'msg': 'Phase B: no quorum, cooldown active — wait next iteration.', 'module_id': module_id})
-                return True, False
-            logger.info({'msg': 'Phase B: no quorum, cooldown expired — try next module.', 'module_id': module_id})
-        return False, False
+        for candidate in candidates:
+            # The consolidation indexer is guaranteed present and ready in the top-up path — validated
+            # at startup when ENABLE_TOP_UP is on (otherwise the bot would not have started).
+            if candidate.wc_type == 2:
+                outcome = self._try_top_up(candidate, 'Phase B')
+            else:
+                outcome = self._try_deposit(candidate.module_id, 'Phase B')
+            if outcome is not PhaseOutcome.SKIPPED:
+                return outcome
+        return PhaseOutcome.SKIPPED
 
     def _deposit_to_module(self, module_id: int) -> bool:
         """New simplified deposit path: gas check (no keys-count) + send."""
@@ -369,13 +433,6 @@ class DepositorBot:
         return success
 
     def _top_up_to_module(self, module_id: int, module_address: str, module_allocation: Wei) -> bool:
-        """New simplified top-up path: gas check (no keys-count) + proof + send. Allocation is passed in."""
-        # Top-up is not allowed without a ready consolidation indexer — we must be able to filter
-        # out keys participating in pending ConsolidationBus requests.
-        if self._consolidation_indexer is None or not self._consolidation_indexer.is_ready:
-            logger.info({'msg': 'Consolidation indexer not ready — skip top-up.', 'module_id': module_id})
-            return False
-
         module_type = self.w3.lido.staking_module(module_id).get_type()
         strategy = self._select_topup_strategy(module_type)
         if strategy is None:
@@ -412,7 +469,7 @@ class DepositorBot:
             module_address,
             module_allocation,
             max_validators,
-            self._consolidation_indexer,
+            cast(ConsolidationIndexer, self._consolidation_indexer),
         )
         if not proof_data:
             logger.info({'msg': 'No top-up candidates.', 'module_id': module_id})
@@ -431,12 +488,17 @@ class DepositorBot:
     def _build_consolidation_indexer(self) -> ConsolidationIndexer | None:
         """Build the ConsolidationBus indexer and run the cold-start backfill.
 
-        Returns None when the Bus is not configured for this chain — top-up is then skipped.
+        Top-up needs a ready indexer (to filter keys in pending consolidation requests). So when
+        ENABLE_TOP_UP is on the indexer is mandatory: a missing Bus config or a failed cold start
+        raises here and the bot does NOT start — fail fast, better than silently skipping every
+        top-up until restart. When top-up is disabled the indexer is not needed and stays None.
         """
+        if not variables.ENABLE_TOP_UP:
+            return None
+
         address, deploy_block = variables.get_consolidation_bus_config(self.w3.eth.chain_id)
         if address is None or deploy_block is None:
-            logger.warning({'msg': 'ConsolidationBus not configured for this chain — top-up will be skipped.'})
-            return None
+            raise ValueError('ENABLE_TOP_UP is set but ConsolidationBus is not configured for this chain.')
 
         contract = cast(
             ConsolidationBusContract,

--- a/tests/blockchain/consolidation/test_indexer.py
+++ b/tests/blockchain/consolidation/test_indexer.py
@@ -243,37 +243,27 @@ def test_get_filter_set_empty_tail_returns_base_only():
     assert result == {_pk(1), _pk(2)}
 
 
-# ---- 11b. is_ready is False before cold_start ----
+# ---- 12. cold_start success indexes the backfilled batch ----
 @pytest.mark.unit
-def test_is_ready_false_before_cold_start():
-    """A freshly built indexer is not ready until cold_start succeeds (bot guard relies on this)."""
-    indexer, _bus, _store = _make_indexer(finalized=10)
-
-    assert indexer.is_ready is False
-
-
-# ---- 12. cold_start success ----
-@pytest.mark.unit
-def test_cold_start_sets_ready():
+def test_cold_start_indexes_pending_batch():
     data, _bh, _ = _batch([([_pk(1)], _pk(2))])
     indexer, bus, store = _make_indexer(finalized=10)
     bus.add_added(block=5, log_index=0, batch_data=data)
 
     indexer.cold_start()
 
-    assert indexer.is_ready is True
     assert store.is_pending(_pk(1))
 
 
-# ---- 13. cold_start failure -> not ready ----
+# ---- 13. cold_start failure is fatal (propagates) ----
 @pytest.mark.unit
-def test_cold_start_failure_marks_not_ready():
+def test_cold_start_failure_raises():
+    # The bot guards on this: a failed backfill must fail fast at startup, not run half-initialized.
     indexer, bus, _store = _make_indexer(finalized=10)
     indexer.w3.eth.get_block.side_effect = Exception('rpc down')
 
-    indexer.cold_start()
-
-    assert indexer.is_ready is False
+    with pytest.raises(Exception, match='rpc down'):
+        indexer.cold_start()
 
 
 # ---- 14. BatchesRemoved with multiple hashes closes all ----

--- a/tests/blockchain/consolidation/test_indexer_integration.py
+++ b/tests/blockchain/consolidation/test_indexer_integration.py
@@ -55,7 +55,7 @@ def test_cold_start_against_live_consolidation_bus(consolidation_indexer_live):
     print(
         f'\ncold_start: {cold_dt:.1f}s | pending_batches={store.pending_batch_count()} ' f'pending_pubkeys={store.pending_pubkey_count()}'
     )
-    assert indexer.is_ready
+    # cold_start raises on failure (fatal), so reaching here means it succeeded.
 
     # 2. Correctness cross-check: every batch we hold as pending is actually open on-chain.
     #    getBatchInfo(batchHash).publisher == 0x0 would mean it is NOT pending.

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, Mock
 import pytest
 import variables
 from blockchain.contracts.staking_router import MODULE_TYPE_CMV2, MODULE_TYPE_CSM, StakingModuleInfo
-from bots.depositor import DepositorBot
+from bots.depositor import DepositorBot, PhaseOutcome, QuorumState
 
 from tests.conftest import COUNCIL_ADDRESS_1, COUNCIL_ADDRESS_2, COUNCIL_PK_1, COUNCIL_PK_2
 from tests.utils.protocol_utils import get_deposit_message
@@ -14,25 +14,26 @@ from tests.utils.protocol_utils import get_deposit_message
 # ─── Shared helpers ────────────────────────────────────────────────
 
 
-def _make_digest(module_id, address, wc_type) -> StakingModuleInfo:
+def _make_digest(module_id, address, wc_type, status=0) -> StakingModuleInfo:
     """Build a StakingModuleInfo as produced by the parsing step in _execute_actual."""
-    return StakingModuleInfo(module_id=module_id, address=address, wc_type=wc_type)
+    return StakingModuleInfo(module_id=module_id, address=address, wc_type=wc_type, status=status)
 
 
 def _make_bot():
     """Build a DepositorBot with all-MagicMock deps. No transports → MessageStorage stays empty."""
     variables.MESSAGE_TRANSPORTS = ''
-    bot = DepositorBot(
-        w3=MagicMock(),
-        sender=MagicMock(),
-        base_deposit_strategy=MagicMock(),
-        csm_strategy=MagicMock(),
-        gas_price_calculator=MagicMock(),
-        keys_api=MagicMock(),
-        cl=MagicMock(),
-    )
-    # A ready consolidation indexer is an orthogonal precondition for the top-up path.
-    bot._consolidation_indexer = MagicMock(is_ready=True)
+    # Skip the real ConsolidationBus backfill (needs RPC) — inject a mock indexer so top-up paths
+    # are still exercised. ENABLE_TOP_UP is left untouched; tests set it as needed.
+    with mock.patch.object(DepositorBot, '_build_consolidation_indexer', return_value=MagicMock()):
+        bot = DepositorBot(
+            w3=MagicMock(),
+            sender=MagicMock(),
+            base_deposit_strategy=MagicMock(),
+            csm_strategy=MagicMock(),
+            gas_price_calculator=MagicMock(),
+            keys_api=MagicMock(),
+            cl=MagicMock(),
+        )
     return bot
 
 
@@ -112,27 +113,103 @@ class TestRefreshModulesState(unittest.TestCase):
         self.assertEqual([1, 3], called_ids)
 
 
-# ─── _is_in_cooldown ───────────────────────────────────────────────
+# ─── _resolve_quorum ───────────────────────────────────────────────
 
 
 @pytest.mark.unit
-class TestIsInCooldown(unittest.TestCase):
+class TestResolveQuorum(unittest.TestCase):
     def setUp(self):
         self.bot = _make_bot()
         variables.DEPOSIT_MODULES_WHITELIST = [1]
 
-    def test_fresh_returns_true(self):
+    def test_ready_when_quorum_present(self):
+        self.bot._get_quorum = Mock(return_value=['msg'])
+        self.assertIs(QuorumState.READY, self.bot._resolve_quorum(1))
+
+    def test_retained_when_no_quorum_but_recent(self):
+        self.bot._get_quorum = Mock(return_value=None)
         self.bot._module_last_heart_beat[1] = datetime.now() - timedelta(minutes=1)
-        self.assertTrue(self.bot._is_in_cooldown(1))
+        self.assertIs(QuorumState.RETAINED, self.bot._resolve_quorum(1))
 
-    def test_stale_returns_false(self):
+    def test_stale_when_no_quorum_and_window_expired(self):
+        self.bot._get_quorum = Mock(return_value=None)
         self.bot._module_last_heart_beat[1] = datetime.now() - timedelta(minutes=variables.QUORUM_RETENTION_MINUTES + 1)
-        self.assertFalse(self.bot._is_in_cooldown(1))
+        self.assertIs(QuorumState.STALE, self.bot._resolve_quorum(1))
 
-    def test_at_boundary_returns_true(self):
-        # The contract is `<=` — exactly at the boundary still counts as cooldown.
+    def test_retained_at_boundary(self):
+        # The window is `<=` — exactly at the boundary still counts as retained.
+        self.bot._get_quorum = Mock(return_value=None)
         self.bot._module_last_heart_beat[1] = datetime.now() - timedelta(minutes=variables.QUORUM_RETENTION_MINUTES, seconds=-1)
-        self.assertTrue(self.bot._is_in_cooldown(1))
+        self.assertIs(QuorumState.RETAINED, self.bot._resolve_quorum(1))
+
+
+# ─── _common_preconditions ─────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestCommonPreconditions(unittest.TestCase):
+    def setUp(self):
+        self.bot = _make_bot()
+        self.bot.w3.lido.lido.can_deposit.return_value = True
+        self.bot.w3.lido.deposit_security_module.get_guardian_quorum.return_value = 1
+
+    def test_passes_when_all_ok(self):
+        self.assertTrue(self.bot._common_preconditions())
+
+    def test_fails_when_lido_cannot_deposit(self):
+        self.bot.w3.lido.lido.can_deposit.return_value = False
+        self.assertFalse(self.bot._common_preconditions())
+
+    def test_fails_when_quorum_zero(self):
+        self.bot.w3.lido.deposit_security_module.get_guardian_quorum.return_value = 0
+        self.assertFalse(self.bot._common_preconditions())
+
+
+# ─── _collect_candidates ───────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestCollectCandidates(unittest.TestCase):
+    def setUp(self):
+        self.bot = _make_bot()
+        variables.DEPOSIT_MODULES_WHITELIST = [1, 2, 3]
+
+    def test_filters_by_wc_type(self):
+        digests = [_make_digest(1, '0xA1', 1), _make_digest(2, '0xA2', 2)]
+        cands = self.bot._collect_candidates(digests, 2, [50, 50], [100, 100])
+        self.assertEqual([2], [c.module_id for c in cands])
+
+    def test_filters_non_whitelisted(self):
+        variables.DEPOSIT_MODULES_WHITELIST = [1]
+        digests = [_make_digest(1, '0xA1', 1), _make_digest(2, '0xA2', 1)]
+        cands = self.bot._collect_candidates(digests, 1, [50, 50], [100, 100])
+        self.assertEqual([1], [c.module_id for c in cands])
+
+    def test_filters_zero_allocation(self):
+        digests = [_make_digest(1, '0xA1', 1), _make_digest(2, '0xA2', 1)]
+        cands = self.bot._collect_candidates(digests, 1, [0, 50], [0, 100])
+        self.assertEqual([2], [c.module_id for c in cands])
+
+    def test_filters_inactive_status(self):
+        # status: 0=Active (kept), 1=DepositsPaused, 2=Stopped (both skipped)
+        digests = [_make_digest(1, '0xA1', 1, status=1), _make_digest(2, '0xA2', 1, status=0), _make_digest(3, '0xA3', 1, status=2)]
+        cands = self.bot._collect_candidates(digests, 1, [50, 50, 50], [100, 100, 100])
+        self.assertEqual([2], [c.module_id for c in cands])
+
+    def test_builds_fields_and_stake(self):
+        digests = [_make_digest(1, '0xA1', 2)]
+        cands = self.bot._collect_candidates(digests, 2, [30], [100])
+        c = cands[0]
+        self.assertEqual((c.digest_index, c.module_id, c.wc_type, c.address), (0, 1, 2, '0xA1'))
+        self.assertEqual(c.stake, 70)  # new - allocated = 100 - 30
+        self.assertEqual(c.allocation, 30)  # allocated[i]
+
+    def test_preserves_digest_order_without_sorting(self):
+        # the method does not sort; index mirrors digest position
+        digests = [_make_digest(1, '0xA1', 1), _make_digest(2, '0xA2', 1), _make_digest(3, '0xA3', 1)]
+        cands = self.bot._collect_candidates(digests, 1, [10, 20, 30], [110, 70, 80])
+        self.assertEqual([0, 1, 2], [c.digest_index for c in cands])
+        self.assertEqual([1, 2, 3], [c.module_id for c in cands])
 
 
 # ─── _phase_seed ───────────────────────────────────────────────────
@@ -145,7 +222,6 @@ class TestPhaseSeed(unittest.TestCase):
         variables.DEPOSIT_MODULES_WHITELIST = [1, 2, 3]
         # Fresh heartbeats → all modules are in cooldown by default.
         self.bot._module_last_heart_beat = {m: datetime.now() for m in [1, 2, 3]}
-        self.bot.w3.lido.deposit_security_module.can_deposit.return_value = True
         self.bot._get_quorum = Mock(return_value=None)
         self.bot._deposit_to_module = Mock(return_value=True)
 
@@ -156,8 +232,8 @@ class TestPhaseSeed(unittest.TestCase):
 
     def test_filters_non_0x02(self):
         digests = [_make_digest(1, '0xA1', 1)]
-        done, success = self.bot._phase_seed([50], [100], digests)
-        self.assertEqual((False, False), (done, success))
+        outcome = self.bot._phase_seed([50], [100], digests)
+        self.assertEqual(PhaseOutcome.SKIPPED, outcome)
         self.bot._deposit_to_module.assert_not_called()
 
     def test_filters_zero_allocation(self):
@@ -169,8 +245,8 @@ class TestPhaseSeed(unittest.TestCase):
 
     def test_filters_non_whitelisted(self):
         digests = [_make_digest(4, '0xA4', 2)]
-        done, success = self.bot._phase_seed([50], [100], digests)
-        self.assertEqual((False, False), (done, success))
+        outcome = self.bot._phase_seed([50], [100], digests)
+        self.assertEqual(PhaseOutcome.SKIPPED, outcome)
         self.bot._deposit_to_module.assert_not_called()
 
     # ─── Sort & selection ──────────────────────────────────────
@@ -181,9 +257,9 @@ class TestPhaseSeed(unittest.TestCase):
         digests = [_make_digest(1, '0xA1', 2), _make_digest(2, '0xA2', 2), _make_digest(3, '0xA3', 2)]
         self.bot._get_quorum = Mock(return_value=['msg'])
 
-        done, success = self.bot._phase_seed([10, 50, 30], [110, 70, 80], digests)
+        outcome = self.bot._phase_seed([10, 50, 30], [110, 70, 80], digests)
 
-        self.assertEqual((True, True), (done, success))
+        self.assertEqual(PhaseOutcome.SENT, outcome)
         # Lowest-stake module (id=2) is tried first.
         self.bot._deposit_to_module.assert_called_once_with(2)
 
@@ -203,37 +279,28 @@ class TestPhaseSeed(unittest.TestCase):
         self.bot._deposit_to_module.assert_called_once_with(1)
 
     def test_empty_digests_returns_done_false(self):
-        done, success = self.bot._phase_seed([], [], [])
-        self.assertEqual((False, False), (done, success))
+        outcome = self.bot._phase_seed([], [], [])
+        self.assertEqual(PhaseOutcome.SKIPPED, outcome)
 
     # ─── Iteration ─────────────────────────────────────────────
-
-    def test_can_deposit_false_moves_to_next(self):
-        digests = [_make_digest(1, '0xA1', 2), _make_digest(2, '0xA2', 2)]
-        # m2 has lower stake → tried first; can_deposit=False on m2 → fall to m1
-        self.bot.w3.lido.deposit_security_module.can_deposit.side_effect = lambda mid: mid != 2
-        self.bot._get_quorum = Mock(return_value=['msg'])
-
-        self.bot._phase_seed([10, 50], [110, 70], digests)
-        self.bot._deposit_to_module.assert_called_once_with(1)
 
     def test_single_with_quorum_deposits(self):
         digests = [_make_digest(1, '0xA1', 2)]
         self.bot._get_quorum = Mock(return_value=['msg'])
 
-        done, success = self.bot._phase_seed([50], [100], digests)
+        outcome = self.bot._phase_seed([50], [100], digests)
 
-        self.assertEqual((True, True), (done, success))
+        self.assertEqual(PhaseOutcome.SENT, outcome)
         self.bot._deposit_to_module.assert_called_once_with(1)
 
     def test_cooldown_active_no_quorum_stops_phase(self):
-        # Cooldown active (fresh heartbeat) + no quorum → stop phase, don't proceed.
+        # Retention active (fresh heartbeat) + no quorum → stop phase, don't proceed.
         digests = [_make_digest(1, '0xA1', 2)]
         self.bot._get_quorum = Mock(return_value=None)
 
-        done, success = self.bot._phase_seed([50], [100], digests)
+        outcome = self.bot._phase_seed([50], [100], digests)
 
-        self.assertEqual((True, False), (done, success))
+        self.assertEqual(PhaseOutcome.WAIT_QUORUM, outcome)
         self.bot._deposit_to_module.assert_not_called()
 
     def test_cooldown_expired_no_quorum_moves_to_next(self):
@@ -251,9 +318,9 @@ class TestPhaseSeed(unittest.TestCase):
         self._set_cooldown_expired(2)
         self.bot._get_quorum = Mock(return_value=None)
 
-        done, success = self.bot._phase_seed([30, 50], [50, 100], digests)
+        outcome = self.bot._phase_seed([30, 50], [50, 100], digests)
 
-        self.assertEqual((False, False), (done, success))
+        self.assertEqual(PhaseOutcome.SKIPPED, outcome)
         self.bot._deposit_to_module.assert_not_called()
 
     def test_deposit_failure_still_returns_done_true(self):
@@ -261,10 +328,34 @@ class TestPhaseSeed(unittest.TestCase):
         self.bot._get_quorum = Mock(return_value=['msg'])
         self.bot._deposit_to_module = Mock(return_value=False)
 
-        done, success = self.bot._phase_seed([50], [100], digests)
+        outcome = self.bot._phase_seed([50], [100], digests)
 
-        # done=True → caller stops; success=False → no deposit
-        self.assertEqual((True, False), (done, success))
+        self.assertEqual(PhaseOutcome.TX_FAILED, outcome)  # deposit attempted, tx failed
+
+    # ─── distance cooldown ─────────────────────────────────────
+
+    def test_distance_not_passed_waits(self):
+        # min deposit distance not passed → wait, don't divert.
+        digests = [_make_digest(1, '0xA1', 2)]
+        self.bot.w3.lido.deposit_security_module.is_min_deposit_distance_passed.return_value = False
+        self.bot._get_quorum = Mock(return_value=['msg'])  # quorum exists — to prove we return before checking it
+
+        outcome = self.bot._phase_seed([50], [100], digests)
+
+        self.assertEqual(PhaseOutcome.WAIT_DISTANCE, outcome)  # no fall-through to Phase B
+        self.bot._deposit_to_module.assert_not_called()
+        self.bot._get_quorum.assert_not_called()
+
+    def test_distance_block_on_priority_does_not_divert(self):
+        # Priority (lowest-stake) m2 is distance-blocked → wait for it; do NOT deposit lower-priority m1.
+        digests = [_make_digest(1, '0xA1', 2), _make_digest(2, '0xA2', 2)]
+        self.bot.w3.lido.deposit_security_module.is_min_deposit_distance_passed.side_effect = lambda mid: mid != 2
+        self.bot._get_quorum = Mock(return_value=['msg'])
+        # m1 stake = 110-10 = 100; m2 stake = 70-50 = 20 (lowest → tried first)
+        outcome = self.bot._phase_seed([10, 50], [110, 70], digests)
+
+        self.assertEqual(PhaseOutcome.WAIT_DISTANCE, outcome)
+        self.bot._deposit_to_module.assert_not_called()
 
 
 # ─── _phase_full ───────────────────────────────────────────────────
@@ -276,7 +367,6 @@ class TestPhaseFull(unittest.TestCase):
         self.bot = _make_bot()
         variables.DEPOSIT_MODULES_WHITELIST = [1, 2, 3]
         self.bot._module_last_heart_beat = {m: datetime.now() for m in [1, 2, 3]}
-        self.bot.w3.lido.deposit_security_module.can_deposit.return_value = True
         self.bot._get_quorum = Mock(return_value=None)
         self.bot._deposit_to_module = Mock(return_value=True)
 
@@ -285,8 +375,8 @@ class TestPhaseFull(unittest.TestCase):
 
     def test_filters_non_0x01(self):
         digests = [_make_digest(1, '0xA1', 2)]
-        done, success = self.bot._phase_full([50], [100], digests)
-        self.assertEqual((False, False), (done, success))
+        outcome = self.bot._phase_full([50], [100], digests)
+        self.assertEqual(PhaseOutcome.SKIPPED, outcome)
         self.bot._deposit_to_module.assert_not_called()
 
     def test_filters_zero_seed_allocation(self):
@@ -297,8 +387,8 @@ class TestPhaseFull(unittest.TestCase):
 
     def test_filters_non_whitelisted(self):
         digests = [_make_digest(4, '0xA4', 1)]
-        done, success = self.bot._phase_full([50], [100], digests)
-        self.assertEqual((False, False), (done, success))
+        outcome = self.bot._phase_full([50], [100], digests)
+        self.assertEqual(PhaseOutcome.SKIPPED, outcome)
         self.bot._deposit_to_module.assert_not_called()
 
     def test_sorts_by_stake_asc(self):
@@ -308,29 +398,22 @@ class TestPhaseFull(unittest.TestCase):
         self.bot._phase_full([10, 50, 30], [110, 70, 80], digests)
         self.bot._deposit_to_module.assert_called_once_with(2)
 
-    def test_can_deposit_false_moves_to_next(self):
-        digests = [_make_digest(1, '0xA1', 1), _make_digest(2, '0xA2', 1)]
-        self.bot.w3.lido.deposit_security_module.can_deposit.side_effect = lambda mid: mid != 2
-        self.bot._get_quorum = Mock(return_value=['msg'])
-        self.bot._phase_full([10, 50], [110, 70], digests)
-        self.bot._deposit_to_module.assert_called_once_with(1)
-
     def test_quorum_active_deposits(self):
         digests = [_make_digest(1, '0xA1', 1)]
         self.bot._get_quorum = Mock(return_value=['msg'])
 
-        done, success = self.bot._phase_full([50], [100], digests)
+        outcome = self.bot._phase_full([50], [100], digests)
 
-        self.assertEqual((True, True), (done, success))
+        self.assertEqual(PhaseOutcome.SENT, outcome)
         self.bot._deposit_to_module.assert_called_once_with(1)
 
     def test_cooldown_active_stops_phase(self):
         digests = [_make_digest(1, '0xA1', 1)]
         self.bot._get_quorum = Mock(return_value=None)
 
-        done, success = self.bot._phase_full([50], [100], digests)
+        outcome = self.bot._phase_full([50], [100], digests)
 
-        self.assertEqual((True, False), (done, success))
+        self.assertEqual(PhaseOutcome.WAIT_QUORUM, outcome)
         self.bot._deposit_to_module.assert_not_called()
 
     def test_cooldown_expired_moves_to_next(self):
@@ -342,8 +425,21 @@ class TestPhaseFull(unittest.TestCase):
         self.bot._deposit_to_module.assert_called_once_with(1)
 
     def test_empty_digests_returns_done_false(self):
-        done, success = self.bot._phase_full([], [], [])
-        self.assertEqual((False, False), (done, success))
+        outcome = self.bot._phase_full([], [], [])
+        self.assertEqual(PhaseOutcome.SKIPPED, outcome)
+
+    # ─── distance cooldown ─────────────────────────────────────
+
+    def test_distance_not_passed_waits(self):
+        digests = [_make_digest(1, '0xA1', 1)]
+        self.bot.w3.lido.deposit_security_module.is_min_deposit_distance_passed.return_value = False
+        self.bot._get_quorum = Mock(return_value=['msg'])
+
+        outcome = self.bot._phase_full([50], [100], digests)
+
+        self.assertEqual(PhaseOutcome.WAIT_DISTANCE, outcome)
+        self.bot._deposit_to_module.assert_not_called()
+        self.bot._get_quorum.assert_not_called()
 
 
 # ─── _phase_full_and_topup ─────────────────────────────────────────
@@ -355,7 +451,6 @@ class TestPhaseFullAndTopup(unittest.TestCase):
         self.bot = _make_bot()
         variables.DEPOSIT_MODULES_WHITELIST = [1, 2, 3]
         self.bot._module_last_heart_beat = {m: datetime.now() for m in [1, 2, 3]}
-        self.bot.w3.lido.deposit_security_module.can_deposit.return_value = True
         self.bot.w3.lido.topup_gateway.can_top_up.return_value = True
         self.bot.w3.lido.topup_gateway.is_block_distance_passed.return_value = True
         self.bot._get_quorum = Mock(return_value=None)
@@ -375,8 +470,8 @@ class TestPhaseFullAndTopup(unittest.TestCase):
         variables.DEPOSIT_MODULES_WHITELIST = [1]
         digests = [_make_digest(2, '0xA2', 2), _make_digest(3, '0xA3', 1)]
         self._set_topup_allocation([50, 50], [100, 100])
-        done, success = self.bot._phase_full_and_topup(100, [0, 50], [0, 100], digests)
-        self.assertEqual((False, False), (done, success))
+        outcome = self.bot._phase_full_and_topup(100, [0, 50], [0, 100], digests)
+        self.assertEqual(PhaseOutcome.SKIPPED, outcome)
         self.bot._top_up_to_module.assert_not_called()
         self.bot._deposit_to_module.assert_not_called()
 
@@ -387,9 +482,9 @@ class TestPhaseFullAndTopup(unittest.TestCase):
         self._set_topup_allocation([0, 50], [0, 100])
         self.bot._get_quorum = Mock(return_value=['msg'])
 
-        done, success = self.bot._phase_full_and_topup(100, [50, 0], [100, 0], digests)
+        outcome = self.bot._phase_full_and_topup(100, [50, 0], [100, 0], digests)
 
-        self.assertEqual((False, False), (done, success))
+        self.assertEqual(PhaseOutcome.SKIPPED, outcome)
         self.bot._top_up_to_module.assert_not_called()
         self.bot._deposit_to_module.assert_not_called()
 
@@ -426,20 +521,6 @@ class TestPhaseFullAndTopup(unittest.TestCase):
         self.bot._deposit_to_module.assert_called_once_with(2)
         self.bot._top_up_to_module.assert_not_called()
 
-    def test_indexer_not_ready_skips_0x02_and_lets_0x01_proceed(self):
-        # m1 (0x02) has the lowest stake → tried first, but the indexer is not ready,
-        # so it is skipped and the 0x01 module deposits instead.
-        self.bot._consolidation_indexer.is_ready = False
-        digests = [_make_digest(1, '0xA1', 2), _make_digest(2, '0xA2', 1)]
-        self._set_topup_allocation([50, 999], [70, 999])  # m1 0x02 stake = 20 (lowest)
-        self.bot._get_quorum = Mock(return_value=['msg'])  # m2 0x01 has quorum
-
-        done, success = self.bot._phase_full_and_topup(100, [999, 50], [999, 100], digests)
-
-        self.assertEqual((True, True), (done, success))
-        self.bot._top_up_to_module.assert_not_called()
-        self.bot._deposit_to_module.assert_called_once_with(2)
-
     # ─── 0x02 branch ───────────────────────────────────────────
 
     def test_can_top_up_false_skips_to_next(self):
@@ -460,40 +541,30 @@ class TestPhaseFullAndTopup(unittest.TestCase):
         self._set_topup_allocation([50], [100])
         self.bot.w3.lido.topup_gateway.is_block_distance_passed.return_value = False
 
-        done, success = self.bot._phase_full_and_topup(100, [0], [0], digests)
+        outcome = self.bot._phase_full_and_topup(100, [0], [0], digests)
 
-        self.assertEqual((True, False), (done, success))
+        self.assertEqual(PhaseOutcome.WAIT_DISTANCE, outcome)
         self.bot._top_up_to_module.assert_not_called()
 
     def test_routes_0x02_to_top_up_with_topup_allocation(self):
         digests = [_make_digest(1, '0xA1', 2)]
         self._set_topup_allocation([42], [100])  # 42 is the value that must be passed through
 
-        done, success = self.bot._phase_full_and_topup(100, [0], [0], digests)
+        outcome = self.bot._phase_full_and_topup(100, [0], [0], digests)
 
-        self.assertEqual((True, True), (done, success))
+        self.assertEqual(PhaseOutcome.SENT, outcome)
         self.bot._top_up_to_module.assert_called_once_with(1, '0xA1', 42)
 
     # ─── 0x01 branch ───────────────────────────────────────────
-
-    def test_0x01_can_deposit_false_moves_to_next(self):
-        digests = [_make_digest(1, '0xA1', 1), _make_digest(2, '0xA2', 1)]
-        self._set_topup_allocation([0, 0], [0, 0])
-        self.bot.w3.lido.deposit_security_module.can_deposit.side_effect = lambda mid: mid != 1
-        self.bot._get_quorum = Mock(return_value=['msg'])
-
-        # Both 0x01, both have seed alloc. m1 stake = 10, m2 stake = 50 → m1 tried first
-        self.bot._phase_full_and_topup(100, [50, 50], [60, 100], digests)
-        self.bot._deposit_to_module.assert_called_once_with(2)
 
     def test_0x01_with_quorum_deposits(self):
         digests = [_make_digest(1, '0xA1', 1)]
         self._set_topup_allocation([0], [0])
         self.bot._get_quorum = Mock(return_value=['msg'])
 
-        done, success = self.bot._phase_full_and_topup(100, [50], [100], digests)
+        outcome = self.bot._phase_full_and_topup(100, [50], [100], digests)
 
-        self.assertEqual((True, True), (done, success))
+        self.assertEqual(PhaseOutcome.SENT, outcome)
         self.bot._deposit_to_module.assert_called_once_with(1)
 
     def test_0x01_cooldown_active_stops_phase(self):
@@ -502,9 +573,9 @@ class TestPhaseFullAndTopup(unittest.TestCase):
         # Fresh heartbeat → cooldown active. No quorum.
         self.bot._get_quorum = Mock(return_value=None)
 
-        done, success = self.bot._phase_full_and_topup(100, [50], [100], digests)
+        outcome = self.bot._phase_full_and_topup(100, [50], [100], digests)
 
-        self.assertEqual((True, False), (done, success))
+        self.assertEqual(PhaseOutcome.WAIT_QUORUM, outcome)
         self.bot._deposit_to_module.assert_not_called()
 
     def test_0x01_cooldown_expired_moves_to_next(self):
@@ -528,11 +599,37 @@ class TestPhaseFullAndTopup(unittest.TestCase):
         self.bot._get_quorum = Mock(return_value=None)  # m1 has no quorum
 
         # m1 seed stake = 60-50 = 10, m2 topup stake = 150 → m1 first
-        done, success = self.bot._phase_full_and_topup(100, [50, 999], [60, 999], digests)
+        outcome = self.bot._phase_full_and_topup(100, [50, 999], [60, 999], digests)
 
-        self.assertEqual((True, True), (done, success))
+        self.assertEqual(PhaseOutcome.SENT, outcome)
         self.bot._top_up_to_module.assert_called_once_with(2, '0xA2', 50)
         self.bot._deposit_to_module.assert_not_called()
+
+    # ─── distance cooldown ─────────────────────────────────────
+
+    def test_deposits_paused_skips_0x01_keeps_topup(self):
+        # deposits_paused=True → 0x01 full deposits are not collected; 0x02 top-up still happens.
+        digests = [_make_digest(1, '0xA1', 1), _make_digest(2, '0xA2', 2)]
+        self._set_topup_allocation([999, 50], [999, 200])  # m2 0x02 is a top-up candidate
+        self.bot._get_quorum = Mock(return_value=['msg'])  # m1 0x01 would deposit if collected
+
+        outcome = self.bot._phase_full_and_topup(100, [50, 999], [60, 999], digests, deposits_paused=True)
+
+        self.assertEqual(PhaseOutcome.SENT, outcome)
+        self.bot._top_up_to_module.assert_called_once_with(2, '0xA2', 50)
+        self.bot._deposit_to_module.assert_not_called()
+
+    def test_0x01_distance_block_does_not_divert_to_topup(self):
+        # Priority 0x01 module is distance-blocked → wait for it; do NOT divert to the ready 0x02 top-up.
+        digests = [_make_digest(1, '0xA1', 1), _make_digest(2, '0xA2', 2)]
+        self._set_topup_allocation([999, 50], [999, 200])  # m2 0x02 topup stake = 150
+        self.bot.w3.lido.deposit_security_module.is_min_deposit_distance_passed.return_value = False
+        # m1 0x01 seed stake = 60-50 = 10 (lowest → tried first), m2 topup stake = 150
+        outcome = self.bot._phase_full_and_topup(100, [50, 999], [60, 999], digests)
+
+        self.assertEqual(PhaseOutcome.WAIT_DISTANCE, outcome)
+        self.bot._deposit_to_module.assert_not_called()
+        self.bot._top_up_to_module.assert_not_called()
 
 
 # ─── _execute_actual ───────────────────────────────────────────────
@@ -551,11 +648,13 @@ def depositor_bot(
         variables.MESSAGE_TRANSPORTS = ''
         variables.DEPOSIT_MODULES_WHITELIST = [1, 2]
         web3_lido_unit.eth.get_block = Mock(return_value=block_data)
-        bot = DepositorBot(
-            web3_lido_unit, deposit_transaction_sender, base_deposit_strategy, csm_strategy, gas_price_calculator, Mock(), Mock()
-        )
-        # A ready consolidation indexer is an orthogonal precondition for the top-up path.
-        bot._consolidation_indexer = MagicMock(is_ready=True)
+        # Skip the real ConsolidationBus backfill (needs RPC) — inject a mock indexer.
+        with mock.patch.object(DepositorBot, '_build_consolidation_indexer', return_value=MagicMock()):
+            bot = DepositorBot(
+                web3_lido_unit, deposit_transaction_sender, base_deposit_strategy, csm_strategy, gas_price_calculator, Mock(), Mock()
+            )
+        bot.w3.lido.deposit_security_module.is_deposits_paused = Mock(return_value=False)
+        bot.w3.lido.topup_gateway.is_paused = Mock(return_value=False)
         yield bot
 
 
@@ -579,12 +678,12 @@ def test_execute_actual_zero_depositable_ether_short_circuits(depositor_bot):
 
 @pytest.mark.unit
 def test_execute_actual_phase_a_deposit_short_circuits(depositor_bot):
-    """Phase A returns (True, True) → return True, phase B not called."""
+    """Phase A SENT → _execute_actual returns backoff=True, phase B not called."""
     depositor_bot._refresh_modules_state = Mock()
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
     depositor_bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(return_value=[])
-    depositor_bot._phase_seed = Mock(return_value=(True, True))
+    depositor_bot._phase_seed = Mock(return_value=PhaseOutcome.SENT)
     depositor_bot._phase_full = Mock()
     depositor_bot._phase_full_and_topup = Mock()
 
@@ -595,12 +694,12 @@ def test_execute_actual_phase_a_deposit_short_circuits(depositor_bot):
 
 @pytest.mark.unit
 def test_execute_actual_phase_a_failure_does_not_call_phase_b(depositor_bot):
-    """Phase A returns (True, False) — e.g. deposit attempt failed — phase B not called."""
+    """Phase A returns a non-SKIPPED wait/fail outcome → phase B not called."""
     depositor_bot._refresh_modules_state = Mock()
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
     depositor_bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(return_value=[])
-    depositor_bot._phase_seed = Mock(return_value=(True, False))
+    depositor_bot._phase_seed = Mock(return_value=PhaseOutcome.WAIT_QUORUM)
     depositor_bot._phase_full = Mock()
     depositor_bot._phase_full_and_topup = Mock()
 
@@ -611,13 +710,12 @@ def test_execute_actual_phase_a_failure_does_not_call_phase_b(depositor_bot):
 
 @pytest.mark.unit
 def test_execute_actual_phase_a_cooldown_does_not_call_phase_b(depositor_bot):
-    """Same as failure: cooldown returns (True, False) — phase B still not called.
-    Documented separately because the algorithm treats cooldown explicitly."""
+    """Quorum-retention wait (WAIT_QUORUM) is non-SKIPPED → phase B still not called."""
     depositor_bot._refresh_modules_state = Mock()
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
     depositor_bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(return_value=[])
-    depositor_bot._phase_seed = Mock(return_value=(True, False))
+    depositor_bot._phase_seed = Mock(return_value=PhaseOutcome.WAIT_QUORUM)
     depositor_bot._phase_full = Mock()
     depositor_bot._phase_full_and_topup = Mock()
 
@@ -628,14 +726,14 @@ def test_execute_actual_phase_a_cooldown_does_not_call_phase_b(depositor_bot):
 
 @pytest.mark.unit
 def test_execute_actual_phase_a_empty_falls_through_to_phase_b(depositor_bot):
-    """Phase A returns (False, False) → continue to phase B."""
+    """Phase A SKIPPED → continue to phase B."""
     variables.ENABLE_TOP_UP = False
     depositor_bot._refresh_modules_state = Mock()
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [10, 20], [50, 50]))
     depositor_bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(return_value=[])
-    depositor_bot._phase_seed = Mock(return_value=(False, False))
-    depositor_bot._phase_full = Mock(return_value=(True, True))
+    depositor_bot._phase_seed = Mock(return_value=PhaseOutcome.SKIPPED)
+    depositor_bot._phase_full = Mock(return_value=PhaseOutcome.SENT)
 
     assert depositor_bot._execute_actual() is True
     # phase_full receives the seed allocations and the parsed (empty) digests list
@@ -649,8 +747,8 @@ def test_execute_actual_routes_to_phase_full_when_top_up_disabled(depositor_bot)
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
     depositor_bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(return_value=[])
-    depositor_bot._phase_seed = Mock(return_value=(False, False))
-    depositor_bot._phase_full = Mock(return_value=(False, False))
+    depositor_bot._phase_seed = Mock(return_value=PhaseOutcome.SKIPPED)
+    depositor_bot._phase_full = Mock(return_value=PhaseOutcome.SKIPPED)
     depositor_bot._phase_full_and_topup = Mock()
 
     depositor_bot._execute_actual()
@@ -665,13 +763,51 @@ def test_execute_actual_routes_to_phase_full_and_topup_when_top_up_enabled(depos
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
     depositor_bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(return_value=[])
-    depositor_bot._phase_seed = Mock(return_value=(False, False))
+    depositor_bot._phase_seed = Mock(return_value=PhaseOutcome.SKIPPED)
     depositor_bot._phase_full = Mock()
-    depositor_bot._phase_full_and_topup = Mock(return_value=(False, False))
+    depositor_bot._phase_full_and_topup = Mock(return_value=PhaseOutcome.SKIPPED)
 
     depositor_bot._execute_actual()
     depositor_bot._phase_full.assert_not_called()
     depositor_bot._phase_full_and_topup.assert_called_once()
+
+
+@pytest.mark.unit
+def test_execute_actual_top_up_gateway_paused_routes_to_phase_full(depositor_bot):
+    """ENABLE_TOP_UP on but TopUpGateway paused → top-ups disabled this iteration; route to _phase_full."""
+    variables.ENABLE_TOP_UP = True
+    depositor_bot.w3.lido.topup_gateway.is_paused = Mock(return_value=True)
+    depositor_bot._refresh_modules_state = Mock()
+    depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
+    depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
+    depositor_bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(return_value=[])
+    depositor_bot._phase_seed = Mock(return_value=PhaseOutcome.SKIPPED)
+    depositor_bot._phase_full = Mock(return_value=PhaseOutcome.SKIPPED)
+    depositor_bot._phase_full_and_topup = Mock()
+
+    depositor_bot._execute_actual()
+    depositor_bot._phase_full.assert_called_once()
+    depositor_bot._phase_full_and_topup.assert_not_called()
+
+
+@pytest.mark.unit
+def test_execute_actual_deposits_paused_skips_phase_a_and_passes_flag(depositor_bot):
+    """Deposits paused → Phase A (seed deposits) skipped; Phase B runs with deposits_paused=True (top-ups only)."""
+    variables.ENABLE_TOP_UP = True
+    depositor_bot._refresh_modules_state = Mock()
+    depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
+    depositor_bot.w3.lido.deposit_security_module.is_deposits_paused = Mock(return_value=True)
+    depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
+    depositor_bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(return_value=[])
+    depositor_bot._phase_seed = Mock()
+    depositor_bot._phase_full = Mock()
+    depositor_bot._phase_full_and_topup = Mock(return_value=PhaseOutcome.SKIPPED)
+
+    depositor_bot._execute_actual()
+
+    depositor_bot._phase_seed.assert_not_called()  # Phase A is deposits-only → skipped while paused
+    depositor_bot._phase_full_and_topup.assert_called_once()
+    assert depositor_bot._phase_full_and_topup.call_args.args[-1] is True  # deposits_paused flag
 
 
 @pytest.mark.unit
@@ -681,10 +817,144 @@ def test_execute_actual_both_phases_return_false(depositor_bot):
     depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
     depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
     depositor_bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(return_value=[])
-    depositor_bot._phase_seed = Mock(return_value=(False, False))
-    depositor_bot._phase_full = Mock(return_value=(False, False))
+    depositor_bot._phase_seed = Mock(return_value=PhaseOutcome.SKIPPED)
+    depositor_bot._phase_full = Mock(return_value=PhaseOutcome.SKIPPED)
 
     assert depositor_bot._execute_actual() is False
+
+
+# ─── Regression matrix: _execute_actual() Executor-facing signal ────
+#
+# Snapshot of the Executor scheduling signal (the bool _execute_actual returns: True → +BBE backoff,
+# False → +1 poll next block) per scenario, against the CURRENT behavior. Driven through the real
+# phases via stable low-level seams (_collect_candidates inputs, distance/quorum gates), so it stays
+# comparable across the PhaseOutcome refactor: the enum step must keep EVERY row unchanged; only the
+# later distance-backoff step is allowed to flip the distance rows (A1, B3) from False to True.
+
+
+@pytest.mark.unit
+class TestExecuteActualScheduling(unittest.TestCase):
+    def setUp(self):
+        variables.ENABLE_TOP_UP = True
+        variables.DEPOSIT_MODULES_WHITELIST = [5, 1]
+        self.bot = _make_bot()
+        self.bot._refresh_modules_state = Mock()
+        self.bot._common_preconditions = Mock(return_value=True)
+        self.bot.w3.lido.deposit_security_module.is_deposits_paused = Mock(return_value=False)
+        self.bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
+        self.bot._deposit_to_module = Mock(return_value=True)
+        self.bot._top_up_to_module = Mock(return_value=True)
+        self.bot.w3.lido.deposit_security_module.is_min_deposit_distance_passed = Mock(return_value=True)
+        self.bot.w3.lido.topup_gateway.can_top_up = Mock(return_value=True)
+        self.bot.w3.lido.topup_gateway.is_block_distance_passed = Mock(return_value=True)
+        self.bot.w3.lido.topup_gateway.is_paused = Mock(return_value=False)
+        self.bot._get_quorum = Mock(return_value=['msg'])
+        # heartbeats fresh → quorum-retention cooldown active by default
+        self.bot._module_last_heart_beat = {5: datetime.now(), 1: datetime.now()}
+        # digests: index 0 = m5 (0x02, active), index 1 = m1 (0x01, active)
+        self.bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(
+            return_value=[_make_digest(5, '0x5', 2), _make_digest(1, '0x1', 1)]
+        )
+
+    def _set_alloc(self, seed, topup):
+        """Per-digest-index allocations; `new` = allocated + 1000 so stake is non-zero."""
+
+        def alloc(_amount, is_top_up):
+            src = topup if is_top_up else seed
+            return (0, list(src), [v + 1000 for v in src])
+
+        self.bot.w3.lido.staking_router.get_deposit_allocations = Mock(side_effect=alloc)
+
+    def _stale_quorum(self, module_id):
+        self.bot._module_last_heart_beat[module_id] = datetime.now() - timedelta(minutes=variables.QUORUM_RETENTION_MINUTES + 1)
+
+    # ─── A. deposit candidate (Phase A seed 0x02) ──────────────
+
+    def test_A1_deposit_distance_not_passed(self):
+        self._set_alloc(seed=[100, 0], topup=[0, 0])
+        self.bot.w3.lido.deposit_security_module.is_min_deposit_distance_passed = Mock(return_value=False)
+        self.assertTrue(self.bot._execute_actual())  # distance-backoff: +BBE instead of polling every block
+        self.bot._deposit_to_module.assert_not_called()
+
+    def test_A2_deposit_sent(self):
+        self._set_alloc(seed=[100, 0], topup=[0, 0])
+        self.assertTrue(self.bot._execute_actual())  # +BBE
+        self.bot._deposit_to_module.assert_called_once_with(5)
+
+    def test_A3_deposit_failed(self):
+        self._set_alloc(seed=[100, 0], topup=[0, 0])
+        self.bot._deposit_to_module = Mock(return_value=False)
+        self.assertFalse(self.bot._execute_actual())  # +1
+        self.bot._deposit_to_module.assert_called_once_with(5)
+
+    def test_A4_quorum_retained_wait(self):
+        self._set_alloc(seed=[100, 0], topup=[0, 0])
+        self.bot._get_quorum = Mock(return_value=None)  # no quorum now, heartbeat fresh → retained
+        self.assertFalse(self.bot._execute_actual())  # +1
+        self.bot._deposit_to_module.assert_not_called()
+
+    def test_A5_quorum_stale_phase_a_skips(self):
+        self._set_alloc(seed=[100, 0], topup=[0, 0])  # no top-up, no 0x01 → Phase B empty
+        self.bot._get_quorum = Mock(return_value=None)
+        self._stale_quorum(5)
+        self.assertFalse(self.bot._execute_actual())  # +1
+        self.bot._deposit_to_module.assert_not_called()
+        self.bot._top_up_to_module.assert_not_called()
+
+    def test_A6_quorum_retained_holds_priority_over_ready_module(self):
+        # Two 0x02 seed candidates. Priority m5 (lower stake) has no quorum but is in retention → we
+        # WAIT and do NOT divert to m2, even though m2 has a quorum and could deposit right now.
+        variables.DEPOSIT_MODULES_WHITELIST = [5, 2]
+        self.bot._module_last_heart_beat = {5: datetime.now(), 2: datetime.now()}  # both retained (fresh)
+        self.bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(
+            return_value=[_make_digest(5, '0x5', 2), _make_digest(2, '0x2', 2)]
+        )
+
+        def alloc(_amount, is_top_up):
+            if is_top_up:
+                return (0, [0, 0], [0, 0])
+            return (0, [100, 100], [200, 2000])  # m5 stake=100 (priority), m2 stake=1900
+
+        self.bot.w3.lido.staking_router.get_deposit_allocations = Mock(side_effect=alloc)
+        self.bot._get_quorum = Mock(side_effect=lambda mid: ['msg'] if mid == 2 else None)  # only m2 has quorum
+
+        self.assertFalse(self.bot._execute_actual())  # WAIT on priority m5 (+1)
+        self.bot._deposit_to_module.assert_not_called()  # did NOT divert to the ready m2
+
+    # ─── B. top-up candidate (Phase B 0x02) ────────────────────
+
+    def test_B2_can_top_up_false_skips(self):
+        self._set_alloc(seed=[0, 0], topup=[100, 0])  # m5 top-up candidate; Phase A empty
+        self.bot.w3.lido.topup_gateway.can_top_up = Mock(return_value=False)
+        self.assertFalse(self.bot._execute_actual())  # +1
+        self.bot._top_up_to_module.assert_not_called()
+
+    def test_B3_top_up_distance_not_passed(self):
+        self._set_alloc(seed=[0, 0], topup=[100, 0])
+        self.bot.w3.lido.topup_gateway.is_block_distance_passed = Mock(return_value=False)
+        self.assertTrue(self.bot._execute_actual())  # distance-backoff: +BBE instead of polling every block
+        self.bot._top_up_to_module.assert_not_called()
+
+    def test_B4_top_up_sent(self):
+        self._set_alloc(seed=[0, 0], topup=[100, 0])
+        self.assertTrue(self.bot._execute_actual())  # +BBE
+        self.bot._top_up_to_module.assert_called_once()
+
+    def test_B5_top_up_failed(self):
+        self._set_alloc(seed=[0, 0], topup=[100, 0])
+        self.bot._top_up_to_module = Mock(return_value=False)
+        self.assertFalse(self.bot._execute_actual())  # +1
+        self.bot._top_up_to_module.assert_called_once()
+
+    # ─── C. cascade (skip a candidate, act on the next) ────────
+
+    def test_C3_skip_topup_then_full_deposit(self):
+        # Phase B: m5 (0x02) can_top_up=False → skip; m1 (0x01) deposits.
+        self._set_alloc(seed=[0, 50], topup=[100, 0])
+        self.bot.w3.lido.topup_gateway.can_top_up = Mock(return_value=False)
+        self.assertTrue(self.bot._execute_actual())  # +BBE (deposit sent)
+        self.bot._top_up_to_module.assert_not_called()
+        self.bot._deposit_to_module.assert_called_once_with(1)
 
 
 # ─── _deposit_to_module ────────────────────────────────────────────
@@ -762,25 +1032,6 @@ def test_deposit_to_module_general_strategy_for_non_csm_module_type(depositor_bo
 
 
 @pytest.mark.unit
-def test_top_up_to_module_skipped_when_indexer_not_ready(depositor_bot):
-    """Indexer present but not ready → skip top-up before selecting a strategy."""
-    depositor_bot._consolidation_indexer.is_ready = False
-    depositor_bot._select_topup_strategy = Mock()
-
-    assert depositor_bot._top_up_to_module(1, '0xAddr', 50) is False
-    depositor_bot._select_topup_strategy.assert_not_called()
-
-
-@pytest.mark.unit
-def test_top_up_to_module_skipped_when_indexer_none(depositor_bot):
-    """No indexer configured for this chain → skip top-up."""
-    depositor_bot._consolidation_indexer = None
-    depositor_bot._select_topup_strategy = Mock()
-
-    assert depositor_bot._top_up_to_module(1, '0xAddr', 50) is False
-    depositor_bot._select_topup_strategy.assert_not_called()
-
-
 @pytest.mark.unit
 def test_top_up_to_module_unknown_type_returns_false(depositor_bot):
     mock_module = Mock()
@@ -898,6 +1149,25 @@ def test_top_up_to_module_passes_module_allocation_through_to_strategy(depositor
     # allocation 1234 forwarded; getDepositAllocations NOT re-queried
     assert strategy.get_topup_candidates.call_args.args[4] == 1234
     depositor_bot.w3.lido.staking_router.get_deposit_allocations.assert_not_called()
+
+
+# ─── _build_consolidation_indexer ──────────────────────────────────
+
+
+@pytest.mark.unit
+def test_build_consolidation_indexer_none_when_top_up_disabled():
+    variables.ENABLE_TOP_UP = False
+    bot = _make_bot()
+    assert bot._build_consolidation_indexer() is None
+
+
+@pytest.mark.unit
+def test_build_consolidation_indexer_raises_when_top_up_enabled_but_bus_unconfigured():
+    # ENABLE_TOP_UP on + no Bus config → fail fast at startup (don't run with top-ups silently off).
+    variables.ENABLE_TOP_UP = True
+    bot = _make_bot()
+    with mock.patch.object(variables, 'get_consolidation_bus_config', return_value=(None, None)), pytest.raises(ValueError):
+        bot._build_consolidation_indexer()
 
 
 # ─── _select_topup_strategy ────────────────────────────────────────


### PR DESCRIPTION
New behavior

  Added a cooldown for the case when a deposit can't go through because the distance between deposits hasn't passed yet — min deposit distance not passed. In the future it might be worth returning, in such cases, after how many blocks to restart.

  Refactoring

  - Removed code duplication across _phase_seed, _phase_full, _phase_full_and_topup.
  - Removed canDeposit, because the checks inside it either overlap with what's already in the digest, the distance we need to check for the cooldown anyway, and it also mixes checks that are common to all modules with per-module ones.
  - Added an enum that illustrates what happened in a given phase.

  Fix

  - No longer let the bot start if top-ups are enabled and the consolidation indexer failed to initialize for some reason.