### PR TITLE
ORC-781: fix: pre-initialize per-module deposit metrics

### DIFF
--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -336,6 +336,8 @@ for _module_id in DEPOSIT_MODULES_WHITELIST:
     for _kind in ('seed', 'topup'):
         MODULE_ALLOCATION.labels(_module_id, _kind).set(0)
         MODULE_STAKE.labels(_module_id, _kind).set(0)
+    POSSIBLE_DEPOSITS_AMOUNT.labels(_module_id).set(0)
+    DEPOSIT_AMOUNT_OK.labels(_module_id).set(0)
 
 # Absent Gauges are indistinguishable from "feature disabled"; 0 is more honest.
 DEPOSITS_PAUSED.set(0)
@@ -349,6 +351,7 @@ KEYS_API_BLOCK_NUMBER.set(0)
 KEYS_API_BLOCK_AGE_SECONDS.set(0)
 EL_HEAD_BLOCK_NUMBER.set(0)
 EL_HEAD_BLOCK_AGE_SECONDS.set(0)
+BOT_LAST_CYCLE_TIMESTAMP.set(0)
 
 INFO = Info(name='build', documentation='Info metric', namespace=PROMETHEUS_PREFIX)
 CONVERTED_PUBLIC_ENV = {k: str(v) for k, v in PUBLIC_ENV_VARS.items()}

--- a/tests/metrics/test_preinit.py
+++ b/tests/metrics/test_preinit.py
@@ -1,0 +1,54 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DUMP_SCRIPT = """
+import sys
+
+import metrics.metrics  # noqa: F401
+from prometheus_client import generate_latest
+
+sys.stdout.write(generate_latest().decode())
+"""
+
+
+def _exposition(whitelist: str) -> str:
+    result = subprocess.run(
+        [sys.executable, '-c', DUMP_SCRIPT],
+        cwd=REPO_ROOT,
+        env={
+            'PATH': '/usr/bin:/bin',
+            'PYTHONPATH': str(REPO_ROOT / 'src'),
+            'PROMETHEUS_PREFIX': 'depositor_bot',
+            'DEPOSIT_MODULES_WHITELIST': whitelist,
+        },
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=True,
+    )
+    return result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    'series',
+    [
+        'depositor_bot_possible_deposits_amount',
+        'depositor_bot_is_deposit_amount_ok',
+    ],
+)
+def test_module_series_exported_before_first_cycle(series):
+    exposition = _exposition('1,3')
+
+    for module_id in ('1', '3'):
+        assert f'{series}{{module_id="{module_id}"}} 0.0' in exposition
+
+
+@pytest.mark.unit
+def test_liveness_series_exported_before_first_cycle():
+    assert 'depositor_bot_bot_last_cycle_timestamp_seconds 0.0' in _exposition('1')


### PR DESCRIPTION
## Problem

`DepositorBotPossibleDepositsAbsent` fired critical on Jul 24 during the release redeploy (`ccb788e`). It was a false positive — the bot was working.

`possible_deposits_amount` is a **labeled** Gauge (`module_id`), and a labeled metric in `prometheus_client` exports **no samples at all** until `.labels()` is called once. Its only write site is `src/bots/depositor.py:280`, which sits behind two early returns in `_execute_actual`:

```
246   if depositable_ether == 0:            -> return False   # routine: buffer empty
252   if not self._common_preconditions():  -> return False
...
280       POSSIBLE_DEPOSITS_AMOUNT.labels(digest['module_id']).set(possible_deposits)
```

An empty buffer is the healthy steady state, so:

- **Before the restart** the label child already existed from whenever the buffer was last non-empty, and a Gauge holds its last value forever. The series kept reporting a stale number every scrape, so `absent()` could never fire.
- **The restart wiped it.** New process, empty buffer, early return every iteration, series never recreated -> 15 min of nothing -> critical.

The alert didn't detect a new problem; it detected that the series' *presence* had been coasting on a stale value.

Confirming detail: `start_http_server` runs at `src/main.py:62`, before the bot loop, so the endpoint was scrapeable the whole time. Everything in the existing pre-init block kept reporting — only the metrics missing from it went absent. That's what rules out "metrics server down."

## Change

`src/metrics/metrics.py` already has a block for exactly this, whose comment describes the failure mode (*"Absent Gauges are indistinguishable from 'feature disabled'; 0 is more honest"*). `POSSIBLE_DEPOSITS_AMOUNT` and `DEPOSIT_AMOUNT_OK` were never added to it. Now they are, per whitelisted module — matching the whitelist filter at the write site.

Also seeds `BOT_LAST_CYCLE_TIMESTAMP` for consistency with the adjacent unlabeled gauges. Note this line is **cosmetic, not functional**: unlabeled gauges are already exported at `0` from creation, so that series was never absent. Same is true of the other unlabeled `.set(0)` calls already in the block.

## Test

`tests/metrics/test_preinit.py` renders the exposition in a **fresh subprocess** — reproducing the production condition (new process, no cycle completed) rather than asserting against the shared global registry, which would pollute it and would be vacuous in CI anyway (the unit job sets no `DEPOSIT_MODULES_WHITELIST`, so it defaults to `[]`).

Verified it reproduces the bug: with the fix reverted, both module-series cases fail. The liveness case passes either way, for the reason noted above.

Full unit suite: 221 passed.

## Not included

**1. Zeroing the gauges on the empty-buffer path.** Pre-init fixes *presence*; the values are still **stale** — once set to N they stay N after the buffer drains, which `absent()` can never catch. Resetting to 0 at the `depositable_ether == 0` return would fix that, but an empty buffer is normal, so it would page continuously if any rule fires on `== 0`. Needs an alert-rule check first (they live outside this repo). Not a regression from this PR — pre-existing behavior.

**2. `ruff check --fix` reorders imports in 11 unrelated files.** The repo has drifted (ruff is `continue-on-error: true` in CI) — `metrics.py:1` reports a pre-existing `I001` on `develop`, unrelated to this diff. Left alone; worth a separate cleanup PR.