### PR TITLE
ORC-778: perf: TTL-cache guardian delegate map to bound EL-provider load

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ MESSAGE_TRANSPORTS=onchain_transport
 ONCHAIN_TRANSPORT_RPC_ENDPOINTS=https://rpc.gnosis.gateway.fm
 ONCHAIN_TRANSPORT_ADDRESS=0x37De961D6bb5865867aDd416be07189D2Dd960e6
 
-# Seconds to cache the DSMv5 guardian->delegate map (0 disables).
+# Seconds to cache the DSMv5 delegate->guardian map (0 disables).
 GUARDIAN_DELEGATES_CACHE_TTL=60
 
 # rabbit secrets

--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,9 @@ MESSAGE_TRANSPORTS=onchain_transport
 ONCHAIN_TRANSPORT_RPC_ENDPOINTS=https://rpc.gnosis.gateway.fm
 ONCHAIN_TRANSPORT_ADDRESS=0x37De961D6bb5865867aDd416be07189D2Dd960e6
 
+# Seconds to cache the DSMv5 guardian->delegate map (0 disables).
+GUARDIAN_DELEGATES_CACHE_TTL=60
+
 # rabbit secrets
 RABBIT_MQ_URL=ws://127.0.0.1:15674/ws
 RABBIT_MQ_USERNAME=guest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,16 @@ Node operators pre-submit validator signing keys to StakingRouter to get them ap
 - A single tx is capped at `getMaxOperatorsPerUnvetting()` operators.
 - Nonce filter: messages with `nonce < current_module_nonce` are discarded (the state has already advanced past them).
 
+### Guardian delegation (EDF / LIP-37, DSM v5)
+
+From DSM `version() == 5` a guardian is no longer an EOA but an ERC-1271 **delegation contract**. A rotatable **delegate EOA** (`getDelegate()`) is what signs council messages and posts to the Data Bus. The guardian contract stays the identity used for quorum/dedup; the delegate is the signer. The bot holds none of these keys — it receives, verifies, reshapes, and submits already-signed messages.
+
+- The switch is driven entirely by the on-chain version, never a flag: `LidoContracts.guardian_delegation_active()` (`dsm_version >= GUARDIAN_DELEGATION_DSM_VERSION`, `=5`). This one boolean (`delegated`) gates all delegation behavior. `DSM_CONTRACT_BY_VERSION` in `lido_contracts.py` is what "supports" a version — the bot now boots on both v4 and v5.
+- **Below v5 the delegation paths are exact no-ops**: the delegate map resolves to `{guardian: guardian}`, the digest/verification stay legacy, `getDelegate()` is never called (it would revert on an EOA). Don't add v5 special-casing without preserving this.
+- Three touchpoints, all gated by `delegated`: (1) Data Bus reception reverse-maps `sender → guardian` (`onchain_transport.py`); (2) off-chain sign filter folds the guardian address into the digest and checks the signer against the delegate (`msg_types/common.py`); (3) `to_guardian_signature` reshapes the compact `(r,_vs)` into the v5 `GuardianSignature` `(guardian, r‖s‖v)` — it does **not** sign (`cryptography/verify_signature.py`).
+- The `{delegate: guardian}` map is memoized for `GUARDIAN_DELEGATES_CACHE_TTL` seconds (default 60). Freshness backstop is the on-chain check at submission, not the cache.
+- **Full details: `docs/edf-guardian-delegation.md`.** Read it before touching signature shaping, the sign filter, or Data Bus sender handling.
+
 ## Architecture
 
 ### Entry point and Web3 extension pattern

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Next cases requires bot restart:
 | ENABLE_TOP_UP             | false                                      | Enable top-up functionality. Must be disabled until Node Operators submit consolidation requests                         |
 | ---                       | ---	                                       | ---                                                                                                                      |
 | MESSAGE_TRANSPORTS        | -                                          | Transports used in bot. One of/or both: rabbit/onchain_transport. `rabbit` is DSMv4-only — its messages carry no guardian delegate, so they are dropped under DSMv5 delegation |
