### PR TITLE
chore: add CLAUDE.local.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ node_modules/
 
 # Claude
 .claude
+CLAUDE.local.md


### PR DESCRIPTION
Adds CLAUDE.local.md to .gitignore to prevent local Claude configuration overrides from being committed.