### PR TITLE
feat: Metrics for srv4 logic monitoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,72 @@ All environment variables are read in `src/variables.py`. When adding a new one:
 
 `pyproject.toml` sets `pythonpath = ["src", "tests"]`. All imports are relative to `src/` — use `from blockchain.contracts...`, not `from src.blockchain...`.
 
+## Debugging: "why wasn't key X deposited / topped up?"
+
+This question splits into two different investigations depending on what X is. Conflating them
+wastes time — figure out which one applies before looking at anything.
+
+### X is an already-active validator (top-up path)
+
+CMv2 evaluates individual pubkeys for top-up, so there's always a definitive, instrumented answer.
+Walk the gates in order; the first one that isn't "pass" is almost always the whole answer.
+
+Module-level gates (Prometheus, defined in `src/metrics/metrics.py`, set in `src/bots/depositor.py`):
+
+1. `topup_gateway_paused == 0` (and `variables.ENABLE_TOP_UP` is true — checked at startup, not a metric).
+2. `module_allocation_wei{module_id, kind="topup"} > 0`. Zero here is the single most common reason
+   nothing happens — the StakingRouter allocation algorithm didn't route ETH to this module at all
+   this cycle.
+3. `module_stake_wei{module_id, kind="topup"}` — lowest value across candidate modules goes first.
+   Only **one** module is acted on per bot iteration (`_phase_full_and_topup` returns on the first
+   non-`SKIPPED` outcome), so a module that lost the priority race this cycle never gets its
+   `phase_outcome`/`quorum_state` touched — those stay at whatever they were last time this module
+   *was* reached. Tell "evaluated and skipped" from "not reached this cycle" by comparing
+   `phase_last_run_timestamp_seconds{phase="B", module_id}` against `module_allocation_wei`'s own
+   freshness (both are set every cycle regardless of whether the module becomes a candidate).
+4. `topup_gas_ok{module_id}` / `topup_gas_fee_wei{type}`.
+5. `phase_outcome{phase="B", module_id} != wait_distance` (TopUpGateway block distance).
+
+Key-level gates — module_id is now known, question narrows to pubkey X. Instrumented in
+`CMv2TopUpStrategy` (`src/blockchain/topup/cmv2_strategy.py`), evaluated in this order:
+
+- `not_in_beacon_state` / `not_active` / `slashed` / `exiting` / `beacon_consolidation_target` /
+  `already_at_target_balance` — `_check_key_eligibility`.
+- `pending_consolidation_bus` — excluded by a pending ConsolidationBus request.
+- `operator_budget_exhausted` — eligible and funded in isolation, but the operator's allocation ran
+  out before reaching X in validator-index order (`_take_up_to_allocation`). This is a queue-position
+  problem, not an eligibility problem — X is a strong candidate for the next cycle.
+- `truncated_by_max_validators` — eligible, funded, and within its operator's budget, but cut by the
+  cross-operator `max_validators` cap on the final sorted list.
+
+**`topup_key_excluded_total{module_id, reason}` (Counter) only tells you a reason is trending up —
+it is deliberately not labeled by pubkey** (would explode cardinality across thousands of keys).
+For "why was key X specifically excluded," grep logs for the structured line every excluded
+candidate gets, once per cycle, from `_log_excluded_key`:
+
+```
+{"msg": "Top-up candidate excluded.", "module_id": ..., "operator_id": ..., "pubkey": "0x...", "reason": "..."}
+```
+
+### X has never been deposited (first-deposit / 0x01 path)
+
+The bot does **not** pick a specific key here — it only decides how much ETH to route to X's
+*module* via `depositBufferedEther`. Which key gets consumed next is decided on-chain by that
+module's registry contract (NodeOperatorsRegistry / CSM), based on operator stake share and key
+submission order. That logic lives outside this repo and this repo has no metric for it — don't go
+looking for one.
+
+Check, in order: `deposits_paused`, `depositable_ether`, `module_status{module_id}` +
+`module_allocation_wei{module_id, kind="seed"}`, `quorum_state{module_id}` (deposits require a
+signed guardian quorum; top-ups don't — this gate has no equivalent on the top-up path),
+`phase_outcome{phase, module_id}`.
+
+If all of those pass and a deposit was sent, the module is healthy and the bot did its job — whether
+X specifically was the key consumed requires a separate lookup outside this bot: compare X's key
+index for its operator (Keys API) against the operator's currently-used-key count and stake share
+(StakingRouter). That's a one-off chain-state query, not something worth turning into a bot metric —
+it doesn't change cycle to cycle the way allocation or gas does.
+
 ## Testing
 
 Unit tests (`-m unit`) are fully offline and run on every commit via pre-commit hook. Integration tests (`-m integration`) fork Hoodi via anvil and require `TESTNET_WEB3_RPC_ENDPOINTS`.

--- a/src/blockchain/consolidation/indexer.py
+++ b/src/blockchain/consolidation/indexer.py
@@ -19,6 +19,7 @@ from blockchain.consolidation.store import InMemoryPendingStore
 from blockchain.contracts.consolidation_bus import ConsolidationBusContract
 from blockchain.typings import Web3
 from eth_abi.abi import decode as abi_decode
+from metrics.metrics import CONSOLIDATION_CURSOR_LAG, CONSOLIDATION_PENDING_BATCHES, CONSOLIDATION_PENDING_PUBKEYS
 from web3.types import EventData
 
 logger = logging.getLogger(__name__)
@@ -72,6 +73,10 @@ class ConsolidationIndexer:
         if start <= finalized:
             logger.info({'msg': 'Consolidation base sync.', 'from': start, 'to': finalized})
             self._sync_range(start, finalized)
+        CONSOLIDATION_PENDING_BATCHES.set(self.store.pending_batch_count())
+        CONSOLIDATION_PENDING_PUBKEYS.set(self.store.pending_pubkey_count())
+        cursor = self.store.get_cursor(default=self.deploy_block - 1)
+        CONSOLIDATION_CURSOR_LAG.set(max(0, finalized - cursor))
         return finalized
 
     def _sync_range(self, from_block: int, to_block: int) -> None:

--- a/src/blockchain/deposit_strategy/base_deposit_strategy.py
+++ b/src/blockchain/deposit_strategy/base_deposit_strategy.py
@@ -9,7 +9,7 @@ from blockchain.contracts.staking_router import (
 from blockchain.deposit_strategy.gas_price_calculator import GasPriceCalculator
 from blockchain.deposit_strategy.strategy import DepositStrategy
 from blockchain.typings import Web3
-from metrics.metrics import DEPOSIT_AMOUNT_OK, DEPOSITABLE_ETHER, GAS_FEE, GAS_OK, POSSIBLE_DEPOSITS_AMOUNT
+from metrics.metrics import GAS_FEE, GAS_OK
 from web3.types import Wei
 
 logger = logging.getLogger(__name__)
@@ -26,7 +26,6 @@ class BaseDepositStrategy(DepositStrategy):
         if success:
             base_fee_per_gas = self._gas_price_calculator.get_pending_base_fee()
             success = self._is_deposit_recommended_based_on_keys_amount(possible_keys, base_fee_per_gas, module_id)
-        DEPOSIT_AMOUNT_OK.labels(module_id).set(int(success))
         return success
 
     def _is_keys_amount_above_threshold(self, keys: int, module_id: int) -> bool:
@@ -64,18 +63,14 @@ class BaseDepositStrategy(DepositStrategy):
         return 1
 
     def _depositable_ether(self) -> Wei:
-        depositable_ether = self.w3.lido.lido.get_depositable_ether()
-        DEPOSITABLE_ETHER.set(depositable_ether)
-        return depositable_ether
+        return self.w3.lido.lido.get_depositable_ether()
 
     def deposited_keys_amount(self, module_id: int) -> int:
         depositable_ether = self._depositable_ether()
-        possible_deposits_amount = self.w3.lido.staking_router.get_staking_module_max_deposits_count(
+        return self.w3.lido.staking_router.get_staking_module_max_deposits_count(
             module_id,
             depositable_ether,
         )
-        POSSIBLE_DEPOSITS_AMOUNT.labels(module_id).set(possible_deposits_amount)
-        return possible_deposits_amount
 
     def can_deposit_keys_based_on_allocation(self, module_id: int) -> bool:
         """
@@ -88,7 +83,6 @@ class BaseDepositStrategy(DepositStrategy):
         if success:
             base_fee_per_gas = self._gas_price_calculator.get_pending_base_fee()
             success = self._is_deposit_recommended_based_on_keys_amount(possible_keys, base_fee_per_gas, module_id)
-        DEPOSIT_AMOUNT_OK.labels(module_id).set(int(success))
         return success
 
     def _allocated_keys_amount(self, module_id: int) -> int:
@@ -107,7 +101,6 @@ class BaseDepositStrategy(DepositStrategy):
                 keys = allocated[i] // (32 * 10**18)
                 break
 
-        POSSIBLE_DEPOSITS_AMOUNT.labels(module_id).set(keys)
         return keys
 
     @staticmethod

--- a/src/blockchain/executor.py
+++ b/src/blockchain/executor.py
@@ -2,12 +2,13 @@
 
 import logging
 import traceback
-from time import sleep
+from time import sleep, time
 from typing import Any, Callable, Optional
 
 from blockchain.constants import SLOT_TIME
 from blockchain.typings import Web3
 from metrics import healthcheck_pulse
+from metrics.metrics import EL_HEAD_BLOCK_AGE_SECONDS, EL_HEAD_BLOCK_NUMBER, UNEXPECTED_EXCEPTIONS
 from utils.timeout import TimeoutManager, TimeoutManagerError
 from web3.types import BlockData
 from web3_multi_provider import NoActiveProviderError
@@ -74,6 +75,8 @@ class Executor:
             while True:
                 latest_block: BlockData = self.w3.eth.get_block('latest')
                 logger.debug({'msg': 'Fetch latest block.', 'value': latest_block})
+                EL_HEAD_BLOCK_NUMBER.set(latest_block['number'])
+                EL_HEAD_BLOCK_AGE_SECONDS.set(max(0, time() - latest_block['timestamp']))
 
                 if latest_block['number'] >= self._next_expected_block:
                     self._next_expected_block = latest_block['number']
@@ -97,11 +100,18 @@ class Executor:
         try:
             return function(*args, **kwargs)
         except TimeoutManagerError as exception:
+            UNEXPECTED_EXCEPTIONS.labels('timeout').inc()
             logger.error({'msg': 'Timeout error.', 'error': str(exception), 'function': function.__name__})
             raise TimeoutManagerError('Bot stuck. Shut down.') from exception
         except NoActiveProviderError as exception:
+            UNEXPECTED_EXCEPTIONS.labels('no_active_provider').inc()
             logger.error({'msg': 'No active node available. Shut down.', 'error': str(exception)})
-            raise NoActiveProviderError from exception
+            # NoActiveProviderError is a BaseExceptionGroup subclass and needs (msg, exceptions) to
+            # construct — re-raising the caught instance is simpler and preserves its sub-exceptions.
+            raise
         except Exception as error:
+            # Swallowed on purpose (no re-raise) so a single bad cycle doesn't kill the daemon —
+            # which is exactly why this needs a counter: nothing else surfaces it happening.
+            UNEXPECTED_EXCEPTIONS.labels(type(error).__name__).inc()
             stack_trace = traceback.format_exc()
             logger.error({'msg': 'Unexpected error.', 'error': str(error), 'args': str(error.args), 'stack': stack_trace})

--- a/src/blockchain/topup/cmv2_strategy.py
+++ b/src/blockchain/topup/cmv2_strategy.py
@@ -48,6 +48,7 @@ class CMv2TopUpStrategy(TopUpStrategy):
             now = time.time()
             TOPUP_CANDIDATES_SELECTED.labels(module_id).set(0)
             TOPUP_CANDIDATES_LAST_RUN_TIMESTAMP.labels(module_id).set(now)
+            TOPUP_CONSOLIDATION_FILTERED.labels(module_id).set(0)
             logger.info({'msg': 'No allocation from CMv2.', 'module_id': module_id})
             return None
 
@@ -56,6 +57,7 @@ class CMv2TopUpStrategy(TopUpStrategy):
             now = time.time()
             TOPUP_CANDIDATES_SELECTED.labels(module_id).set(0)
             TOPUP_CANDIDATES_LAST_RUN_TIMESTAMP.labels(module_id).set(now)
+            TOPUP_CONSOLIDATION_FILTERED.labels(module_id).set(0)
             logger.info({'msg': 'No operators with allocation.', 'module_id': module_id})
             return None
 

--- a/src/blockchain/topup/cmv2_strategy.py
+++ b/src/blockchain/topup/cmv2_strategy.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import List, Optional, cast
 
 from blockchain.beacon_state.ssz_types import (
@@ -13,7 +14,7 @@ from blockchain.topup.strategy import TopUpStrategy
 from blockchain.topup.types import TopUpCandidate, TopUpProofData
 from blockchain.typings import Web3
 from eth_typing import HexStr
-from metrics.metrics import TOPUP_CANDIDATES_SELECTED, TOPUP_CONSOLIDATION_FILTERED
+from metrics.metrics import TOPUP_CANDIDATES_LAST_RUN_TIMESTAMP, TOPUP_CANDIDATES_SELECTED, TOPUP_CONSOLIDATION_FILTERED
 from providers.consensus import ConsensusClient
 from providers.keys_api import KeysAPIClient, LidoKey
 from web3.types import Wei
@@ -44,11 +45,17 @@ class CMv2TopUpStrategy(TopUpStrategy):
         allocated, operator_ids, allocations = cmv2.get_deposits_allocation(module_allocation)
 
         if allocated == 0:
+            now = time.time()
+            TOPUP_CANDIDATES_SELECTED.labels(module_id).set(0)
+            TOPUP_CANDIDATES_LAST_RUN_TIMESTAMP.labels(module_id).set(now)
             logger.info({'msg': 'No allocation from CMv2.', 'module_id': module_id})
             return None
 
         allocation_by_operator: dict[int, int] = {op_id: alloc for op_id, alloc in zip(operator_ids, allocations) if alloc > 0}
         if not allocation_by_operator:
+            now = time.time()
+            TOPUP_CANDIDATES_SELECTED.labels(module_id).set(0)
+            TOPUP_CANDIDATES_LAST_RUN_TIMESTAMP.labels(module_id).set(now)
             logger.info({'msg': 'No operators with allocation.', 'module_id': module_id})
             return None
 
@@ -82,14 +89,11 @@ class CMv2TopUpStrategy(TopUpStrategy):
         except Exception as e:
             logger.error({'msg': 'Consolidation tail read failed — skip top-up.', 'module_id': module_id, 'err': repr(e)})
             return None
-        consolidation_filtered = len(all_pubkeys & pending_consolidation)
-        TOPUP_CONSOLIDATION_FILTERED.labels(module_id).set(consolidation_filtered)
         logger.info(
             {
                 'msg': 'Consolidation pending filter ready.',
                 'module_id': module_id,
                 'pending_pubkeys': len(pending_consolidation),
-                'consolidation_filtered': consolidation_filtered,
             }
         )
 
@@ -111,20 +115,32 @@ class CMv2TopUpStrategy(TopUpStrategy):
 
         # Step 6: select candidates per operator (excluding keys in pending ConsolidationBus requests)
         candidates: list[TopUpCandidate] = []
+        total_consolidation_filtered = 0
         for op_id, op_allocation in allocation_by_operator.items():
-            candidates.extend(
-                _select_operator_candidates(
-                    keys_by_operator[op_id],
-                    op_allocation,
-                    beacon_data,
-                    pending_consolidation,
-                    target_balance_gwei,
-                    min_top_up_gwei,
-                )
+            selected, filtered = _select_operator_candidates(
+                keys_by_operator[op_id],
+                op_allocation,
+                beacon_data,
+                pending_consolidation,
+                target_balance_gwei,
+                min_top_up_gwei,
             )
+            candidates.extend(selected)
+            total_consolidation_filtered += filtered
 
         # LidoKey instances are no longer needed; free before the memory-heavy proof build.
         del keys_by_operator
+        TOPUP_CONSOLIDATION_FILTERED.labels(module_id).set(total_consolidation_filtered)
+
+        # Step 7: TopUpGateway requires strictly ascending validator_indices across operators
+        candidates.sort(key=lambda c: c.validator_index)
+        # Step 8: limit to max_validators
+        candidates = candidates[:max_validators]
+        # Set before the early return so metrics are always fresh after a selection run,
+        # including the 0 case — avoids stale values from a previous cycle.
+        now = time.time()
+        TOPUP_CANDIDATES_SELECTED.labels(module_id).set(len(candidates))
+        TOPUP_CANDIDATES_LAST_RUN_TIMESTAMP.labels(module_id).set(now)
 
         if not candidates:
             logger.info({'msg': 'No eligible candidates.', 'module_id': module_id})
@@ -132,11 +148,6 @@ class CMv2TopUpStrategy(TopUpStrategy):
 
         logger.info({'msg': 'CMv2 candidates selected.', 'module_id': module_id, 'count': len(candidates)})
 
-        # Step 7: TopUpGateway requires strictly ascending validator_indices across operators
-        candidates.sort(key=lambda c: c.validator_index)
-        # Step 8: limit to max_validators
-        candidates = candidates[:max_validators]
-        TOPUP_CANDIDATES_SELECTED.labels(module_id).set(len(candidates))
         # Step 9: build proofs
         return build_topup_proofs(beacon_data, candidates)
 
@@ -156,29 +167,34 @@ def _select_operator_candidates(
     pending_consolidation: set[bytes],
     target_balance_gwei: int,
     min_top_up_gwei: int,
-) -> List[TopUpCandidate]:
+) -> tuple[List[TopUpCandidate], int]:
+    """Returns (selected_candidates, consolidation_filtered_count).
+
+    consolidation_filtered_count counts only keys that passed all other eligibility checks but
+    were blocked by a pending ConsolidationBus request — not all keys in the pending set.
+    """
+    consolidation_filtered = 0
     eligible = []
     for key in keys:
-        candidate = _check_key_eligibility(key, beacon_data, pending_consolidation, target_balance_gwei, min_top_up_gwei)
-        if candidate is not None:
-            eligible.append(candidate)
+        candidate = _check_key_eligibility(key, beacon_data, target_balance_gwei, min_top_up_gwei)
+        if candidate is None:
+            continue
+        if candidate.pubkey in pending_consolidation:
+            consolidation_filtered += 1
+            continue
+        eligible.append(candidate)
 
     eligible.sort(key=lambda c: c.validator_index)
-    return _take_up_to_allocation(eligible, allocation, beacon_data, target_balance_gwei, min_top_up_gwei)
+    return _take_up_to_allocation(eligible, allocation, beacon_data, target_balance_gwei, min_top_up_gwei), consolidation_filtered
 
 
 def _check_key_eligibility(
     key: LidoKey,
     beacon_data: BeaconStateData,
-    pending_consolidation: set[bytes],
     target_balance_gwei: int,
     min_top_up_gwei: int,
 ) -> Optional[TopUpCandidate]:
     pubkey = Web3.to_bytes(hexstr=HexStr(key.key))
-
-    # Exclude keys participating in a pending ConsolidationBus request (source or target).
-    if pubkey in pending_consolidation:
-        return None
 
     validator_index = beacon_data.pubkey_to_index.get(pubkey)
     if validator_index is None:

--- a/src/blockchain/topup/cmv2_strategy.py
+++ b/src/blockchain/topup/cmv2_strategy.py
@@ -13,6 +13,7 @@ from blockchain.topup.strategy import TopUpStrategy
 from blockchain.topup.types import TopUpCandidate, TopUpProofData
 from blockchain.typings import Web3
 from eth_typing import HexStr
+from metrics.metrics import TOPUP_CANDIDATES_SELECTED, TOPUP_CONSOLIDATION_FILTERED
 from providers.consensus import ConsensusClient
 from providers.keys_api import KeysAPIClient, LidoKey
 from web3.types import Wei
@@ -81,11 +82,14 @@ class CMv2TopUpStrategy(TopUpStrategy):
         except Exception as e:
             logger.error({'msg': 'Consolidation tail read failed — skip top-up.', 'module_id': module_id, 'err': repr(e)})
             return None
+        consolidation_filtered = len(all_pubkeys & pending_consolidation)
+        TOPUP_CONSOLIDATION_FILTERED.labels(module_id).set(consolidation_filtered)
         logger.info(
             {
                 'msg': 'Consolidation pending filter ready.',
                 'module_id': module_id,
                 'pending_pubkeys': len(pending_consolidation),
+                'consolidation_filtered': consolidation_filtered,
             }
         )
 
@@ -132,6 +136,7 @@ class CMv2TopUpStrategy(TopUpStrategy):
         candidates.sort(key=lambda c: c.validator_index)
         # Step 8: limit to max_validators
         candidates = candidates[:max_validators]
+        TOPUP_CANDIDATES_SELECTED.labels(module_id).set(len(candidates))
         # Step 9: build proofs
         return build_topup_proofs(beacon_data, candidates)
 

--- a/src/blockchain/topup/cmv2_strategy.py
+++ b/src/blockchain/topup/cmv2_strategy.py
@@ -14,12 +14,51 @@ from blockchain.topup.strategy import TopUpStrategy
 from blockchain.topup.types import TopUpCandidate, TopUpProofData
 from blockchain.typings import Web3
 from eth_typing import HexStr
-from metrics.metrics import TOPUP_CANDIDATES_LAST_RUN_TIMESTAMP, TOPUP_CANDIDATES_SELECTED, TOPUP_CONSOLIDATION_FILTERED
+from metrics.metrics import (
+    TOPUP_CANDIDATES_LAST_RUN_TIMESTAMP,
+    TOPUP_CANDIDATES_SELECTED,
+    TOPUP_CONSOLIDATION_FILTERED,
+    TOPUP_KEY_EXCLUDED,
+)
 from providers.consensus import ConsensusClient
 from providers.keys_api import KeysAPIClient, LidoKey
 from web3.types import Wei
 
 logger = logging.getLogger(__name__)
+
+# Stable per-key exclusion reasons — used for both the per-cycle log line and TOPUP_KEY_EXCLUDED.
+# This is the full answer set for "why wasn't key X topped up this cycle" (see _check_key_eligibility,
+# _take_up_to_allocation and the max_validators truncation in get_topup_candidates).
+_REASON_NOT_IN_BEACON_STATE = 'not_in_beacon_state'
+_REASON_NOT_ACTIVE = 'not_active'
+_REASON_SLASHED = 'slashed'
+_REASON_EXITING = 'exiting'
+_REASON_BEACON_CONSOLIDATION_TARGET = 'beacon_consolidation_target'
+_REASON_ALREADY_AT_TARGET_BALANCE = 'already_at_target_balance'
+_REASON_PENDING_CONSOLIDATION_BUS = 'pending_consolidation_bus'
+_REASON_OPERATOR_BUDGET_EXHAUSTED = 'operator_budget_exhausted'
+_REASON_TRUNCATED_BY_MAX_VALIDATORS = 'truncated_by_max_validators'
+
+
+def _pubkey_hex(pubkey: bytes) -> str:
+    return '0x' + pubkey.hex()
+
+
+def _log_excluded_key(module_id: int, operator_id: int, pubkey: str, reason: str) -> None:
+    """One INFO line per excluded top-up candidate — the way to answer "why wasn't key X topped
+    up this cycle" for a specific pubkey (grep logs by pubkey). `reason` is also counted in
+    TOPUP_KEY_EXCLUDED for trend visibility without per-key cardinality.
+    """
+    TOPUP_KEY_EXCLUDED.labels(module_id, reason).inc()
+    logger.info(
+        {
+            'msg': 'Top-up candidate excluded.',
+            'module_id': module_id,
+            'operator_id': operator_id,
+            'pubkey': pubkey,
+            'reason': reason,
+        }
+    )
 
 
 class CMv2TopUpStrategy(TopUpStrategy):
@@ -126,6 +165,7 @@ class CMv2TopUpStrategy(TopUpStrategy):
                 pending_consolidation,
                 target_balance_gwei,
                 min_top_up_gwei,
+                module_id,
             )
             candidates.extend(selected)
             total_consolidation_filtered += filtered
@@ -136,7 +176,10 @@ class CMv2TopUpStrategy(TopUpStrategy):
 
         # Step 7: TopUpGateway requires strictly ascending validator_indices across operators
         candidates.sort(key=lambda c: c.validator_index)
-        # Step 8: limit to max_validators
+        # Step 8: limit to max_validators — everything past the cap loses purely to cross-operator
+        # competition for tx space, not to any eligibility problem of its own.
+        for excluded in candidates[max_validators:]:
+            _log_excluded_key(module_id, excluded.operator_id, _pubkey_hex(excluded.pubkey), _REASON_TRUNCATED_BY_MAX_VALIDATORS)
         candidates = candidates[:max_validators]
         # Set before the early return so metrics are always fresh after a selection run,
         # including the 0 case — avoids stale values from a previous cycle.
@@ -169,6 +212,7 @@ def _select_operator_candidates(
     pending_consolidation: set[bytes],
     target_balance_gwei: int,
     min_top_up_gwei: int,
+    module_id: int,
 ) -> tuple[List[TopUpCandidate], int]:
     """Returns (selected_candidates, consolidation_filtered_count).
 
@@ -178,16 +222,20 @@ def _select_operator_candidates(
     consolidation_filtered = 0
     eligible = []
     for key in keys:
-        candidate = _check_key_eligibility(key, beacon_data, target_balance_gwei, min_top_up_gwei)
+        candidate, reason = _check_key_eligibility(key, beacon_data, target_balance_gwei, min_top_up_gwei)
         if candidate is None:
+            assert reason is not None
+            _log_excluded_key(module_id, key.operatorIndex, key.key, reason)
             continue
         if candidate.pubkey in pending_consolidation:
             consolidation_filtered += 1
+            _log_excluded_key(module_id, candidate.operator_id, key.key, _REASON_PENDING_CONSOLIDATION_BUS)
             continue
         eligible.append(candidate)
 
     eligible.sort(key=lambda c: c.validator_index)
-    return _take_up_to_allocation(eligible, allocation, beacon_data, target_balance_gwei, min_top_up_gwei), consolidation_filtered
+    selected = _take_up_to_allocation(eligible, allocation, beacon_data, target_balance_gwei, min_top_up_gwei, module_id)
+    return selected, consolidation_filtered
 
 
 def _check_key_eligibility(
@@ -195,37 +243,41 @@ def _check_key_eligibility(
     beacon_data: BeaconStateData,
     target_balance_gwei: int,
     min_top_up_gwei: int,
-) -> Optional[TopUpCandidate]:
+) -> tuple[Optional[TopUpCandidate], Optional[str]]:
+    """Returns (candidate, exclusion_reason) — reason is set only when candidate is None."""
     pubkey = Web3.to_bytes(hexstr=HexStr(key.key))
 
     validator_index = beacon_data.pubkey_to_index.get(pubkey)
     if validator_index is None:
-        return None
+        return None, _REASON_NOT_IN_BEACON_STATE
 
     fields = beacon_data.validators_fields[validator_index]
     pending = beacon_data.pending_deposits.get(pubkey, 0)
     current_epoch = beacon_data.slot // SLOTS_PER_EPOCH
 
     if not _is_active(fields, current_epoch):
-        return None
+        return None, _REASON_NOT_ACTIVE
     if _is_slashed(fields):
-        return None
+        return None, _REASON_SLASHED
     if _is_exiting(fields):
-        return None
+        return None, _REASON_EXITING
     if validator_index in beacon_data.consolidation_targets:
-        return None
+        return None, _REASON_BEACON_CONSOLIDATION_TARGET
     # Mirror TopUpGateway._evaluateTopUpLimit: a balance above (target - min) leaves less than the
     # minimum meaningful top-up, so the contract would return limit 0 — exclude such keys here too.
     max_eligible_balance_gwei = target_balance_gwei - min_top_up_gwei
     if fields.effective_balance + pending > max_eligible_balance_gwei:
-        return None
+        return None, _REASON_ALREADY_AT_TARGET_BALANCE
 
-    return TopUpCandidate(
-        validator_index=validator_index,
-        key_index=key.index,
-        operator_id=key.operatorIndex,
-        pubkey=pubkey,
-        pending_balance=pending,
+    return (
+        TopUpCandidate(
+            validator_index=validator_index,
+            key_index=key.index,
+            operator_id=key.operatorIndex,
+            pubkey=pubkey,
+            pending_balance=pending,
+        ),
+        None,
     )
 
 
@@ -247,19 +299,23 @@ def _take_up_to_allocation(
     beacon_data: BeaconStateData,
     target_balance_gwei: int,
     min_top_up_gwei: int,
+    module_id: int,
 ) -> List[TopUpCandidate]:
     result = []
     remaining = allocation_wei // 10**9
-    for c in candidates:
+    for i, c in enumerate(candidates):
         # Stop before adding a validator the leftover budget can't fund to at least the minimum:
         # the contract spends the allocation in order and tops the last validator up only by what
         # remains — if that is < min it reverts. Checked before append so a sub-min tail is never selected.
         if remaining < min_top_up_gwei:
+            for excluded in candidates[i:]:
+                _log_excluded_key(module_id, excluded.operator_id, _pubkey_hex(excluded.pubkey), _REASON_OPERATOR_BUDGET_EXHAUSTED)
             break
         balance = beacon_data.validators_fields[c.validator_index].effective_balance
         topup_amount = target_balance_gwei - (balance + c.pending_balance)
         # Already at/near the cap — the contract tops up nothing (mirrors TopUpGateway._evaluateTopUpLimit).
         if topup_amount < min_top_up_gwei:
+            _log_excluded_key(module_id, c.operator_id, _pubkey_hex(c.pubkey), _REASON_ALREADY_AT_TARGET_BALANCE)
             continue
         result.append(c)
         # May go negative: the last selected validator absorbs the remaining budget as a partial top-up.

--- a/src/blockchain/topup/cmv2_strategy.py
+++ b/src/blockchain/topup/cmv2_strategy.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from enum import StrEnum
 from typing import List, Optional, cast
 
 from blockchain.beacon_state.ssz_types import (
@@ -26,25 +27,32 @@ from web3.types import Wei
 
 logger = logging.getLogger(__name__)
 
-# Stable per-key exclusion reasons — used for both the per-cycle log line and TOPUP_KEY_EXCLUDED.
-# This is the full answer set for "why wasn't key X topped up this cycle" (see _check_key_eligibility,
-# _take_up_to_allocation and the max_validators truncation in get_topup_candidates).
-_REASON_NOT_IN_BEACON_STATE = 'not_in_beacon_state'
-_REASON_NOT_ACTIVE = 'not_active'
-_REASON_SLASHED = 'slashed'
-_REASON_EXITING = 'exiting'
-_REASON_BEACON_CONSOLIDATION_TARGET = 'beacon_consolidation_target'
-_REASON_ALREADY_AT_TARGET_BALANCE = 'already_at_target_balance'
-_REASON_PENDING_CONSOLIDATION_BUS = 'pending_consolidation_bus'
-_REASON_OPERATOR_BUDGET_EXHAUSTED = 'operator_budget_exhausted'
-_REASON_TRUNCATED_BY_MAX_VALIDATORS = 'truncated_by_max_validators'
+
+class TopUpExclusionReason(StrEnum):
+    """Stable per-key exclusion reasons — used for both the per-cycle log line and TOPUP_KEY_EXCLUDED.
+
+    This is the full answer set for "why wasn't key X topped up this cycle" (see
+    _check_key_eligibility, _take_up_to_allocation and the max_validators truncation in
+    get_topup_candidates). A StrEnum member is a plain str at runtime, so it works directly as a
+    Prometheus label value and a JSON log field without a separate mapping.
+    """
+
+    NOT_IN_BEACON_STATE = 'not_in_beacon_state'
+    NOT_ACTIVE = 'not_active'
+    SLASHED = 'slashed'
+    EXITING = 'exiting'
+    BEACON_CONSOLIDATION_TARGET = 'beacon_consolidation_target'
+    ALREADY_AT_TARGET_BALANCE = 'already_at_target_balance'
+    PENDING_CONSOLIDATION_BUS = 'pending_consolidation_bus'
+    OPERATOR_BUDGET_EXHAUSTED = 'operator_budget_exhausted'
+    TRUNCATED_BY_MAX_VALIDATORS = 'truncated_by_max_validators'
 
 
 def _pubkey_hex(pubkey: bytes) -> str:
     return '0x' + pubkey.hex()
 
 
-def _log_excluded_key(module_id: int, operator_id: int, pubkey: str, reason: str) -> None:
+def _log_excluded_key(module_id: int, operator_id: int, pubkey: str, reason: TopUpExclusionReason) -> None:
     """One INFO line per excluded top-up candidate — the way to answer "why wasn't key X topped
     up this cycle" for a specific pubkey (grep logs by pubkey). `reason` is also counted in
     TOPUP_KEY_EXCLUDED for trend visibility without per-key cardinality.
@@ -179,7 +187,9 @@ class CMv2TopUpStrategy(TopUpStrategy):
         # Step 8: limit to max_validators — everything past the cap loses purely to cross-operator
         # competition for tx space, not to any eligibility problem of its own.
         for excluded in candidates[max_validators:]:
-            _log_excluded_key(module_id, excluded.operator_id, _pubkey_hex(excluded.pubkey), _REASON_TRUNCATED_BY_MAX_VALIDATORS)
+            _log_excluded_key(
+                module_id, excluded.operator_id, _pubkey_hex(excluded.pubkey), TopUpExclusionReason.TRUNCATED_BY_MAX_VALIDATORS
+            )
         candidates = candidates[:max_validators]
         # Set before the early return so metrics are always fresh after a selection run,
         # including the 0 case — avoids stale values from a previous cycle.
@@ -229,7 +239,7 @@ def _select_operator_candidates(
             continue
         if candidate.pubkey in pending_consolidation:
             consolidation_filtered += 1
-            _log_excluded_key(module_id, candidate.operator_id, key.key, _REASON_PENDING_CONSOLIDATION_BUS)
+            _log_excluded_key(module_id, candidate.operator_id, key.key, TopUpExclusionReason.PENDING_CONSOLIDATION_BUS)
             continue
         eligible.append(candidate)
 
@@ -243,31 +253,31 @@ def _check_key_eligibility(
     beacon_data: BeaconStateData,
     target_balance_gwei: int,
     min_top_up_gwei: int,
-) -> tuple[Optional[TopUpCandidate], Optional[str]]:
+) -> tuple[Optional[TopUpCandidate], Optional[TopUpExclusionReason]]:
     """Returns (candidate, exclusion_reason) — reason is set only when candidate is None."""
     pubkey = Web3.to_bytes(hexstr=HexStr(key.key))
 
     validator_index = beacon_data.pubkey_to_index.get(pubkey)
     if validator_index is None:
-        return None, _REASON_NOT_IN_BEACON_STATE
+        return None, TopUpExclusionReason.NOT_IN_BEACON_STATE
 
     fields = beacon_data.validators_fields[validator_index]
     pending = beacon_data.pending_deposits.get(pubkey, 0)
     current_epoch = beacon_data.slot // SLOTS_PER_EPOCH
 
     if not _is_active(fields, current_epoch):
-        return None, _REASON_NOT_ACTIVE
+        return None, TopUpExclusionReason.NOT_ACTIVE
     if _is_slashed(fields):
-        return None, _REASON_SLASHED
+        return None, TopUpExclusionReason.SLASHED
     if _is_exiting(fields):
-        return None, _REASON_EXITING
+        return None, TopUpExclusionReason.EXITING
     if validator_index in beacon_data.consolidation_targets:
-        return None, _REASON_BEACON_CONSOLIDATION_TARGET
+        return None, TopUpExclusionReason.BEACON_CONSOLIDATION_TARGET
     # Mirror TopUpGateway._evaluateTopUpLimit: a balance above (target - min) leaves less than the
     # minimum meaningful top-up, so the contract would return limit 0 — exclude such keys here too.
     max_eligible_balance_gwei = target_balance_gwei - min_top_up_gwei
     if fields.effective_balance + pending > max_eligible_balance_gwei:
-        return None, _REASON_ALREADY_AT_TARGET_BALANCE
+        return None, TopUpExclusionReason.ALREADY_AT_TARGET_BALANCE
 
     return (
         TopUpCandidate(
@@ -309,13 +319,15 @@ def _take_up_to_allocation(
         # remains — if that is < min it reverts. Checked before append so a sub-min tail is never selected.
         if remaining < min_top_up_gwei:
             for excluded in candidates[i:]:
-                _log_excluded_key(module_id, excluded.operator_id, _pubkey_hex(excluded.pubkey), _REASON_OPERATOR_BUDGET_EXHAUSTED)
+                _log_excluded_key(
+                    module_id, excluded.operator_id, _pubkey_hex(excluded.pubkey), TopUpExclusionReason.OPERATOR_BUDGET_EXHAUSTED
+                )
             break
         balance = beacon_data.validators_fields[c.validator_index].effective_balance
         topup_amount = target_balance_gwei - (balance + c.pending_balance)
         # Already at/near the cap — the contract tops up nothing (mirrors TopUpGateway._evaluateTopUpLimit).
         if topup_amount < min_top_up_gwei:
-            _log_excluded_key(module_id, c.operator_id, _pubkey_hex(c.pubkey), _REASON_ALREADY_AT_TARGET_BALANCE)
+            _log_excluded_key(module_id, c.operator_id, _pubkey_hex(c.pubkey), TopUpExclusionReason.ALREADY_AT_TARGET_BALANCE)
             continue
         result.append(c)
         # May go negative: the last selected validator absorbs the remaining budget as a partial top-up.

--- a/src/blockchain/topup/strategy.py
+++ b/src/blockchain/topup/strategy.py
@@ -7,6 +7,7 @@ from blockchain.consolidation.indexer import ConsolidationIndexer
 from blockchain.deposit_strategy.gas_price_calculator import GasPriceCalculator
 from blockchain.topup.types import TopUpProofData
 from blockchain.typings import Web3
+from metrics.metrics import TOPUP_GAS_FEE
 from providers.consensus import ConsensusClient
 from providers.keys_api import KeysAPIClient
 from web3.types import Wei
@@ -23,6 +24,8 @@ class TopUpStrategy(abc.ABC):
         current_gas_fee = self._gas_price_calculator.get_pending_base_fee()
         current_buffered_ether = self.w3.lido.lido.get_depositable_ether()
         recommended_gas_fee = self._gas_price_calculator.get_recommended_gas_fee()
+        TOPUP_GAS_FEE.labels('current_fee').set(current_gas_fee)
+        TOPUP_GAS_FEE.labels('recommended_fee').set(recommended_gas_fee)
 
         if current_buffered_ether > variables.MAX_BUFFERED_ETHERS:
             success = current_gas_fee <= variables.MAX_GAS_FEE

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -25,9 +25,16 @@ from blockchain.typings import Web3
 from metrics.metrics import (
     ACCOUNT_BALANCE,
     CURRENT_QUORUM_SIZE,
+    DEPOSITS_PAUSED,
     GUARDIAN_BALANCE,
+    MODULE_STATUS,
     MODULE_TX_SEND,
+    PHASE_OUTCOME,
     QUORUM,
+    QUORUM_STATE,
+    TOPUP_GAS_OK,
+    TOPUP_GATEWAY_PAUSED,
+    TOPUP_TX_SEND,
     UNEXPECTED_EXCEPTIONS,
 )
 from metrics.transport_message_metrics import message_metrics_filter
@@ -85,6 +92,15 @@ class PhaseOutcome(Enum):
         polls every block instead — a quorum can re-form on any block and we want to catch it fast.
         """
         return self in (PhaseOutcome.SENT, PhaseOutcome.WAIT_DISTANCE)
+
+
+_PHASE_OUTCOME_INT: dict[PhaseOutcome, int] = {
+    PhaseOutcome.SKIPPED: 0,
+    PhaseOutcome.SENT: 1,
+    PhaseOutcome.TX_FAILED: 2,
+    PhaseOutcome.WAIT_DISTANCE: 3,
+    PhaseOutcome.WAIT_QUORUM: 4,
+}
 
 
 def run_depositor(w3, keys_api: KeysAPIClient, cl: ConsensusClient):
@@ -212,6 +228,7 @@ class DepositorBot:
         # isDepositsPaused gates only deposits (depositBufferedEther), not top-ups — read once and use
         # it to drop deposit candidates this iteration while top-ups keep flowing (no need to wait it out).
         deposits_paused = self.w3.lido.deposit_security_module.is_deposits_paused()
+        DEPOSITS_PAUSED.set(int(deposits_paused))
         if deposits_paused:
             logger.info({'msg': 'Deposits are paused in DSM contract — only top-ups this iteration.'})
 
@@ -227,6 +244,9 @@ class DepositorBot:
             }
         )
         digests: list[StakingModuleInfo] = self.w3.lido.staking_router.get_all_staking_module_digests()
+        for digest in digests:
+            if digest['module_id'] in variables.DEPOSIT_MODULES_WHITELIST:
+                MODULE_STATUS.labels(digest['module_id']).set(digest['status'])
 
         # Phase A: seed deposits into 0x02 modules (deposits only — skipped while deposits are paused).
         if not deposits_paused:
@@ -238,7 +258,12 @@ class DepositorBot:
 
         # Phase B: top-ups (0x02) and full deposits (0x01). A paused TopUpGateway disables top-ups for
         # this iteration — same effect as ENABLE_TOP_UP=False (deposits still flow via _phase_full).
-        top_up_enabled = variables.ENABLE_TOP_UP and not self.w3.lido.topup_gateway.is_paused()
+        if variables.ENABLE_TOP_UP:
+            _gw_paused = self.w3.lido.topup_gateway.is_paused()
+            TOPUP_GATEWAY_PAUSED.set(int(_gw_paused))
+            top_up_enabled = not _gw_paused
+        else:
+            top_up_enabled = False
         if not top_up_enabled:
             if deposits_paused:
                 logger.info({'msg': 'Deposits paused and top-up disabled/paused — nothing to do.'})
@@ -273,34 +298,44 @@ class DepositorBot:
     def _resolve_quorum(self, module_id: int) -> QuorumState:
         """Read the guardian quorum and apply the retention window (replaces _is_in_cooldown)."""
         if self._get_quorum(module_id):
+            QUORUM_STATE.labels(module_id).set(2)
             return QuorumState.READY
         last = self._module_last_heart_beat[module_id]
         if datetime.now() - last <= timedelta(minutes=variables.QUORUM_RETENTION_MINUTES):
+            QUORUM_STATE.labels(module_id).set(1)
             return QuorumState.RETAINED
+        QUORUM_STATE.labels(module_id).set(0)
         return QuorumState.STALE
 
     def _try_deposit(self, module_id: int, phase: str) -> PhaseOutcome:
         """One seed/full deposit attempt on a module. SKIPPED → caller tries the next candidate."""
         if not self.w3.lido.deposit_security_module.is_min_deposit_distance_passed(module_id):
             logger.info({'msg': f'{phase}: min deposit distance not passed — wait next iteration.', 'module_id': module_id})
-            return PhaseOutcome.WAIT_DISTANCE
-        state = self._resolve_quorum(module_id)
-        if state is QuorumState.READY:
-            return PhaseOutcome.SENT if self._deposit_to_module(module_id) else PhaseOutcome.TX_FAILED
-        if state is QuorumState.RETAINED:
-            logger.info({'msg': f'{phase}: no quorum, retention active — wait next iteration.', 'module_id': module_id})
-            return PhaseOutcome.WAIT_QUORUM
-        logger.info({'msg': f'{phase}: no quorum, retention expired — try next module.', 'module_id': module_id})
-        return PhaseOutcome.SKIPPED
+            outcome = PhaseOutcome.WAIT_DISTANCE
+        else:
+            state = self._resolve_quorum(module_id)
+            if state is QuorumState.READY:
+                outcome = PhaseOutcome.SENT if self._deposit_to_module(module_id) else PhaseOutcome.TX_FAILED
+            elif state is QuorumState.RETAINED:
+                logger.info({'msg': f'{phase}: no quorum, retention active — wait next iteration.', 'module_id': module_id})
+                outcome = PhaseOutcome.WAIT_QUORUM
+            else:
+                logger.info({'msg': f'{phase}: no quorum, retention expired — try next module.', 'module_id': module_id})
+                outcome = PhaseOutcome.SKIPPED
+        PHASE_OUTCOME.labels(phase.split()[-1], module_id).set(_PHASE_OUTCOME_INT[outcome])
+        return outcome
 
     def _try_top_up(self, candidate: ModuleCandidate, phase: str) -> PhaseOutcome:
         """One top-up attempt on a 0x02 module (no quorum needed). SKIPPED → caller tries the next candidate."""
         module_id = candidate.module_id
         if not self.w3.lido.topup_gateway.is_block_distance_passed():
             logger.info({'msg': f'{phase}: top-up block distance not passed — wait next iteration.', 'module_id': module_id})
-            return PhaseOutcome.WAIT_DISTANCE
-        sent = self._top_up_to_module(module_id, candidate.address, candidate.allocation)
-        return PhaseOutcome.SENT if sent else PhaseOutcome.TX_FAILED
+            outcome = PhaseOutcome.WAIT_DISTANCE
+        else:
+            sent = self._top_up_to_module(module_id, candidate.address, candidate.allocation)
+            outcome = PhaseOutcome.SENT if sent else PhaseOutcome.TX_FAILED
+        PHASE_OUTCOME.labels(phase.split()[-1], module_id).set(_PHASE_OUTCOME_INT[outcome])
+        return outcome
 
     def _collect_candidates(
         self, digests: list[StakingModuleInfo], wc_type: int, allocated: list[int], new: list[int]
@@ -440,7 +475,9 @@ class DepositorBot:
             )
             return False
 
-        if not strategy.is_gas_price_ok():
+        gas_ok = strategy.is_gas_price_ok()
+        TOPUP_GAS_OK.labels(module_id).set(int(gas_ok))
+        if not gas_ok:
             logger.info({'msg': 'Gas price too high for top-up.', 'module_id': module_id})
             return False
 
@@ -472,6 +509,7 @@ class DepositorBot:
 
         tx = self.w3.lido.topup_gateway.top_up(module_id, proof_data)
         success = self.w3.transaction.check(tx) and self.w3.transaction.send(tx, False, 6)
+        TOPUP_TX_SEND.labels('success' if success else 'failure', module_id).inc()
         logger.info({'msg': f'Top-up tx result: {success}.', 'module_id': module_id})
         return success
 

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -4,7 +4,7 @@ import time
 from collections import defaultdict
 from collections.abc import Callable
 from datetime import datetime, timedelta
-from enum import Enum
+from enum import StrEnum
 from typing import Literal, NamedTuple, cast
 
 import variables
@@ -78,18 +78,17 @@ class ModuleCandidate(NamedTuple):
     allocation: Wei
 
 
-class QuorumState(Enum):
+class QuorumState(StrEnum):
+    """A StrEnum member is a plain str at runtime, so it can be passed straight into
+    QUORUM_STATE.state(...) (a prometheus_client.Enum, which stores state as its string value)
+    without a separate int-mapping table."""
+
     READY = 'ready'  # a guardian quorum exists now → deposit
     RETAINED = 'retained'  # no quorum now, but one existed within QUORUM_RETENTION_MINUTES → wait
     STALE = 'stale'  # no quorum and none recently → try the next module
 
 
-_QUORUM_STALE = 0
-_QUORUM_RETAINED = 1
-_QUORUM_READY = 2
-
-
-class PhaseOutcome(Enum):
+class PhaseOutcome(StrEnum):
     SENT = 'sent'  # deposit/top-up tx sent ok
     TX_FAILED = 'tx_failed'  # deposit/top-up tx failed
     WAIT_DISTANCE = 'wait_distance'  # blocked by min deposit / top-up block distance
@@ -107,16 +106,9 @@ class PhaseOutcome(Enum):
         return self in (PhaseOutcome.SENT, PhaseOutcome.WAIT_DISTANCE)
 
 
-_PHASE_OUTCOME_INT: dict[PhaseOutcome, int] = {
-    PhaseOutcome.SKIPPED: 0,
-    PhaseOutcome.SENT: 1,
-    PhaseOutcome.TX_FAILED: 2,
-    PhaseOutcome.WAIT_DISTANCE: 3,
-    PhaseOutcome.WAIT_QUORUM: 4,
-}
-
-_PHASE_A = 'A'
-_PHASE_B = 'B'
+class Phase(StrEnum):
+    A = 'A'  # seed deposits to 0x02 modules
+    B = 'B'  # top-ups (0x02) and full deposits (0x01)
 
 
 def run_depositor(w3, keys_api: KeysAPIClient, cl: ConsensusClient):
@@ -311,8 +303,12 @@ class DepositorBot:
         for module_id in variables.DEPOSIT_MODULES_WHITELIST:
             # Probe gas-price strategy purely for metrics — gas is re-checked right before the tx is sent.
             self._select_strategy(module_id).is_gas_price_ok(module_id)
-            quorum = self._get_quorum(module_id)
-            if quorum:
+            # Route through _resolve_quorum (not a bare _get_quorum call) so QUORUM_STATE is refreshed
+            # for every whitelisted module every cycle — otherwise a module that's never actually
+            # attempted this cycle (top-up-only cycle, lost the priority race, zero allocation) leaves
+            # QUORUM_STATE stale at whatever it last was.
+            state = self._resolve_quorum(module_id)
+            if state is QuorumState.READY:
                 self._module_last_heart_beat[module_id] = now
                 MODULE_QUORUM_LAST_SEEN_TIMESTAMP.labels(module_id).set(now.timestamp())
                 logger.info({'msg': 'Module has quorum — heartbeat refreshed.', 'module_id': module_id})
@@ -322,16 +318,16 @@ class DepositorBot:
     def _resolve_quorum(self, module_id: int) -> QuorumState:
         """Read the guardian quorum and apply the retention window (replaces _is_in_cooldown)."""
         if self._get_quorum(module_id):
-            QUORUM_STATE.labels(module_id).set(_QUORUM_READY)
+            QUORUM_STATE.labels(module_id).state(QuorumState.READY)
             return QuorumState.READY
         last = self._module_last_heart_beat[module_id]
         if datetime.now() - last <= timedelta(minutes=variables.QUORUM_RETENTION_MINUTES):
-            QUORUM_STATE.labels(module_id).set(_QUORUM_RETAINED)
+            QUORUM_STATE.labels(module_id).state(QuorumState.RETAINED)
             return QuorumState.RETAINED
-        QUORUM_STATE.labels(module_id).set(_QUORUM_STALE)
+        QUORUM_STATE.labels(module_id).state(QuorumState.STALE)
         return QuorumState.STALE
 
-    def _try_deposit(self, module_id: int, phase: Literal['A', 'B']) -> PhaseOutcome:
+    def _try_deposit(self, module_id: int, phase: Phase) -> PhaseOutcome:
         """One seed/full deposit attempt on a module. SKIPPED → caller tries the next candidate."""
         if not self.w3.lido.deposit_security_module.is_min_deposit_distance_passed(module_id):
             logger.info({'msg': f'Phase {phase}: min deposit distance not passed — wait next iteration.', 'module_id': module_id})
@@ -347,11 +343,11 @@ class DepositorBot:
                 logger.info({'msg': f'Phase {phase}: no quorum, retention expired — try next module.', 'module_id': module_id})
                 outcome = PhaseOutcome.SKIPPED
         now = time.time()
-        PHASE_OUTCOME.labels(phase, module_id).set(_PHASE_OUTCOME_INT[outcome])
+        PHASE_OUTCOME.labels(phase, module_id).state(outcome)
         PHASE_LAST_RUN_TIMESTAMP.labels(phase, module_id).set(now)
         return outcome
 
-    def _try_top_up(self, candidate: ModuleCandidate, phase: Literal['A', 'B']) -> PhaseOutcome:
+    def _try_top_up(self, candidate: ModuleCandidate, phase: Phase) -> PhaseOutcome:
         """One top-up attempt on a 0x02 module (no quorum needed). SKIPPED → caller tries the next candidate."""
         module_id = candidate.module_id
         if not self.w3.lido.topup_gateway.is_block_distance_passed():
@@ -360,7 +356,7 @@ class DepositorBot:
         else:
             outcome = self._top_up_to_module(module_id, candidate.address, candidate.allocation)
         now = time.time()
-        PHASE_OUTCOME.labels(phase, module_id).set(_PHASE_OUTCOME_INT[outcome])
+        PHASE_OUTCOME.labels(phase, module_id).state(outcome)
         PHASE_LAST_RUN_TIMESTAMP.labels(phase, module_id).set(now)
         return outcome
 
@@ -423,7 +419,7 @@ class DepositorBot:
         )
 
         for candidate in candidates:
-            outcome = self._try_deposit(candidate.module_id, _PHASE_A)
+            outcome = self._try_deposit(candidate.module_id, Phase.A)
             if outcome is not PhaseOutcome.SKIPPED:
                 return outcome
         return PhaseOutcome.SKIPPED
@@ -440,7 +436,7 @@ class DepositorBot:
         )
 
         for candidate in candidates:
-            outcome = self._try_deposit(candidate.module_id, _PHASE_B)
+            outcome = self._try_deposit(candidate.module_id, Phase.B)
             if outcome is not PhaseOutcome.SKIPPED:
                 return outcome
         return PhaseOutcome.SKIPPED
@@ -478,7 +474,7 @@ class DepositorBot:
         for candidate in candidates:
             # The consolidation indexer is guaranteed present and ready in the top-up path — validated
             # at startup when ENABLE_TOP_UP is on (otherwise the bot would not have started).
-            outcome = self._try_top_up(candidate, _PHASE_B) if candidate.wc_type == 2 else self._try_deposit(candidate.module_id, _PHASE_B)
+            outcome = self._try_top_up(candidate, Phase.B) if candidate.wc_type == 2 else self._try_deposit(candidate.module_id, Phase.B)
             if outcome is not PhaseOutcome.SKIPPED:
                 return outcome
         return PhaseOutcome.SKIPPED

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -27,8 +27,12 @@ from metrics.metrics import (
     ACCOUNT_BALANCE,
     BOT_LAST_CYCLE_TIMESTAMP,
     CURRENT_QUORUM_SIZE,
+    DEPOSITABLE_ETHER,
     DEPOSITS_PAUSED,
     GUARDIAN_BALANCE,
+    MODULE_ALLOCATION,
+    MODULE_QUORUM_LAST_SEEN_TIMESTAMP,
+    MODULE_STAKE,
     MODULE_STATUS,
     MODULE_TX_SEND,
     PHASE_LAST_RUN_TIMESTAMP,
@@ -158,6 +162,8 @@ class DepositorBot:
         self._consolidation_indexer = self._build_consolidation_indexer()
         now = datetime.now()
         self._module_last_heart_beat: dict[int, datetime] = {module_id: now for module_id in variables.DEPOSIT_MODULES_WHITELIST}
+        for module_id in variables.DEPOSIT_MODULES_WHITELIST:
+            MODULE_QUORUM_LAST_SEEN_TIMESTAMP.labels(module_id).set(now.timestamp())
 
         transports = []
 
@@ -233,6 +239,7 @@ class DepositorBot:
 
         # Read depositable ether once; if 0 — nothing to do this iteration.
         depositable_ether = self.w3.lido.lido.get_depositable_ether()
+        DEPOSITABLE_ETHER.set(depositable_ether)
         logger.info({'msg': 'Depositable ether.', 'value': depositable_ether})
         if depositable_ether == 0:
             logger.info({'msg': 'No depositable ether — skip iteration.'})
@@ -261,6 +268,7 @@ class DepositorBot:
         for digest in digests:
             if digest['module_id'] in variables.DEPOSIT_MODULES_WHITELIST:
                 MODULE_STATUS.labels(digest['module_id']).set(digest['status'])
+        self._publish_allocation_metrics(digests, seed_allocated, seed_new, 'seed')
 
         # Phase A: seed deposits into 0x02 modules (deposits only — skipped while deposits are paused).
         if not deposits_paused:
@@ -306,6 +314,7 @@ class DepositorBot:
             quorum = self._get_quorum(module_id)
             if quorum:
                 self._module_last_heart_beat[module_id] = now
+                MODULE_QUORUM_LAST_SEEN_TIMESTAMP.labels(module_id).set(now.timestamp())
                 logger.info({'msg': 'Module has quorum — heartbeat refreshed.', 'module_id': module_id})
             else:
                 logger.info({'msg': 'Module has no quorum right now.', 'module_id': module_id})
@@ -354,6 +363,19 @@ class DepositorBot:
         PHASE_OUTCOME.labels(phase, module_id).set(_PHASE_OUTCOME_INT[outcome])
         PHASE_LAST_RUN_TIMESTAMP.labels(phase, module_id).set(now)
         return outcome
+
+    def _publish_allocation_metrics(
+        self, digests: list[StakingModuleInfo], allocated: list[int], new: list[int], kind: Literal['seed', 'topup']
+    ) -> None:
+        """Expose allocation/stake for every whitelisted module, not just ones that make it into
+        candidates — a module excluded by zero allocation would otherwise keep showing whatever
+        outcome it last had, which misrepresents why it isn't being deposited to."""
+        for i, digest in enumerate(digests):
+            module_id = digest['module_id']
+            if module_id not in variables.DEPOSIT_MODULES_WHITELIST:
+                continue
+            MODULE_ALLOCATION.labels(module_id, kind).set(allocated[i])
+            MODULE_STAKE.labels(module_id, kind).set(new[i] - allocated[i])
 
     def _collect_candidates(
         self, digests: list[StakingModuleInfo], wc_type: int, allocated: list[int], new: list[int]
@@ -438,6 +460,7 @@ class DepositorBot:
         """
         sr_v4 = cast(StakingRouterContractV4, self.w3.lido.staking_router)
         _total, topup_allocated, topup_new = sr_v4.get_deposit_allocations(depositable_ether, is_top_up=True)
+        self._publish_allocation_metrics(digests, topup_allocated, topup_new, 'topup')
 
         # Top-ups (0x02) from is_top_up=True allocations always; full deposits (0x01) from seed
         # (is_top_up=False) allocations only while deposits are not paused.

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -1,10 +1,11 @@
 # pyright: reportTypedDictNotRequiredAccess=false
 import logging
+import time
 from collections import defaultdict
 from collections.abc import Callable
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import NamedTuple, cast
+from typing import Literal, NamedTuple, cast
 
 import variables
 from blockchain.consolidation.indexer import ConsolidationIndexer
@@ -24,15 +25,18 @@ from blockchain.topup.strategy import TopUpStrategy
 from blockchain.typings import Web3
 from metrics.metrics import (
     ACCOUNT_BALANCE,
+    BOT_LAST_CYCLE_TIMESTAMP,
     CURRENT_QUORUM_SIZE,
     DEPOSITS_PAUSED,
     GUARDIAN_BALANCE,
     MODULE_STATUS,
     MODULE_TX_SEND,
+    PHASE_LAST_RUN_TIMESTAMP,
     PHASE_OUTCOME,
     QUORUM,
     QUORUM_STATE,
     TOPUP_GAS_OK,
+    TOPUP_GAS_OK_LAST_RUN_TIMESTAMP,
     TOPUP_GATEWAY_PAUSED,
     TOPUP_TX_SEND,
     UNEXPECTED_EXCEPTIONS,
@@ -101,6 +105,9 @@ _PHASE_OUTCOME_INT: dict[PhaseOutcome, int] = {
     PhaseOutcome.WAIT_DISTANCE: 3,
     PhaseOutcome.WAIT_QUORUM: 4,
 }
+
+_PHASE_A = 'A'
+_PHASE_B = 'B'
 
 
 def run_depositor(w3, keys_api: KeysAPIClient, cl: ConsensusClient):
@@ -191,6 +198,7 @@ class DepositorBot:
         self._check_balance()
 
         result = self._execute_actual()
+        BOT_LAST_CYCLE_TIMESTAMP.set(time.time())
         logger.info({'msg': 'Depositor iteration finished.', 'value': result})
         return result
 
@@ -213,6 +221,11 @@ class DepositorBot:
         # Step 0: refresh quorum + gas metrics for all whitelisted modules.
         self._refresh_modules_state()
 
+        # isDepositsPaused is read before the depositable-ether guard so DEPOSITS_PAUSED is always
+        # current — the pause state is important to monitor even when the buffer is empty.
+        deposits_paused = self.w3.lido.deposit_security_module.is_deposits_paused()
+        DEPOSITS_PAUSED.set(int(deposits_paused))
+
         # Read depositable ether once; if 0 — nothing to do this iteration.
         depositable_ether = self.w3.lido.lido.get_depositable_ether()
         logger.info({'msg': 'Depositable ether.', 'value': depositable_ether})
@@ -225,10 +238,6 @@ class DepositorBot:
         if not self._common_preconditions():
             return False
 
-        # isDepositsPaused gates only deposits (depositBufferedEther), not top-ups — read once and use
-        # it to drop deposit candidates this iteration while top-ups keep flowing (no need to wait it out).
-        deposits_paused = self.w3.lido.deposit_security_module.is_deposits_paused()
-        DEPOSITS_PAUSED.set(int(deposits_paused))
         if deposits_paused:
             logger.info({'msg': 'Deposits are paused in DSM contract — only top-ups this iteration.'})
 
@@ -307,34 +316,37 @@ class DepositorBot:
         QUORUM_STATE.labels(module_id).set(0)
         return QuorumState.STALE
 
-    def _try_deposit(self, module_id: int, phase: str) -> PhaseOutcome:
+    def _try_deposit(self, module_id: int, phase: Literal['A', 'B']) -> PhaseOutcome:
         """One seed/full deposit attempt on a module. SKIPPED → caller tries the next candidate."""
         if not self.w3.lido.deposit_security_module.is_min_deposit_distance_passed(module_id):
-            logger.info({'msg': f'{phase}: min deposit distance not passed — wait next iteration.', 'module_id': module_id})
+            logger.info({'msg': f'Phase {phase}: min deposit distance not passed — wait next iteration.', 'module_id': module_id})
             outcome = PhaseOutcome.WAIT_DISTANCE
         else:
             state = self._resolve_quorum(module_id)
             if state is QuorumState.READY:
                 outcome = PhaseOutcome.SENT if self._deposit_to_module(module_id) else PhaseOutcome.TX_FAILED
             elif state is QuorumState.RETAINED:
-                logger.info({'msg': f'{phase}: no quorum, retention active — wait next iteration.', 'module_id': module_id})
+                logger.info({'msg': f'Phase {phase}: no quorum, retention active — wait next iteration.', 'module_id': module_id})
                 outcome = PhaseOutcome.WAIT_QUORUM
             else:
-                logger.info({'msg': f'{phase}: no quorum, retention expired — try next module.', 'module_id': module_id})
+                logger.info({'msg': f'Phase {phase}: no quorum, retention expired — try next module.', 'module_id': module_id})
                 outcome = PhaseOutcome.SKIPPED
-        PHASE_OUTCOME.labels(phase.split()[-1], module_id).set(_PHASE_OUTCOME_INT[outcome])
+        now = time.time()
+        PHASE_OUTCOME.labels(phase, module_id).set(_PHASE_OUTCOME_INT[outcome])
+        PHASE_LAST_RUN_TIMESTAMP.labels(phase, module_id).set(now)
         return outcome
 
-    def _try_top_up(self, candidate: ModuleCandidate, phase: str) -> PhaseOutcome:
+    def _try_top_up(self, candidate: ModuleCandidate, phase: Literal['A', 'B']) -> PhaseOutcome:
         """One top-up attempt on a 0x02 module (no quorum needed). SKIPPED → caller tries the next candidate."""
         module_id = candidate.module_id
         if not self.w3.lido.topup_gateway.is_block_distance_passed():
-            logger.info({'msg': f'{phase}: top-up block distance not passed — wait next iteration.', 'module_id': module_id})
+            logger.info({'msg': f'Phase {phase}: top-up block distance not passed — wait next iteration.', 'module_id': module_id})
             outcome = PhaseOutcome.WAIT_DISTANCE
         else:
-            sent = self._top_up_to_module(module_id, candidate.address, candidate.allocation)
-            outcome = PhaseOutcome.SENT if sent else PhaseOutcome.TX_FAILED
-        PHASE_OUTCOME.labels(phase.split()[-1], module_id).set(_PHASE_OUTCOME_INT[outcome])
+            outcome = self._top_up_to_module(module_id, candidate.address, candidate.allocation)
+        now = time.time()
+        PHASE_OUTCOME.labels(phase, module_id).set(_PHASE_OUTCOME_INT[outcome])
+        PHASE_LAST_RUN_TIMESTAMP.labels(phase, module_id).set(now)
         return outcome
 
     def _collect_candidates(
@@ -383,7 +395,7 @@ class DepositorBot:
         )
 
         for candidate in candidates:
-            outcome = self._try_deposit(candidate.module_id, 'Phase A')
+            outcome = self._try_deposit(candidate.module_id, _PHASE_A)
             if outcome is not PhaseOutcome.SKIPPED:
                 return outcome
         return PhaseOutcome.SKIPPED
@@ -400,7 +412,7 @@ class DepositorBot:
         )
 
         for candidate in candidates:
-            outcome = self._try_deposit(candidate.module_id, 'Phase B')
+            outcome = self._try_deposit(candidate.module_id, _PHASE_B)
             if outcome is not PhaseOutcome.SKIPPED:
                 return outcome
         return PhaseOutcome.SKIPPED
@@ -437,10 +449,7 @@ class DepositorBot:
         for candidate in candidates:
             # The consolidation indexer is guaranteed present and ready in the top-up path — validated
             # at startup when ENABLE_TOP_UP is on (otherwise the bot would not have started).
-            if candidate.wc_type == 2:
-                outcome = self._try_top_up(candidate, 'Phase B')
-            else:
-                outcome = self._try_deposit(candidate.module_id, 'Phase B')
+            outcome = self._try_top_up(candidate, _PHASE_B) if candidate.wc_type == 2 else self._try_deposit(candidate.module_id, _PHASE_B)
             if outcome is not PhaseOutcome.SKIPPED:
                 return outcome
         return PhaseOutcome.SKIPPED
@@ -462,7 +471,7 @@ class DepositorBot:
         self._flashbots_works = not self._flashbots_works or success
         return success
 
-    def _top_up_to_module(self, module_id: int, module_address: str, module_allocation: Wei) -> bool:
+    def _top_up_to_module(self, module_id: int, module_address: str, module_allocation: Wei) -> PhaseOutcome:
         module_type = self.w3.lido.staking_module(module_id).get_type()
         strategy = self._select_topup_strategy(module_type)
         if strategy is None:
@@ -473,13 +482,14 @@ class DepositorBot:
                     'type': module_type.rstrip(b'\x00').decode('ascii', errors='replace'),
                 }
             )
-            return False
+            return PhaseOutcome.SKIPPED
 
         gas_ok = strategy.is_gas_price_ok()
         TOPUP_GAS_OK.labels(module_id).set(int(gas_ok))
+        TOPUP_GAS_OK_LAST_RUN_TIMESTAMP.labels(module_id).set(time.time())
         if not gas_ok:
             logger.info({'msg': 'Gas price too high for top-up.', 'module_id': module_id})
-            return False
+            return PhaseOutcome.SKIPPED
 
         max_validators = min(
             variables.MAX_VALIDATORS_PER_TOP_UP,
@@ -505,13 +515,13 @@ class DepositorBot:
         )
         if not proof_data:
             logger.info({'msg': 'No top-up candidates.', 'module_id': module_id})
-            return False
+            return PhaseOutcome.SKIPPED
 
         tx = self.w3.lido.topup_gateway.top_up(module_id, proof_data)
         success = self.w3.transaction.check(tx) and self.w3.transaction.send(tx, False, 6)
         TOPUP_TX_SEND.labels('success' if success else 'failure', module_id).inc()
         logger.info({'msg': f'Top-up tx result: {success}.', 'module_id': module_id})
-        return success
+        return PhaseOutcome.SENT if success else PhaseOutcome.TX_FAILED
 
     def _select_topup_strategy(self, module_type: bytes) -> TopUpStrategy | None:
         if module_type == MODULE_TYPE_CMV2:

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -80,6 +80,11 @@ class QuorumState(Enum):
     STALE = 'stale'  # no quorum and none recently → try the next module
 
 
+_QUORUM_STALE = 0
+_QUORUM_RETAINED = 1
+_QUORUM_READY = 2
+
+
 class PhaseOutcome(Enum):
     SENT = 'sent'  # deposit/top-up tx sent ok
     TX_FAILED = 'tx_failed'  # deposit/top-up tx failed
@@ -272,6 +277,7 @@ class DepositorBot:
             TOPUP_GATEWAY_PAUSED.set(int(_gw_paused))
             top_up_enabled = not _gw_paused
         else:
+            TOPUP_GATEWAY_PAUSED.set(0)
             top_up_enabled = False
         if not top_up_enabled:
             if deposits_paused:
@@ -307,13 +313,13 @@ class DepositorBot:
     def _resolve_quorum(self, module_id: int) -> QuorumState:
         """Read the guardian quorum and apply the retention window (replaces _is_in_cooldown)."""
         if self._get_quorum(module_id):
-            QUORUM_STATE.labels(module_id).set(2)
+            QUORUM_STATE.labels(module_id).set(_QUORUM_READY)
             return QuorumState.READY
         last = self._module_last_heart_beat[module_id]
         if datetime.now() - last <= timedelta(minutes=variables.QUORUM_RETENTION_MINUTES):
-            QUORUM_STATE.labels(module_id).set(1)
+            QUORUM_STATE.labels(module_id).set(_QUORUM_RETAINED)
             return QuorumState.RETAINED
-        QUORUM_STATE.labels(module_id).set(0)
+        QUORUM_STATE.labels(module_id).set(_QUORUM_STALE)
         return QuorumState.STALE
 
     def _try_deposit(self, module_id: int, phase: Literal['A', 'B']) -> PhaseOutcome:

--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -152,7 +152,7 @@ TOPUP_TX_SEND = Counter(
 )
 
 TOPUP_GAS_OK = Gauge(
-    'is_topup_gas_ok',
+    'topup_gas_ok',
     '1 when gas price is acceptable for a top-up transaction.',
     ['module_id'],
     namespace=PROMETHEUS_PREFIX,

--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -53,26 +53,6 @@ CURRENT_QUORUM_SIZE = Gauge(
     namespace=PROMETHEUS_PREFIX,
 )
 
-DEPOSITABLE_ETHER = Gauge(
-    'depositable_ether',
-    'Depositable Ether',
-    namespace=PROMETHEUS_PREFIX,
-)
-
-POSSIBLE_DEPOSITS_AMOUNT = Gauge(
-    'possible_deposits_amount',
-    'Possible deposits amount.',
-    ['module_id'],
-    namespace=PROMETHEUS_PREFIX,
-)
-
-IS_DEPOSITABLE = Gauge(
-    'is_depositable',
-    'Represents is_depositable check.',
-    ['module_id'],
-    namespace=PROMETHEUS_PREFIX,
-)
-
 QUORUM = Gauge(
     'quorum',
     'Represents if quorum could be collected.',
@@ -83,13 +63,6 @@ QUORUM = Gauge(
 GAS_OK = Gauge(
     'is_gas_ok',
     'Represents is_gas_ok check.',
-    ['module_id'],
-    namespace=PROMETHEUS_PREFIX,
-)
-
-DEPOSIT_AMOUNT_OK = Gauge(
-    'is_deposit_amount_ok',
-    'Represents is_deposit_amount_ok check.',
     ['module_id'],
     namespace=PROMETHEUS_PREFIX,
 )
@@ -131,7 +104,7 @@ DEPOSITS_PAUSED = Gauge(
 
 TOPUP_GATEWAY_PAUSED = Gauge(
     'topup_gateway_paused',
-    '1 when TopUpGateway.isPaused() is true. Only set when ENABLE_TOP_UP=true.',
+    '1 when TopUpGateway.isPaused() is true. 0 when ENABLE_TOP_UP=false.',
     namespace=PROMETHEUS_PREFIX,
 )
 
@@ -148,6 +121,13 @@ MODULE_STATUS = Gauge(
 PHASE_OUTCOME = Gauge(
     'phase_outcome',
     'Last outcome for a module in a given phase. 0=skipped 1=sent 2=tx_failed 3=wait_distance 4=wait_quorum',
+    ['phase', 'module_id'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
+PHASE_LAST_RUN_TIMESTAMP = Gauge(
+    'phase_last_run_timestamp_seconds',
+    'Unix timestamp of the last time a module was processed in a given phase.',
     ['phase', 'module_id'],
     namespace=PROMETHEUS_PREFIX,
 )
@@ -178,9 +158,23 @@ TOPUP_GAS_OK = Gauge(
     namespace=PROMETHEUS_PREFIX,
 )
 
+TOPUP_GAS_OK_LAST_RUN_TIMESTAMP = Gauge(
+    'topup_gas_ok_last_run_timestamp_seconds',
+    'Unix timestamp of the last time the top-up gas check ran for a module.',
+    ['module_id'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
 TOPUP_CANDIDATES_SELECTED = Gauge(
     'topup_candidates_selected',
     'Validators selected for top-up after eligibility filtering.',
+    ['module_id'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
+TOPUP_CANDIDATES_LAST_RUN_TIMESTAMP = Gauge(
+    'topup_candidates_last_run_timestamp_seconds',
+    'Unix timestamp of the last time candidate selection ran for a module.',
     ['module_id'],
     namespace=PROMETHEUS_PREFIX,
 )
@@ -211,6 +205,28 @@ CONSOLIDATION_CURSOR_LAG = Gauge(
     'Blocks between the consolidation indexer cursor and the current finalized block.',
     namespace=PROMETHEUS_PREFIX,
 )
+
+# --- Bot liveness ---
+
+BOT_LAST_CYCLE_TIMESTAMP = Gauge(
+    'bot_last_cycle_timestamp_seconds',
+    'Unix timestamp of the last time the depositor bot completed a full iteration.',
+    namespace=PROMETHEUS_PREFIX,
+)
+
+# --- Pre-initialize series that must exist even before the first bot cycle ---
+
+# Absent counter series cause rate() to return "no data" instead of 0, masking alerts.
+for _module_id in DEPOSIT_MODULES_WHITELIST:
+    TOPUP_TX_SEND.labels('success', _module_id).inc(0)
+    TOPUP_TX_SEND.labels('failure', _module_id).inc(0)
+
+# Absent Gauges are indistinguishable from "feature disabled"; 0 is more honest.
+DEPOSITS_PAUSED.set(0)
+TOPUP_GATEWAY_PAUSED.set(0)
+CONSOLIDATION_PENDING_BATCHES.set(0)
+CONSOLIDATION_PENDING_PUBKEYS.set(0)
+CONSOLIDATION_CURSOR_LAG.set(0)
 
 INFO = Info(name='build', documentation='Info metric', namespace=PROMETHEUS_PREFIX)
 CONVERTED_PUBLIC_ENV = {k: str(v) for k, v in PUBLIC_ENV_VARS.items()}

--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -121,6 +121,97 @@ MODULES = Gauge('modules', 'Modules gauge', ['module_id'], namespace=PROMETHEUS_
 for module_id in DEPOSIT_MODULES_WHITELIST:
     MODULES.labels(module_id).set(1)
 
+# --- Deposit / top-up gate state ---
+
+DEPOSITS_PAUSED = Gauge(
+    'deposits_paused',
+    '1 when DSM.isDepositsPaused() is true.',
+    namespace=PROMETHEUS_PREFIX,
+)
+
+TOPUP_GATEWAY_PAUSED = Gauge(
+    'topup_gateway_paused',
+    '1 when TopUpGateway.isPaused() is true. Only set when ENABLE_TOP_UP=true.',
+    namespace=PROMETHEUS_PREFIX,
+)
+
+MODULE_STATUS = Gauge(
+    'module_status',
+    'Staking module status from StakingRouter digest. 0=active 1=deposits_paused 2=stopped',
+    ['module_id'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
+# --- Phase outcomes ---
+# Values: 0=skipped 1=sent 2=tx_failed 3=wait_distance 4=wait_quorum
+
+PHASE_OUTCOME = Gauge(
+    'phase_outcome',
+    'Last outcome for a module in a given phase. 0=skipped 1=sent 2=tx_failed 3=wait_distance 4=wait_quorum',
+    ['phase', 'module_id'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
+# --- Quorum state per module ---
+# Values: 0=stale 1=retained 2=ready
+
+QUORUM_STATE = Gauge(
+    'quorum_state',
+    'Guardian quorum state per module. 0=stale 1=retained 2=ready',
+    ['module_id'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
+# --- Top-up transactions ---
+
+TOPUP_TX_SEND = Counter(
+    'topup_transactions',
+    'Top-up transactions attempted by the depositor bot.',
+    ['status', 'module_id'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
+TOPUP_GAS_OK = Gauge(
+    'is_topup_gas_ok',
+    '1 when gas price is acceptable for a top-up transaction.',
+    ['module_id'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
+TOPUP_CANDIDATES_SELECTED = Gauge(
+    'topup_candidates_selected',
+    'Validators selected for top-up after eligibility filtering.',
+    ['module_id'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
+TOPUP_CONSOLIDATION_FILTERED = Gauge(
+    'topup_consolidation_filtered_keys',
+    'Keys excluded from top-up because they appear in a pending ConsolidationBus request.',
+    ['module_id'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
+# --- Consolidation indexer ---
+
+CONSOLIDATION_PENDING_BATCHES = Gauge(
+    'consolidation_pending_batches',
+    'Open ConsolidationBus batches in the in-memory store.',
+    namespace=PROMETHEUS_PREFIX,
+)
+
+CONSOLIDATION_PENDING_PUBKEYS = Gauge(
+    'consolidation_pending_pubkeys',
+    'Pubkeys currently excluded from top-up due to pending consolidation.',
+    namespace=PROMETHEUS_PREFIX,
+)
+
+CONSOLIDATION_CURSOR_LAG = Gauge(
+    'consolidation_cursor_lag_blocks',
+    'Blocks between the consolidation indexer cursor and the current finalized block.',
+    namespace=PROMETHEUS_PREFIX,
+)
+
 INFO = Info(name='build', documentation='Info metric', namespace=PROMETHEUS_PREFIX)
 CONVERTED_PUBLIC_ENV = {k: str(v) for k, v in PUBLIC_ENV_VARS.items()}
 INFO.info(CONVERTED_PUBLIC_ENV)

--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -1,4 +1,4 @@
-from prometheus_client.metrics import Counter, Gauge, Info
+from prometheus_client.metrics import Counter, Enum, Gauge, Info
 from variables import DEPOSIT_MODULES_WHITELIST, PROMETHEUS_PREFIX, PUBLIC_ENV_VARS
 
 GAS_FEE = Gauge(
@@ -116,12 +116,14 @@ MODULE_STATUS = Gauge(
 )
 
 # --- Phase outcomes ---
-# Values: 0=skipped 1=sent 2=tx_failed 3=wait_distance 4=wait_quorum
+# States must stay in sync with bots.depositor.PhaseOutcome's values — kept as plain strings here
+# rather than imported, since metrics.py has no dependency on bots/ (importing it back would cycle).
 
-PHASE_OUTCOME = Gauge(
+PHASE_OUTCOME = Enum(
     'phase_outcome',
-    'Last outcome for a module in a given phase. 0=skipped 1=sent 2=tx_failed 3=wait_distance 4=wait_quorum',
+    'Last outcome for a module in a given phase.',
     ['phase', 'module_id'],
+    states=['skipped', 'sent', 'tx_failed', 'wait_distance', 'wait_quorum'],
     namespace=PROMETHEUS_PREFIX,
 )
 
@@ -133,12 +135,13 @@ PHASE_LAST_RUN_TIMESTAMP = Gauge(
 )
 
 # --- Quorum state per module ---
-# Values: 0=stale 1=retained 2=ready
+# States must stay in sync with bots.depositor.QuorumState's values (see note on PHASE_OUTCOME).
 
-QUORUM_STATE = Gauge(
+QUORUM_STATE = Enum(
     'quorum_state',
-    'Guardian quorum state per module. 0=stale 1=retained 2=ready',
+    'Guardian quorum state per module.',
     ['module_id'],
+    states=['stale', 'retained', 'ready'],
     namespace=PROMETHEUS_PREFIX,
 )
 

--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -186,6 +186,17 @@ TOPUP_CONSOLIDATION_FILTERED = Gauge(
     namespace=PROMETHEUS_PREFIX,
 )
 
+# Per-key exclusion reasons. Low cardinality (module_id x ~9 reasons) — use this for trends
+# ("why is exclusion rate up"); use the matching per-key log line ('Top-up candidate excluded.')
+# to answer "why wasn't key X topped up", since pubkey-labeled Prometheus series would explode
+# cardinality. See CMv2TopUpStrategy for the reason values.
+TOPUP_KEY_EXCLUDED = Counter(
+    'topup_key_excluded',
+    'Top-up candidate keys excluded from a top-up tx, by reason.',
+    ['module_id', 'reason'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
 # --- Consolidation indexer ---
 
 CONSOLIDATION_PENDING_BATCHES = Gauge(
@@ -214,12 +225,90 @@ BOT_LAST_CYCLE_TIMESTAMP = Gauge(
     namespace=PROMETHEUS_PREFIX,
 )
 
+# --- Depositable ether ---
+
+DEPOSITABLE_ETHER = Gauge(
+    'depositable_ether',
+    'Depositable Ether, read once per bot iteration.',
+    namespace=PROMETHEUS_PREFIX,
+)
+
+# --- Module priority / allocation ---
+# kind: 'seed' (is_top_up=False allocation, used by Phase A 0x02 and Phase B 0x01) or
+# 'topup' (is_top_up=True allocation, used by Phase B 0x02). Published for every whitelisted
+# module each cycle, including ones excluded from candidates (allocation == 0) — otherwise a
+# module with no allocation this cycle keeps showing its last successful outcome forever.
+
+MODULE_ALLOCATION = Gauge(
+    'module_allocation_wei',
+    'Ether allocation computed by the StakingRouter allocation algorithm for a module this cycle. 0 means the module got no allocation.',
+    ['module_id', 'kind'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
+MODULE_STAKE = Gauge(
+    'module_stake_wei',
+    'Priority ordering key (new - allocated) for a module; lower value is tried first.',
+    ['module_id', 'kind'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
+# --- Quorum retention ---
+
+MODULE_QUORUM_LAST_SEEN_TIMESTAMP = Gauge(
+    'module_quorum_last_seen_timestamp_seconds',
+    'Unix timestamp of the last time a guardian quorum was observed for a module. '
+    'quorum_state turns stale QUORUM_RETENTION_MINUTES after this.',
+    ['module_id'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
+# --- Top-up gas ---
+
+TOPUP_GAS_FEE = Gauge(
+    'topup_gas_fee_wei',
+    'Gas fee observed during the top-up gas price check (network-wide, not per-module).',
+    ['type'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
+# --- Keys API freshness ---
+
+KEYS_API_BLOCK_NUMBER = Gauge(
+    'keys_api_block_number',
+    'elBlockSnapshot.blockNumber from the last successful Keys API response.',
+    namespace=PROMETHEUS_PREFIX,
+)
+
+KEYS_API_BLOCK_AGE_SECONDS = Gauge(
+    'keys_api_block_age_seconds',
+    'Seconds between elBlockSnapshot.timestamp of the last Keys API response and now.',
+    namespace=PROMETHEUS_PREFIX,
+)
+
+# --- Execution layer freshness ---
+
+EL_HEAD_BLOCK_NUMBER = Gauge(
+    'el_head_block_number',
+    'Latest EL block number seen by the Executor.',
+    namespace=PROMETHEUS_PREFIX,
+)
+
+EL_HEAD_BLOCK_AGE_SECONDS = Gauge(
+    'el_head_block_age_seconds',
+    'Seconds between the latest EL block timestamp and now — detects a stalled/lagging RPC.',
+    namespace=PROMETHEUS_PREFIX,
+)
+
 # --- Pre-initialize series that must exist even before the first bot cycle ---
 
 # Absent counter series cause rate() to return "no data" instead of 0, masking alerts.
 for _module_id in DEPOSIT_MODULES_WHITELIST:
     TOPUP_TX_SEND.labels('success', _module_id).inc(0)
     TOPUP_TX_SEND.labels('failure', _module_id).inc(0)
+    for _kind in ('seed', 'topup'):
+        MODULE_ALLOCATION.labels(_module_id, _kind).set(0)
+        MODULE_STAKE.labels(_module_id, _kind).set(0)
 
 # Absent Gauges are indistinguishable from "feature disabled"; 0 is more honest.
 DEPOSITS_PAUSED.set(0)
@@ -227,6 +316,12 @@ TOPUP_GATEWAY_PAUSED.set(0)
 CONSOLIDATION_PENDING_BATCHES.set(0)
 CONSOLIDATION_PENDING_PUBKEYS.set(0)
 CONSOLIDATION_CURSOR_LAG.set(0)
+TOPUP_GAS_FEE.labels('current_fee').set(0)
+TOPUP_GAS_FEE.labels('recommended_fee').set(0)
+KEYS_API_BLOCK_NUMBER.set(0)
+KEYS_API_BLOCK_AGE_SECONDS.set(0)
+EL_HEAD_BLOCK_NUMBER.set(0)
+EL_HEAD_BLOCK_AGE_SECONDS.set(0)
 
 INFO = Info(name='build', documentation='Info metric', namespace=PROMETHEUS_PREFIX)
 CONVERTED_PUBLIC_ENV = {k: str(v) for k, v in PUBLIC_ENV_VARS.items()}

--- a/src/providers/keys_api.py
+++ b/src/providers/keys_api.py
@@ -1,7 +1,9 @@
 import logging
+import time
 from dataclasses import dataclass
 from typing import NamedTuple
 
+from metrics.metrics import KEYS_API_BLOCK_AGE_SECONDS, KEYS_API_BLOCK_NUMBER
 from prometheus_client import Histogram
 from providers.http_provider import HTTPProvider, data_is_dict
 
@@ -71,12 +73,13 @@ class KeysAPIClient(HTTPProvider):
         Get all used (deposited) keys for a staking module.
         GET /v1/modules/{module_id}/keys?used=true
         """
-        data, _ = self._get(
+        data, meta = self._get(
             endpoint='v1/modules/{}/keys',
             path_params=[module_id],
             query_params={'used': 'true'},
             retval_validator=data_is_dict,
         )
+        self._report_freshness(meta)
         keys = [LidoKey.from_response(**k) for k in data['keys']]
         logger.info(
             {
@@ -86,6 +89,20 @@ class KeysAPIClient(HTTPProvider):
             }
         )
         return keys
+
+    @staticmethod
+    def _report_freshness(meta: dict) -> None:
+        """meta wraps the response's top-level `meta.elBlockSnapshot` (see SRModuleKeyListResponse
+        in lidofinance/lido-keys-api). Defensive .get() chain: an API schema change should degrade
+        to a stale gauge, not break the deposit path.
+        """
+        snapshot = meta.get('meta', {}).get('elBlockSnapshot', {})
+        block_number = snapshot.get('blockNumber')
+        block_timestamp = snapshot.get('timestamp')
+        if block_number is not None:
+            KEYS_API_BLOCK_NUMBER.set(block_number)
+        if block_timestamp is not None:
+            KEYS_API_BLOCK_AGE_SECONDS.set(max(0, time.time() - block_timestamp))
 
     def get_module_operator_used_keys(self, module_id: int, operator_ids: list[int]) -> dict[int, list[LidoKey]]:
         """

--- a/tests/blockchain/test_cmv2_strategy.py
+++ b/tests/blockchain/test_cmv2_strategy.py
@@ -272,7 +272,7 @@ def test_check_key_eligibility_returns_candidate(top_up_proof_fixtures):
     witness = top_up_proof_fixtures['validator_witnesses'][0]
     key = _make_key(witness['pubkey'], 7, 11)
 
-    candidate = _check_key_eligibility(key, beacon_data, set(), TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI)
+    candidate = _check_key_eligibility(key, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI)
 
     assert candidate == TopUpCandidate(
         validator_index=int(witness['validatorIndex']),
@@ -291,35 +291,32 @@ def test_check_key_eligibility_rejects_invalid_cases(top_up_proof_fixtures):
     validator_index = int(witness['validatorIndex'])
     key = _make_key(witness['pubkey'], 7, 11)
 
-    assert _check_key_eligibility(_make_key('0x' + '33' * 48, 7, 11), beacon_data, set(), TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI) is None
-
-    # key participating in a pending ConsolidationBus request is excluded
-    assert _check_key_eligibility(key, beacon_data, {pubkey}, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI) is None
+    assert _check_key_eligibility(_make_key('0x' + '33' * 48, 7, 11), beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI) is None
 
     beacon_data.consolidation_targets = {validator_index}
-    assert _check_key_eligibility(key, beacon_data, set(), TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI) is None
+    assert _check_key_eligibility(key, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI) is None
     beacon_data.consolidation_targets = set()
 
     fields = beacon_data.validators_fields[validator_index]
 
     beacon_data.validators_fields[validator_index] = fields._replace(slashed=True)
-    assert _check_key_eligibility(key, beacon_data, set(), TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI) is None
+    assert _check_key_eligibility(key, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI) is None
 
     beacon_data.validators_fields[validator_index] = fields._replace(exit_epoch=1)
-    assert _check_key_eligibility(key, beacon_data, set(), TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI) is None
+    assert _check_key_eligibility(key, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI) is None
 
     beacon_data.validators_fields[validator_index] = fields._replace(
         exit_epoch=FAR_FUTURE_EPOCH,
         activation_epoch=beacon_data.slot + 1,
     )
-    assert _check_key_eligibility(key, beacon_data, set(), TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI) is None
+    assert _check_key_eligibility(key, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI) is None
 
     # balance exactly at the max eligible threshold + any pending pushes it over -> excluded
     beacon_data.validators_fields[validator_index] = fields._replace(
         effective_balance=MAX_ELIGIBLE_BALANCE_GWEI,
     )
     beacon_data.pending_deposits = {pubkey: 1}
-    assert _check_key_eligibility(key, beacon_data, set(), TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI) is None
+    assert _check_key_eligibility(key, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI) is None
 
 
 @pytest.mark.unit
@@ -343,10 +340,27 @@ def test_select_operator_candidates_sorts_by_key_index():
             side_effect=lambda candidates, allocation, beacon, target, min_top_up: candidates,
         ) as take,
     ):
-        result = _select_operator_candidates(keys, 16 * 10**18, beacon_data, set(), TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI)
+        result, consolidation_filtered = _select_operator_candidates(keys, 16 * 10**18, beacon_data, set(), TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI)
 
     assert [candidate.key_index for candidate in result] == [7, 8]
     assert take.call_args.args[0] == result
+    assert consolidation_filtered == 0
+
+
+@pytest.mark.unit
+def test_select_operator_candidates_counts_consolidation_filtered(top_up_proof_fixtures):
+    """Keys that pass all eligibility checks but are in the pending consolidation set are counted."""
+    beacon_data = _build_beacon_state_data(top_up_proof_fixtures)
+    witness = top_up_proof_fixtures['validator_witnesses'][0]
+    pubkey = bytes.fromhex(witness['pubkey'][2:])
+    key = _make_key(witness['pubkey'], 7, 11)
+
+    result, consolidation_filtered = _select_operator_candidates(
+        [key], 32 * 10**18, beacon_data, {pubkey}, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI
+    )
+
+    assert result == []
+    assert consolidation_filtered == 1
 
 
 @pytest.mark.unit

--- a/tests/blockchain/test_cmv2_strategy.py
+++ b/tests/blockchain/test_cmv2_strategy.py
@@ -20,6 +20,7 @@ from blockchain.topup.cmv2_strategy import (
     CMv2TopUpStrategy,
     _check_key_eligibility,
     _collect_pubkeys,
+    _log_excluded_key,
     _select_operator_candidates,
     _take_up_to_allocation,
 )
@@ -272,8 +273,9 @@ def test_check_key_eligibility_returns_candidate(top_up_proof_fixtures):
     witness = top_up_proof_fixtures['validator_witnesses'][0]
     key = _make_key(witness['pubkey'], 7, 11)
 
-    candidate = _check_key_eligibility(key, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI)
+    candidate, reason = _check_key_eligibility(key, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI)
 
+    assert reason is None
     assert candidate == TopUpCandidate(
         validator_index=int(witness['validatorIndex']),
         key_index=7,
@@ -291,32 +293,44 @@ def test_check_key_eligibility_rejects_invalid_cases(top_up_proof_fixtures):
     validator_index = int(witness['validatorIndex'])
     key = _make_key(witness['pubkey'], 7, 11)
 
-    assert _check_key_eligibility(_make_key('0x' + '33' * 48, 7, 11), beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI) is None
+    candidate, reason = _check_key_eligibility(_make_key('0x' + '33' * 48, 7, 11), beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI)
+    assert candidate is None
+    assert reason == 'not_in_beacon_state'
 
     beacon_data.consolidation_targets = {validator_index}
-    assert _check_key_eligibility(key, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI) is None
+    candidate, reason = _check_key_eligibility(key, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI)
+    assert candidate is None
+    assert reason == 'beacon_consolidation_target'
     beacon_data.consolidation_targets = set()
 
     fields = beacon_data.validators_fields[validator_index]
 
     beacon_data.validators_fields[validator_index] = fields._replace(slashed=True)
-    assert _check_key_eligibility(key, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI) is None
+    candidate, reason = _check_key_eligibility(key, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI)
+    assert candidate is None
+    assert reason == 'slashed'
 
     beacon_data.validators_fields[validator_index] = fields._replace(exit_epoch=1)
-    assert _check_key_eligibility(key, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI) is None
+    candidate, reason = _check_key_eligibility(key, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI)
+    assert candidate is None
+    assert reason == 'exiting'
 
     beacon_data.validators_fields[validator_index] = fields._replace(
         exit_epoch=FAR_FUTURE_EPOCH,
         activation_epoch=beacon_data.slot + 1,
     )
-    assert _check_key_eligibility(key, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI) is None
+    candidate, reason = _check_key_eligibility(key, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI)
+    assert candidate is None
+    assert reason == 'not_active'
 
     # balance exactly at the max eligible threshold + any pending pushes it over -> excluded
     beacon_data.validators_fields[validator_index] = fields._replace(
         effective_balance=MAX_ELIGIBLE_BALANCE_GWEI,
     )
     beacon_data.pending_deposits = {pubkey: 1}
-    assert _check_key_eligibility(key, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI) is None
+    candidate, reason = _check_key_eligibility(key, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI)
+    assert candidate is None
+    assert reason == 'already_at_target_balance'
 
 
 @pytest.mark.unit
@@ -331,16 +345,18 @@ def test_select_operator_candidates_sorts_by_key_index():
         patch(
             'blockchain.topup.cmv2_strategy._check_key_eligibility',
             side_effect=[
-                TopUpCandidate(1, 8, 11, bytes.fromhex('22' * 48), 0),
-                TopUpCandidate(0, 7, 11, bytes.fromhex('11' * 48), 0),
+                (TopUpCandidate(1, 8, 11, bytes.fromhex('22' * 48), 0), None),
+                (TopUpCandidate(0, 7, 11, bytes.fromhex('11' * 48), 0), None),
             ],
         ),
         patch(
             'blockchain.topup.cmv2_strategy._take_up_to_allocation',
-            side_effect=lambda candidates, allocation, beacon, target, min_top_up: candidates,
+            side_effect=lambda candidates, allocation, beacon, target, min_top_up, module_id: candidates,
         ) as take,
     ):
-        result, consolidation_filtered = _select_operator_candidates(keys, 16 * 10**18, beacon_data, set(), TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI)
+        result, consolidation_filtered = _select_operator_candidates(
+            keys, 16 * 10**18, beacon_data, set(), TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI, 1
+        )
 
     assert [candidate.key_index for candidate in result] == [7, 8]
     assert take.call_args.args[0] == result
@@ -356,7 +372,7 @@ def test_select_operator_candidates_counts_consolidation_filtered(top_up_proof_f
     key = _make_key(witness['pubkey'], 7, 11)
 
     result, consolidation_filtered = _select_operator_candidates(
-        [key], 32 * 10**18, beacon_data, {pubkey}, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI
+        [key], 32 * 10**18, beacon_data, {pubkey}, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI, 1
     )
 
     assert result == []
@@ -382,7 +398,7 @@ def test_take_up_to_allocation_respects_remaining_and_skips_below_min_topup():
 
     # 6 ETH allocation: candidate 0 (3 ETH) -> remaining 3 ETH, skip below-min/zero,
     # candidate 1 (4 ETH) exhausts remaining and stops.
-    result = _take_up_to_allocation(candidates, 6 * 10**18, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI)
+    result = _take_up_to_allocation(candidates, 6 * 10**18, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI, 1)
 
     assert result == [candidates[0], candidates[3]]
 
@@ -400,7 +416,7 @@ def test_take_up_to_allocation_skips_sub_min_tail():
     candidates = [TopUpCandidate(i, i, 0, bytes([i]), 0) for i in range(3)]
 
     # 4.5 ETH allocation
-    result = _take_up_to_allocation(candidates, 9 * 10**18 // 2, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI)
+    result = _take_up_to_allocation(candidates, 9 * 10**18 // 2, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI, 1)
 
     assert result == [candidates[0]]
 
@@ -418,8 +434,73 @@ def test_take_up_to_allocation_log_scenario_1216_eth():
 
     # 1216 ETH in Wei — from the log
     allocation_wei = 1216 * 10**18
-    result = _take_up_to_allocation(candidates, allocation_wei, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI)
+    result = _take_up_to_allocation(candidates, allocation_wei, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI, 1)
 
     # topup per validator = 2_014_750_000_000 Gwei (2014.75 ETH) > 1216 ETH allocation
     # first candidate exhausts allocation → only 1 selected
     assert len(result) == 1
+
+
+# ─── Per-key exclusion reasons (answers "why wasn't key X topped up") ───
+
+
+@pytest.mark.unit
+def test_log_excluded_key_reports_metric_and_log_line():
+    with patch('blockchain.topup.cmv2_strategy.TOPUP_KEY_EXCLUDED') as counter:
+        _log_excluded_key(module_id=5, operator_id=11, pubkey='0xabc', reason='not_active')
+
+    counter.labels.assert_called_once_with(5, 'not_active')
+    counter.labels.return_value.inc.assert_called_once()
+
+
+@pytest.mark.unit
+def test_select_operator_candidates_logs_ineligible_reason(top_up_proof_fixtures):
+    beacon_data = _build_beacon_state_data(top_up_proof_fixtures)
+    key = _make_key('0x' + '33' * 48, 7, 11)  # not in beacon state
+
+    with patch('blockchain.topup.cmv2_strategy._log_excluded_key') as log_excluded:
+        _select_operator_candidates([key], 32 * 10**18, beacon_data, set(), TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI, module_id=5)
+
+    log_excluded.assert_called_once_with(5, 11, key.key, 'not_in_beacon_state')
+
+
+@pytest.mark.unit
+def test_select_operator_candidates_logs_pending_consolidation_reason(top_up_proof_fixtures):
+    beacon_data = _build_beacon_state_data(top_up_proof_fixtures)
+    witness = top_up_proof_fixtures['validator_witnesses'][0]
+    pubkey = bytes.fromhex(witness['pubkey'][2:])
+    key = _make_key(witness['pubkey'], 7, 11)
+
+    with patch('blockchain.topup.cmv2_strategy._log_excluded_key') as log_excluded:
+        _select_operator_candidates([key], 32 * 10**18, beacon_data, {pubkey}, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI, module_id=5)
+
+    log_excluded.assert_called_once_with(5, 11, key.key, 'pending_consolidation_bus')
+
+
+@pytest.mark.unit
+def test_take_up_to_allocation_logs_budget_exhausted_for_remaining_tail():
+    beacon_data = Mock(validators_fields={0: _make_fields(TARGET_BALANCE_GWEI - 3 * 10**9)})
+    candidates = [
+        TopUpCandidate(0, 1, 11, b'a', 0),
+        TopUpCandidate(1, 2, 12, b'b', 0),  # never evaluated — budget already exhausted
+    ]
+
+    with patch('blockchain.topup.cmv2_strategy._log_excluded_key') as log_excluded:
+        # 3 ETH allocation: candidate 0 (needs 3 ETH) leaves 0 remaining < min (2 ETH) -> stop.
+        result = _take_up_to_allocation(candidates, 3 * 10**18, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI, module_id=5)
+
+    assert result == [candidates[0]]
+    log_excluded.assert_called_once_with(5, 12, '0x62', 'operator_budget_exhausted')
+
+
+@pytest.mark.unit
+def test_take_up_to_allocation_logs_already_at_target_balance():
+    fields = _make_fields(TARGET_BALANCE_GWEI)  # needs 0 top-up
+    beacon_data = Mock(validators_fields={0: fields})
+    candidates = [TopUpCandidate(0, 1, 11, b'a', 0)]
+
+    with patch('blockchain.topup.cmv2_strategy._log_excluded_key') as log_excluded:
+        result = _take_up_to_allocation(candidates, 10 * 10**18, beacon_data, TARGET_BALANCE_GWEI, MIN_TOP_UP_GWEI, module_id=5)
+
+    assert result == []
+    log_excluded.assert_called_once_with(5, 11, '0x61', 'already_at_target_balance')

--- a/tests/blockchain/test_topup_strategy.py
+++ b/tests/blockchain/test_topup_strategy.py
@@ -1,0 +1,39 @@
+from unittest.mock import Mock, patch
+
+import pytest
+import variables
+from blockchain.topup.cmv2_strategy import CMv2TopUpStrategy
+
+
+@pytest.fixture
+def topup_strategy():
+    w3 = Mock()
+    w3.lido.lido.get_depositable_ether = Mock(return_value=100)
+    gas_price_calculator = Mock()
+    gas_price_calculator.get_pending_base_fee = Mock(return_value=10)
+    gas_price_calculator.get_recommended_gas_fee = Mock(return_value=20)
+    return CMv2TopUpStrategy(w3, gas_price_calculator)
+
+
+@pytest.mark.unit
+def test_is_gas_price_ok_reports_current_and_recommended_fee(topup_strategy):
+    """Gas fee values used for the check must be observable — otherwise TOPUP_GAS_OK's boolean
+    can't be explained without re-deriving the inputs from logs."""
+    variables.MAX_BUFFERED_ETHERS = 200  # buffered (100) below threshold -> recommended-fee branch
+
+    with patch('blockchain.topup.strategy.TOPUP_GAS_FEE') as topup_gas_fee:
+        assert topup_strategy.is_gas_price_ok()
+
+    topup_gas_fee.labels.assert_any_call('current_fee')
+    topup_gas_fee.labels.assert_any_call('recommended_fee')
+    topup_gas_fee.labels.return_value.set.assert_any_call(10)
+    topup_gas_fee.labels.return_value.set.assert_any_call(20)
+
+
+@pytest.mark.unit
+def test_is_gas_price_ok_uses_max_gas_fee_above_buffer_threshold(topup_strategy):
+    variables.MAX_BUFFERED_ETHERS = 50  # buffered (100) above threshold -> max-fee branch
+    variables.MAX_GAS_FEE = 5
+
+    with patch('blockchain.topup.strategy.TOPUP_GAS_FEE'):
+        assert not topup_strategy.is_gas_price_ok()  # current_fee (10) > MAX_GAS_FEE (5)

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -90,6 +90,26 @@ class TestRefreshModulesState(unittest.TestCase):
         for module_id in [1, 2, 3]:
             self.assertEqual(old, self.bot._module_last_heart_beat[module_id])
 
+    def test_quorum_last_seen_metric_updated_on_truthy_quorum(self):
+        self.bot._get_quorum = Mock(return_value=['msg'])
+        self.bot._select_strategy = Mock(return_value=Mock())
+
+        with mock.patch('bots.depositor.MODULE_QUORUM_LAST_SEEN_TIMESTAMP') as gauge:
+            self.bot._refresh_modules_state()
+
+        called_ids = sorted(c.args[0] for c in gauge.labels.call_args_list)
+        self.assertEqual([1, 2, 3], called_ids)
+        gauge.labels.return_value.set.assert_called()
+
+    def test_quorum_last_seen_metric_not_updated_on_none_quorum(self):
+        self.bot._get_quorum = Mock(return_value=None)
+        self.bot._select_strategy = Mock(return_value=Mock())
+
+        with mock.patch('bots.depositor.MODULE_QUORUM_LAST_SEEN_TIMESTAMP') as gauge:
+            self.bot._refresh_modules_state()
+
+        gauge.labels.assert_not_called()
+
     def test_empty_whitelist_noop(self):
         variables.DEPOSIT_MODULES_WHITELIST = []
         self.bot._get_quorum = Mock()
@@ -163,6 +183,50 @@ class TestCommonPreconditions(unittest.TestCase):
     def test_fails_when_quorum_zero(self):
         self.bot.w3.lido.deposit_security_module.get_guardian_quorum.return_value = 0
         self.assertFalse(self.bot._common_preconditions())
+
+
+# ─── _publish_allocation_metrics ─────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestPublishAllocationMetrics(unittest.TestCase):
+    def setUp(self):
+        self.bot = _make_bot()
+        variables.DEPOSIT_MODULES_WHITELIST = [1, 2]
+
+    def test_publishes_allocation_and_stake_for_whitelisted_modules(self):
+        digests = [_make_digest(1, '0xA1', 2), _make_digest(2, '0xA2', 1)]
+
+        with mock.patch('bots.depositor.MODULE_ALLOCATION') as allocation, mock.patch('bots.depositor.MODULE_STAKE') as stake:
+            self.bot._publish_allocation_metrics(digests, [30, 0], [100, 0], 'seed')
+
+        allocation.labels.assert_any_call(1, 'seed')
+        allocation.labels.assert_any_call(2, 'seed')
+        allocation.labels.return_value.set.assert_any_call(30)
+        allocation.labels.return_value.set.assert_any_call(0)
+        stake.labels.return_value.set.assert_any_call(70)  # 100 - 30
+
+    def test_skips_non_whitelisted_modules(self):
+        # Regression: a module excluded here would otherwise show a stale outcome from its last
+        # successful cycle, misrepresenting why it currently isn't a deposit candidate.
+        variables.DEPOSIT_MODULES_WHITELIST = [1]
+        digests = [_make_digest(1, '0xA1', 2), _make_digest(2, '0xA2', 1)]
+
+        with mock.patch('bots.depositor.MODULE_ALLOCATION') as allocation:
+            self.bot._publish_allocation_metrics(digests, [30, 999], [100, 999], 'seed')
+
+        called_ids = {c.args[0] for c in allocation.labels.call_args_list}
+        self.assertEqual({1}, called_ids)
+
+    def test_publishes_zero_allocation_for_excluded_module(self):
+        """A module with zero allocation must still get a fresh 0 this cycle, not be left alone."""
+        digests = [_make_digest(1, '0xA1', 2)]
+
+        with mock.patch('bots.depositor.MODULE_ALLOCATION') as allocation:
+            self.bot._publish_allocation_metrics(digests, [0], [0], 'seed')
+
+        allocation.labels.assert_called_once_with(1, 'seed')
+        allocation.labels.return_value.set.assert_called_once_with(0)
 
 
 # ─── _collect_candidates ───────────────────────────────────────────
@@ -660,6 +724,20 @@ def test_execute_actual_zero_depositable_ether_short_circuits(depositor_bot):
     depositor_bot._phase_seed.assert_not_called()
     depositor_bot._phase_full.assert_not_called()
     depositor_bot._phase_full_and_topup.assert_not_called()
+
+
+@pytest.mark.unit
+def test_execute_actual_reports_depositable_ether_even_when_zero(depositor_bot):
+    """DEPOSITABLE_ETHER must stay current even on the empty-buffer short-circuit — it's the
+    first thing worth checking when asking why nothing is being deposited."""
+    depositor_bot._refresh_modules_state = Mock()
+    depositor_bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(return_value=[])
+    depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=0)
+
+    with mock.patch('bots.depositor.DEPOSITABLE_ETHER') as gauge:
+        depositor_bot._execute_actual()
+
+    gauge.set.assert_called_once_with(0)
 
 
 @pytest.mark.unit

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -454,7 +454,7 @@ class TestPhaseFullAndTopup(unittest.TestCase):
         self.bot.w3.lido.topup_gateway.is_block_distance_passed.return_value = True
         self.bot._get_quorum = Mock(return_value=None)
         self.bot._deposit_to_module = Mock(return_value=True)
-        self.bot._top_up_to_module = Mock(return_value=True)
+        self.bot._top_up_to_module = Mock(return_value=PhaseOutcome.SENT)
 
     def _set_cooldown_expired(self, module_id):
         self.bot._module_last_heart_beat[module_id] = datetime.now() - timedelta(minutes=variables.QUORUM_RETENTION_MINUTES + 1)
@@ -829,7 +829,7 @@ class TestExecuteActualScheduling(unittest.TestCase):
         self.bot.w3.lido.deposit_security_module.is_deposits_paused = Mock(return_value=False)
         self.bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
         self.bot._deposit_to_module = Mock(return_value=True)
-        self.bot._top_up_to_module = Mock(return_value=True)
+        self.bot._top_up_to_module = Mock(return_value=PhaseOutcome.SENT)
         self.bot.w3.lido.deposit_security_module.is_min_deposit_distance_passed = Mock(return_value=True)
         self.bot.w3.lido.topup_gateway.is_block_distance_passed = Mock(return_value=True)
         self.bot.w3.lido.topup_gateway.is_paused = Mock(return_value=False)
@@ -921,7 +921,7 @@ class TestExecuteActualScheduling(unittest.TestCase):
 
     def test_B5_top_up_failed(self):
         self._set_alloc(seed=[0, 0], topup=[100, 0])
-        self.bot._top_up_to_module = Mock(return_value=False)
+        self.bot._top_up_to_module = Mock(return_value=PhaseOutcome.TX_FAILED)
         self.assertFalse(self.bot._execute_actual())  # +1
         self.bot._top_up_to_module.assert_called_once()
 
@@ -1008,7 +1008,7 @@ def test_top_up_to_module_unknown_type_returns_false(depositor_bot):
     depositor_bot.w3.lido.staking_module = Mock(return_value=mock_module)
     depositor_bot._select_topup_strategy = Mock(return_value=None)
 
-    assert depositor_bot._top_up_to_module(1, '0xAddr', 50) is False
+    assert depositor_bot._top_up_to_module(1, '0xAddr', 50) is PhaseOutcome.SKIPPED
 
 
 @pytest.mark.unit
@@ -1021,7 +1021,7 @@ def test_top_up_to_module_gas_too_high_returns_false(depositor_bot):
     strategy.get_topup_candidates = Mock()
     depositor_bot._select_topup_strategy = Mock(return_value=strategy)
 
-    assert depositor_bot._top_up_to_module(1, '0xAddr', 50) is False
+    assert depositor_bot._top_up_to_module(1, '0xAddr', 50) is PhaseOutcome.SKIPPED
     strategy.get_topup_candidates.assert_not_called()
 
 
@@ -1037,7 +1037,7 @@ def test_top_up_to_module_no_proof_data_returns_false(depositor_bot):
     depositor_bot.w3.lido.topup_gateway.get_max_validators_per_top_up = Mock(return_value=10)
     depositor_bot.w3.lido.topup_gateway.top_up = Mock()
 
-    assert depositor_bot._top_up_to_module(1, '0xAddr', 50) is False
+    assert depositor_bot._top_up_to_module(1, '0xAddr', 50) is PhaseOutcome.SKIPPED
     depositor_bot.w3.lido.topup_gateway.top_up.assert_not_called()
 
 
@@ -1090,7 +1090,7 @@ def test_top_up_to_module_happy_path_calls_top_up_check_send(depositor_bot):
     depositor_bot.w3.transaction.check = Mock(return_value=True)
     depositor_bot.w3.transaction.send = Mock(return_value=True)
 
-    assert depositor_bot._top_up_to_module(1, '0xAddr', 50) is True
+    assert depositor_bot._top_up_to_module(1, '0xAddr', 50) is PhaseOutcome.SENT
 
     depositor_bot.w3.lido.topup_gateway.top_up.assert_called_once_with(1, proof_data)
     depositor_bot.w3.transaction.check.assert_called_once_with(tx)

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -110,6 +110,21 @@ class TestRefreshModulesState(unittest.TestCase):
 
         gauge.labels.assert_not_called()
 
+    def test_quorum_state_metric_updated_for_every_whitelisted_module(self):
+        """Regression: QUORUM_STATE used to be set only inside _try_deposit's call path
+        (_resolve_quorum), so a module never reached in a given cycle (top-up-only cycle, lost the
+        priority race, zero allocation) left it stale. _refresh_modules_state must touch it for
+        every whitelisted module every cycle, regardless of whether it has quorum."""
+        self.bot._get_quorum = Mock(return_value=None)
+        self.bot._select_strategy = Mock(return_value=Mock())
+
+        with mock.patch('bots.depositor.QUORUM_STATE') as quorum_state:
+            self.bot._refresh_modules_state()
+
+        called_ids = sorted(c.args[0] for c in quorum_state.labels.call_args_list)
+        self.assertEqual([1, 2, 3], called_ids)
+        quorum_state.labels.return_value.state.assert_called()
+
     def test_empty_whitelist_noop(self):
         variables.DEPOSIT_MODULES_WHITELIST = []
         self.bot._get_quorum = Mock()
@@ -161,6 +176,18 @@ class TestResolveQuorum(unittest.TestCase):
         self.bot._get_quorum = Mock(return_value=None)
         self.bot._module_last_heart_beat[1] = datetime.now() - timedelta(minutes=variables.QUORUM_RETENTION_MINUTES, seconds=-1)
         self.assertIs(QuorumState.RETAINED, self.bot._resolve_quorum(1))
+
+    def test_reports_state_via_enum_metric_not_a_numeric_gauge(self):
+        """QUORUM_STATE is a prometheus_client.Enum — driven with .state(<QuorumState member>),
+        never .set(<int>). A regression here would silently produce a numeric-again series."""
+        self.bot._get_quorum = Mock(return_value=['msg'])
+
+        with mock.patch('bots.depositor.QUORUM_STATE') as quorum_state:
+            self.bot._resolve_quorum(1)
+
+        quorum_state.labels.assert_called_once_with(1)
+        quorum_state.labels.return_value.state.assert_called_once_with(QuorumState.READY)
+        quorum_state.labels.return_value.set.assert_not_called()
 
 
 # ─── _common_preconditions ─────────────────────────────────────────

--- a/tests/bots/test_executor.py
+++ b/tests/bots/test_executor.py
@@ -1,11 +1,12 @@
 import time
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from blockchain.executor import Executor
 from metrics import healthcheck_pulse
 from utils.timeout import TimeoutManagerError
 from web3.types import BlockData
+from web3_multi_provider import NoActiveProviderError
 
 
 def pure_func(block: BlockData):
@@ -85,3 +86,64 @@ def test_blocks_false_result(web3_lido_integration, remove_metrics):
     block_2 = e._next_expected_block
 
     assert block_1 + 1 == block_2
+
+
+# ─── EL freshness / error metrics (unit, no network) ─────────────────
+
+
+@pytest.mark.unit
+def test_wait_until_next_block_reports_el_freshness():
+    w3 = Mock()
+    w3.eth.get_block = Mock(return_value={'number': 100, 'timestamp': 1000})
+    e = Executor(w3, pure_func, 1, 4)
+
+    with (
+        patch('blockchain.executor.EL_HEAD_BLOCK_NUMBER') as block_number_gauge,
+        patch('blockchain.executor.EL_HEAD_BLOCK_AGE_SECONDS') as block_age_gauge,
+        patch('blockchain.executor.time', return_value=1050),
+    ):
+        block = e._wait_until_next_block()
+
+    assert block['number'] == 100
+    block_number_gauge.set.assert_called_with(100)
+    block_age_gauge.set.assert_called_with(50)
+
+
+@pytest.mark.unit
+def test_exception_handler_counts_timeout():
+    def raiser():
+        raise TimeoutManagerError('boom')
+
+    with patch('blockchain.executor.UNEXPECTED_EXCEPTIONS') as counter, pytest.raises(TimeoutManagerError):
+        Executor._exception_handler(raiser)
+
+    counter.labels.assert_called_once_with('timeout')
+    counter.labels.return_value.inc.assert_called_once()
+
+
+@pytest.mark.unit
+def test_exception_handler_counts_no_active_provider():
+    def raiser():
+        raise NoActiveProviderError('no active provider', [ValueError('rpc down')])
+
+    with patch('blockchain.executor.UNEXPECTED_EXCEPTIONS') as counter, pytest.raises(NoActiveProviderError):
+        Executor._exception_handler(raiser)
+
+    counter.labels.assert_called_once_with('no_active_provider')
+    counter.labels.return_value.inc.assert_called_once()
+
+
+@pytest.mark.unit
+def test_exception_handler_counts_and_swallows_generic_exception():
+    """The generic branch swallows the exception (no re-raise) so one bad cycle doesn't kill the
+    daemon — the counter is the only way to notice this happened."""
+
+    def raiser():
+        raise ValueError('unexpected')
+
+    with patch('blockchain.executor.UNEXPECTED_EXCEPTIONS') as counter:
+        result = Executor._exception_handler(raiser)
+
+    assert result is None
+    counter.labels.assert_called_once_with('ValueError')
+    counter.labels.return_value.inc.assert_called_once()

--- a/tests/bots/test_topup_proof_benchmark.py
+++ b/tests/bots/test_topup_proof_benchmark.py
@@ -97,7 +97,7 @@ def eligible_candidates(module_keys, beacon_data_and_timing) -> list[TopUpCandid
     beacon_data = beacon_data_and_timing[0]
     candidates = []
     for key in module_keys:
-        candidate = _check_key_eligibility(key, beacon_data, set(), 2_046_750_000_000, 2_000_000_000)
+        candidate = _check_key_eligibility(key, beacon_data, 2_046_750_000_000, 2_000_000_000)
         if candidate is not None:
             candidates.append(candidate)
     candidates.sort(key=lambda c: c.key_index)

--- a/tests/bots/test_topup_proof_benchmark.py
+++ b/tests/bots/test_topup_proof_benchmark.py
@@ -97,7 +97,7 @@ def eligible_candidates(module_keys, beacon_data_and_timing) -> list[TopUpCandid
     beacon_data = beacon_data_and_timing[0]
     candidates = []
     for key in module_keys:
-        candidate = _check_key_eligibility(key, beacon_data, 2_046_750_000_000, 2_000_000_000)
+        candidate, _ = _check_key_eligibility(key, beacon_data, 2_046_750_000_000, 2_000_000_000)
         if candidate is not None:
             candidates.append(candidate)
     candidates.sort(key=lambda c: c.key_index)

--- a/tests/providers/test_keys_api_freshness.py
+++ b/tests/providers/test_keys_api_freshness.py
@@ -1,0 +1,37 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from providers.keys_api import KeysAPIClient
+
+
+@pytest.mark.unit
+def test_get_module_used_keys_reports_freshness_from_meta():
+    client = KeysAPIClient(host='http://kapi.example')
+    data = {'keys': [{'key': '0xAA', 'index': 0, 'operatorIndex': 1}]}
+    meta = {'meta': {'elBlockSnapshot': {'blockNumber': 123, 'blockHash': '0x1', 'timestamp': 1000, 'lastChangedBlockHash': '0x2'}}}
+    client._get = Mock(return_value=(data, meta))
+
+    with (
+        patch('providers.keys_api.KEYS_API_BLOCK_NUMBER') as block_number_gauge,
+        patch('providers.keys_api.KEYS_API_BLOCK_AGE_SECONDS') as block_age_gauge,
+        patch('providers.keys_api.time') as time_module,
+    ):
+        time_module.time.return_value = 1100
+        keys = client.get_module_used_keys(1)
+
+    assert len(keys) == 1
+    block_number_gauge.set.assert_called_once_with(123)
+    block_age_gauge.set.assert_called_once_with(100)
+
+
+@pytest.mark.unit
+def test_report_freshness_is_defensive_to_missing_meta():
+    """A KAPI schema change (or a response with no meta at all) must not break the deposit path."""
+    with (
+        patch('providers.keys_api.KEYS_API_BLOCK_NUMBER') as block_number_gauge,
+        patch('providers.keys_api.KEYS_API_BLOCK_AGE_SECONDS') as block_age_gauge,
+    ):
+        KeysAPIClient._report_freshness({})
+
+    block_number_gauge.set.assert_not_called()
+    block_age_gauge.set.assert_not_called()


### PR DESCRIPTION
## What

Adds observability coverage for the new top-up, phase, quorum, and consolidation code paths introduced in SR-v4 / DSMv4. Also removes four metrics that were never written to in the current architecture.

## New metrics

| Metric | Type | Labels | Description |
|---|---|---|---|
| `deposits_paused` | Gauge | — | 1 when DSM.isDepositsPaused() is true |
| `topup_gateway_paused` | Gauge | — | 1 when TopUpGateway.isPaused() is true |
| `module_status` | Gauge | `module_id` | Staking module status from SR digest (0=active, 1=paused, 2=stopped) |
| `quorum_state` | Gauge | `module_id` | Guardian quorum state (0=stale, 1=retained, 2=ready) |
| `phase_outcome` | Gauge | `phase`, `module_id` | Last outcome per phase (0=skipped 1=sent 2=tx_failed 3=wait_distance 4=wait_quorum) |
| `phase_last_run_timestamp_seconds` | Gauge | `phase`, `module_id` | Unix timestamp of last phase processing — detects stale values in serial early-exit loops |
| `topup_gas_ok` | Gauge | `module_id` | 1 when gas price is acceptable for a top-up |
| `topup_gas_ok_last_run_timestamp_seconds` | Gauge | `module_id` | Unix timestamp of last top-up gas check |
| `topup_transactions` | Counter | `status`, `module_id` | Top-up txs attempted, by success/failure |
| `topup_candidates_selected` | Gauge | `module_id` | Validators selected for top-up after eligibility filtering |
| `topup_candidates_last_run_timestamp_seconds` | Gauge | `module_id` | Unix timestamp of last candidate selection run |
| `topup_consolidation_filtered_keys` | Gauge | `module_id` | Keys excluded from top-up due to a pending ConsolidationBus request |
| `consolidation_pending_batches` | Gauge | — | Open ConsolidationBus batches in the in-memory store |
| `consolidation_pending_pubkeys` | Gauge | — | Pubkeys currently blocked from top-up by pending consolidation |
| `consolidation_cursor_lag_blocks` | Gauge | — | Blocks between the consolidation indexer cursor and the current finalized block |
| `bot_last_cycle_timestamp_seconds` | Gauge | — | Unix timestamp of the last completed bot iteration (liveness signal) |