+| GUARDIAN_DELEGATES_CACHE_TTL | 60                                      | Seconds to cache the resolved guardian→delegate map (DSMv5). Bounds EL-provider load; on-chain checks remain the freshness backstop. 0 disables |
 | RABBIT_MQ_URL             | -                                          | RabbitMQ url                                                                                                             |
 | RABBIT_MQ_USERNAME        | -                                          | RabbitMQ username for virtualhost                                                                                        |
 | RABBIT_MQ_PASSWORD        | -                                          | RabbitMQ password for virtualhost                                                                                        |

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Next cases requires bot restart:
 | ENABLE_TOP_UP             | false                                      | Enable top-up functionality. Must be disabled until Node Operators submit consolidation requests                         |
 | ---                       | ---	                                       | ---                                                                                                                      |
 | MESSAGE_TRANSPORTS        | -                                          | Transports used in bot. One of/or both: rabbit/onchain_transport. `rabbit` is DSMv4-only — its messages carry no guardian delegate, so they are dropped under DSMv5 delegation |
-| GUARDIAN_DELEGATES_CACHE_TTL | 60                                      | Seconds to cache the resolved guardian→delegate map (DSMv5). Bounds EL-provider load; on-chain checks remain the freshness backstop. 0 disables |
+| GUARDIAN_DELEGATES_CACHE_TTL | 60                                      | Seconds to cache the resolved delegate→guardian map (DSMv5). Bounds EL-provider load; on-chain checks remain the freshness backstop. 0 disables |
 | RABBIT_MQ_URL             | -                                          | RabbitMQ url                                                                                                             |
 | RABBIT_MQ_USERNAME        | -                                          | RabbitMQ username for virtualhost                                                                                        |
 | RABBIT_MQ_PASSWORD        | -                                          | RabbitMQ password for virtualhost                                                                                        |

