### PR TITLE
fix: bump pinned curl to 7.88.1-10+deb12u15 to unbreak image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends -qq \
     gcc=4:12.2.0-3 \
     libffi-dev=3.4.4-1 \
     g++=4:12.2.0-3 \
-    curl=7.88.1-10+deb12u14 \
+    curl=7.88.1-10+deb12u15 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Problem

The Docker image on `develop` fails to build. The `apt-get install` layer pins `curl=7.88.1-10+deb12u14`, but Debian's apt repository serves only the latest point release. A security update superseded that version with `+deb12u15`, so `apt-get install curl=7.88.1-10+deb12u14` now fails with a "Version not found" error and aborts the build.

## Fix

Bump the pin to the current bookworm version, `7.88.1-10+deb12u15`.

```diff
-    curl=7.88.1-10+deb12u14 \
+    curl=7.88.1-10+deb12u15 \
```

## Verification

- Full `linux/amd64` image build completes all stages and exports successfully.
- `curl --version` in the built image reports `curl 7.88.1 ... OpenSSL/3.0.13`.
- Entrypoint boots and validates its bot-module argument as expected.

## Note

The `gcc`, `g++`, and `libffi-dev` pins are exposed to the same failure mode the next time any of them gets a Debian security bump. Left as exact pins for reproducibility on this safety-critical bot; they will need periodic refreshing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)