--- a/docs/edf-guardian-delegation.md
+++ b/docs/edf-guardian-delegation.md
@@ -1,0 +1,113 @@
+# EDF guardian delegation (LIP-37 / DSM v5)
+
+This document describes how the bot behaves when guardians are **delegation
+contracts** instead of EOAs. Relevant from DSM `version() == 5` onward.
+
+## The model
+
+Before v5 a guardian is a plain EOA: it signs council messages with its own key
+and is recovered on-chain with `ecrecover`.
+
+From v5 a guardian is an ERC-1271 **contract**. The key that actually signs
+messages and posts them to the Data Bus is the guardian's **delegate EOA**, which
+the guardian owner can rotate, revoke, or terminate. `getDelegate()` returns the
+*currently effective* delegate (zero address if none).
+
+Two distinct identities result, and both matter:
+
+- **guardian (contract)** — the stable identity used for quorum and dedup.
+- **delegate (EOA)** — the ephemeral signer, carried on each message as
+  `guardianDelegate` so freshness can be re-checked downstream.
+
+The bot never holds any of these keys. It only receives already-signed messages,
+verifies them, reshapes the signatures, and submits them (paying gas with its own
+tx key).
+
+## The version switch
+
+Everything is driven by the on-chain DSM version, never by a config flag — so it
+cannot desync from chain state.
+
+- `GUARDIAN_DELEGATION_DSM_VERSION = 5` (`lido_contracts.py`).
+- `LidoContracts.guardian_delegation_active()` → `dsm_version >= 5`. This single
+  boolean (`delegated`) gates all three touchpoints below.
+- `DSM_CONTRACT_BY_VERSION` maps `4 → DepositSecurityModuleContract`,
+  `5 → DepositSecurityModuleContractV5`. Adding a key here is what "supports" a
+  version; an unmapped version fails to boot.
+
+Below v5 the delegation code paths degrade to exact legacy behavior (see each
+section) — `getDelegate()` is never called (it would revert on an EOA).
+
+## The three touchpoints
+
+### 1. Transport — Data Bus reception (`onchain_transport.py`)
+
+The Data Bus event `sender` is the delegate EOA. The provider:
+
+- Builds `{delegate_EOA: guardian_contract}` via
+  `LidoContracts.get_guardian_delegates()` and filters Data Bus logs by the
+  **delegate** addresses (indexed topic).
+- On receipt, reverse-maps `sender → guardian` and stores both:
+  `guardianAddress = guardian`, `guardianDelegate = delegate`.
+- The map is snapshotted once per fetch and reused for the reverse map, so the
+  topic filter and the lookup always agree. A `sender` with no mapping is dropped
+  (fail closed) — only reachable if a delegate rotates out mid-fetch.
+
+**Below v5** `get_guardian_delegates()` returns the identity map
+`{guardian: guardian}`, so the filter targets guardians and the reverse map is a
+no-op — byte-for-byte the pre-EDF path.
+
+### 2. Verification — off-chain sign filter (`msg_types/common.py`)
+
+`get_messages_sign_filter(prefix, delegated=...)` mirrors the on-chain check:
+
+- **delegated**: the signed digest folds in the guardian contract address —
+  `keccak(prefix, guardian, ...fields)` — and the recovered signer must equal
+  `guardianDelegate`. This is the off-chain twin of the on-chain ERC-1271 →
+  `getDelegate()` check.
+- **below v5**: legacy digest `keccak(prefix, ...fields)`, signer must equal
+  `guardianAddress`.
+
+Because `getDelegate()` is read fresh (subject to the TTL cache below), a message
+from a rotated/revoked delegate stops verifying — the fail-closed backstop.
+
+### 3. Submission — signature reshaping (`cryptography/verify_signature.py`)
+
+Council messages always carry the compact `(r, _vs)` pair.
+`to_guardian_signature(guardian, r, vs, delegated)` reshapes it for the DSM call
+— it does **not** sign anything:
+
+- **delegated**: `(guardian_contract, 65-byte r‖s‖v blob)` — the `GuardianSignature`
+  struct. The 65-byte layout is what ERC-1271 / OpenZeppelin `ECDSA.recover`
+  expects; the guardian address is explicit because recovery yields the delegate,
+  not the guardian.
+- **below v5**: the compact `(r, _vs)` pair, recovered on-chain to the guardian
+  EOA.
+
+Signatures are still sorted ascending by guardian address before submission.
+`deposit_transaction_sender.py` (deposit), `pauser.py`, and `unvetter.py` all pass
+`guardian_delegation_active()` as `delegated`.
+
+## Freshness and caching
+
+`getDelegate()` is called per guardian; the resolved delegate map is memoized for
+`GUARDIAN_DELEGATES_CACHE_TTL` seconds (default `60`) to bound EL-provider load —
+the map is otherwise rebuilt on every module/quorum pass. The cache is a
+throughput optimization, not the correctness boundary: a stale delegate only
+widens the window in which a rotated-out delegate's message could pass the
+off-chain filter, and the DSM still verifies the delegate on-chain at submission
+time.
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `GUARDIAN_DELEGATES_CACHE_TTL` | `60` | Seconds to memoize the `{delegate: guardian}` map. |
+
+No flag enables the feature — it activates automatically at DSM `version() == 5`.
+
+## Interfaces
+
+- `interfaces/Guardian.json` — minimal ABI, only `getDelegate()`.
+- `interfaces/DepositSecurityModuleV5.json` — v5 DSM ABI (compiled from
+  `lidofinance/core@feat/edf`), used when `version() == 5`.

--- a/src/blockchain/web3_extentions/lido_contracts.py
+++ b/src/blockchain/web3_extentions/lido_contracts.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import cast
 
 from eth_typing import ChecksumAddress
@@ -40,6 +41,8 @@ class LidoContracts(Module):
         super().__init__(w3)
         self._staking_module_cache: dict[int, StakingModuleContract] = {}
         self._guardian_cache: dict[ChecksumAddress, GuardianContract] = {}
+        self._delegates_cache: dict[ChecksumAddress, ChecksumAddress] | None = None
+        self._delegates_cached_at: float = 0.0
         self._load_contracts()
 
     def has_contract_address_changed(self) -> bool:
@@ -108,6 +111,7 @@ class LidoContracts(Module):
             self.w3.eth.contract(address=dsm_address, ContractFactoryClass=contract_class),
         )
         self._guardian_cache.clear()
+        self._delegates_cache = None
 
     def guardian_delegation_active(self) -> bool:
         """Whether the DSM uses the LIP-37 delegation model (guardians are contracts with delegates).
@@ -133,11 +137,34 @@ class LidoContracts(Module):
         return contract
 
     def get_guardian_delegates(self, block_identifier: BlockIdentifier = 'latest') -> dict[ChecksumAddress, ChecksumAddress]:
-        """Resolves the current delegate EOA of every registered guardian.
+        """Resolves the current delegate EOA of every registered guardian (TTL-cached).
 
         Returns a reverse map ``{delegate_EOA: guardian_contract}``. This is the mapping the Data Bus
         transport needs: council messages are posted by the delegate EOA (the event `sender`), which
         must be resolved back to its guardian contract, and the topic filter is built from the keys.
+
+        The result is memoized for ``variables.GUARDIAN_DELEGATES_CACHE_TTL`` seconds. Without it the
+        map is rebuilt on every module/quorum pass — several ``getDelegate()`` calls per guardian per
+        bot iteration — which burns EL-provider quota. Caching is safe because the on-chain ERC-1271 /
+        ``getDelegate()`` check at deposit time is the real freshness backstop: a stale delegate only
+        risks a reverted tx, never an invalid deposit. Only the default ``'latest'`` read is cached;
+        an explicit block bypasses the cache. TTL ``0`` disables caching.
+
+        See :meth:`_resolve_guardian_delegates` for the resolution and version semantics.
+        """
+        if block_identifier != 'latest':
+            return self._resolve_guardian_delegates(block_identifier)
+
+        now = time.monotonic()
+        if self._delegates_cache is not None and now - self._delegates_cached_at < variables.GUARDIAN_DELEGATES_CACHE_TTL:
+            return self._delegates_cache
+
+        self._delegates_cache = self._resolve_guardian_delegates(block_identifier)
+        self._delegates_cached_at = now
+        return self._delegates_cache
+
+    def _resolve_guardian_delegates(self, block_identifier: BlockIdentifier = 'latest') -> dict[ChecksumAddress, ChecksumAddress]:
+        """Live resolution of ``{delegate_EOA: guardian_contract}`` (no caching).
 
         Guardians whose delegate is the zero address (never assigned, revoked, or terminated) are
         omitted — they cannot produce a valid message, so their absence makes such messages fail

--- a/src/variables.py
+++ b/src/variables.py
@@ -66,6 +66,12 @@ if ONCHAIN_TRANSPORT_ADDRESS:
     # Expecting onchain databus contract address
     ONCHAIN_TRANSPORT_ADDRESS = Web3.to_checksum_address(ONCHAIN_TRANSPORT_ADDRESS)
 
+# Seconds to cache the resolved {delegate: guardian} map (DSMv5). Bounds EL-provider load: the map is
+# rebuilt at most once per this window instead of on every module/quorum pass. Staleness is safe —
+# the on-chain ERC-1271 / getDelegate() check at deposit time is the real freshness backstop, so a
+# stale delegate only risks a wasted (reverted) tx, never an invalid deposit. 0 disables the cache.
+GUARDIAN_DELEGATES_CACHE_TTL = int(os.getenv('GUARDIAN_DELEGATES_CACHE_TTL', 60))
+
 # Transactions settings
 CREATE_TRANSACTIONS = os.getenv('CREATE_TRANSACTIONS') == 'true'
 
@@ -187,6 +193,7 @@ PUBLIC_ENV_VARS = {
     'DEPOSIT_MODULES_WHITELIST': DEPOSIT_MODULES_WHITELIST,
     'ACCOUNT': '' if ACCOUNT is None else ACCOUNT.address,
     'ONCHAIN_TRANSPORT_ADDRESS': ONCHAIN_TRANSPORT_ADDRESS,
+    'GUARDIAN_DELEGATES_CACHE_TTL': GUARDIAN_DELEGATES_CACHE_TTL,
     'BLOCKS_BETWEEN_EXECUTION': BLOCKS_BETWEEN_EXECUTION,
     'QUORUM_RETENTION_MINUTES': QUORUM_RETENTION_MINUTES,
     'DEPOSIT_TO_FIRST_HEALTHY_MODULE_ONLY': DEPOSIT_TO_FIRST_HEALTHY_MODULE_ONLY,

--- a/tests/blockchain/web3_extentions/test_lido_contracts.py
+++ b/tests/blockchain/web3_extentions/test_lido_contracts.py
@@ -1,8 +1,10 @@
+from unittest import mock
 from unittest.mock import Mock
 
 import pytest
 from web3 import Web3
 
+import variables
 from blockchain.contracts.deposit_security_module import DepositSecurityModuleContract, DepositSecurityModuleContractV5
 from blockchain.web3_extentions.lido_contracts import (
     DSM_CONTRACT_BY_VERSION,
@@ -29,6 +31,8 @@ def _make_lido_contracts(
     obj = LidoContracts.__new__(LidoContracts)
     obj.w3 = Web3()
     obj.dsm_version = dsm_version
+    obj._delegates_cache = None
+    obj._delegates_cached_at = 0.0
     obj.deposit_security_module = Mock()
     obj.deposit_security_module.get_guardians = Mock(return_value=guardians)
 
@@ -97,3 +101,57 @@ def test_dsm_contract_class_by_version():
     # v5 selects the delegation-aware contract class; v4 the legacy one.
     assert DSM_CONTRACT_BY_VERSION[5] is DepositSecurityModuleContractV5
     assert DSM_CONTRACT_BY_VERSION[4] is DepositSecurityModuleContract
+
+
+# ─── Delegate-map TTL cache ───────────────────────────────────────────────────
+# `_guardian_contract.call_count` is a faithful proxy for RPC load: it is invoked exactly once per
+# guardian per *rebuild*, so N guardians → +N per resolution and 0 on a cache hit.
+
+
+def _patch_clock(*values):
+    return mock.patch('blockchain.web3_extentions.lido_contracts.time.monotonic', side_effect=list(values))
+
+
+@pytest.mark.unit
+def test_delegates_cache_hit_within_ttl():
+    lido = _make_lido_contracts([_GUARDIAN_1, _GUARDIAN_2], {_GUARDIAN_1: _DELEGATE_1, _GUARDIAN_2: _DELEGATE_2})
+    with mock.patch.object(variables, 'GUARDIAN_DELEGATES_CACHE_TTL', 60), _patch_clock(1000.0, 1030.0):
+        first = lido.get_guardian_delegates()
+        second = lido.get_guardian_delegates()
+
+    assert first == {_DELEGATE_1: _GUARDIAN_1, _DELEGATE_2: _GUARDIAN_2}
+    assert second is first  # same cached object returned, no rebuild
+    assert lido._guardian_contract.call_count == 2  # resolved once (2 guardians)
+
+
+@pytest.mark.unit
+def test_delegates_cache_expires_after_ttl():
+    lido = _make_lido_contracts([_GUARDIAN_1, _GUARDIAN_2], {_GUARDIAN_1: _DELEGATE_1, _GUARDIAN_2: _DELEGATE_2})
+    # Second call is 80s after the first with a 60s TTL → cache expired → rebuild.
+    with mock.patch.object(variables, 'GUARDIAN_DELEGATES_CACHE_TTL', 60), _patch_clock(1000.0, 1080.0):
+        lido.get_guardian_delegates()
+        lido.get_guardian_delegates()
+
+    assert lido._guardian_contract.call_count == 4  # two rebuilds × 2 guardians
+
+
+@pytest.mark.unit
+def test_delegates_cache_disabled_when_ttl_zero():
+    lido = _make_lido_contracts([_GUARDIAN_1], {_GUARDIAN_1: _DELEGATE_1})
+    with mock.patch.object(variables, 'GUARDIAN_DELEGATES_CACHE_TTL', 0), _patch_clock(1000.0, 1000.0):
+        lido.get_guardian_delegates()
+        lido.get_guardian_delegates()
+
+    assert lido._guardian_contract.call_count == 2  # rebuilt on every call
+
+
+@pytest.mark.unit
+def test_delegates_explicit_block_bypasses_cache():
+    lido = _make_lido_contracts([_GUARDIAN_1], {_GUARDIAN_1: _DELEGATE_1})
+    # A non-'latest' read must never be served from (or populate) the cache — clock is never consulted.
+    with mock.patch.object(variables, 'GUARDIAN_DELEGATES_CACHE_TTL', 60), _patch_clock():
+        lido.get_guardian_delegates(block_identifier=123)
+        lido.get_guardian_delegates(block_identifier=123)
+
+    assert lido._guardian_contract.call_count == 2
+    assert lido._delegates_cache is None


### PR DESCRIPTION
> **Stacked on #367** (`feat/edf-guardian-delegate-reception`). It extends `get_guardian_delegates()`, which is introduced there — so this cannot target `develop` directly. GitHub will auto-retarget to `develop` once #367 merges. Review/merge #367 first.

## Problem

`LidoContracts.get_guardian_delegates()` resolves the `{delegate: guardian}` map with one `getDelegate()` call **per guardian**. It's called on every module/quorum pass (`_get_quorum` → `_get_message_actualize_filter`) and once per transport fetch — so a single bot iteration triggers **several × N** `getDelegate()` calls (N = guardian count). We pay per EL-provider request and have quota limits; that multiplication is wasteful.

## Fix

Memoize the resolved map for **`GUARDIAN_DELEGATES_CACHE_TTL`** seconds (configurable, **default 60**), rebuilt at most once per window. Rough effect at N≈7: from *several × N per iteration* down to ~**N per TTL window** (≈11k `getDelegate` calls/day at 60s), with no dependence on module count.

Split into a thin cached `get_guardian_delegates()` wrapper + a `_resolve_guardian_delegates()` body (the previous logic, unchanged). Cache validity is checked with `time.monotonic()` — **zero extra RPC** to decide freshness.

## Why caching is safe here

The off-chain delegate check is a **pre-filter, not the security boundary**: `depositBufferedEther` runs the ERC-1271 / `getDelegate()` check on-chain at its own block. So a stale cache can at worst cost a **reverted tx**, never an invalid deposit. Bounded staleness (≤ TTL) is an acceptable trade for the request savings.

## Deliberate choices

- **No aggregator contract** (e.g. Multicall3). A safety-critical bot shouldn't take an external, non-Lido contract into its decision path, so `N→1` batching is intentionally out of scope. TTL alone removes the multiplication, which was the real cost.
- **`getGuardians()` keeps its process-lifetime `lru_cache`.** Refreshing the guardian *set* would *add* requests; it only changes on rare governance action (a restart handles it), and reception already relied on that cache — no regression.
- Only `'latest'` reads are cached; an explicit block bypasses; **TTL `0` disables** the cache entirely.

## Tests

- Cache hit within TTL (single rebuild, same object returned, N `getDelegate`).
- Expiry after TTL (rebuild → 2×N).
- TTL `0` disables (rebuild every call).
- Explicit block bypasses cache (clock never consulted, cache stays empty).
- Clock is controlled via a patched `time.monotonic`; `_guardian_contract.call_count` is the RPC-load proxy.
- Full unit suite green (239 passed); pinned ruff + format pass; pyright clean on changed files.

## Config

`GUARDIAN_DELEGATES_CACHE_TTL` (seconds, default 60) — added to `variables.py`, `PUBLIC_ENV_VARS`, `README.md`, `.env.example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)