### PR TITLE
ORC-786: feat: accept both Data Bus message generations (council v4 and v5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,24 @@ Each bot is driven by `Executor` (`src/blockchain/executor.py`), which polls for
 
 Council Daemon guardians broadcast signed messages over one or both transports:
 - **RabbitMQ** (`src/transport/msg_providers/rabbit.py`) — STOMP protocol
-- **Onchain DataBus** (`src/transport/msg_providers/onchain_transport.py`) — Gnosis chain contract events parsed by `EventParser` subclasses (`DepositParser`, `PingParser`, etc.)
+- **Onchain DataBus** (`src/transport/msg_providers/onchain_transport.py`) — Gnosis chain contract events parsed by `EventParser` subclasses (`DepositV1Parser`, `PingParser`, etc.)
+
+#### DataBus message generations (council v4 / v5)
+
+Two generations of DataBus events are live at once, because the change is rolled out council by council:
+
+| | council v4 | council v5 |
+|---|---|---|
+| deposit | `MessageDepositV1` | `MessageDepositV2` |
+| pause | `MessagePauseV3` | `MessagePauseV4` |
+| unvet | `MessageUnvetV1` | `MessageUnvetV2` |
+| ping | `MessagePingV1` | `MessagePingV1` (unchanged, unsigned) |
+
+The only difference is the guardian signature: v4 events carry the compact `(bytes32 r, bytes32 vs)` pair, v5 events carry a flat 65-byte `bytes` blob (`r ‖ s ‖ v`) — the shape DSMv5 verifies via ERC-1271. Parsers normalise the blob back into `(r, _vs)` (`compact_signature` in `src/cryptography/verify_signature.py`), so **nothing downstream is version-aware**: one internal signature representation serves RabbitMQ, the sign filter and both DSM versions.
+
+Both parser sets are registered in each bot (`parsers_providers=[...]`). **Cleanup after the on-chain rollout completes: delete the V1/V3 parsers and their tests.**
+
+Logs are dispatched to the parser that declared their event id (`topic0`), never by trying parsers until one does not raise — the V1 layout decodes a V2 payload *without* raising (the ABI offset word reads as `blockNumber`), so a fallback chain would silently turn every v5 message into garbage that only fails later, at signature verification.
 
 `MessageStorage` (`src/transport/msg_storage.py`) aggregates messages from all active transports, applies static filters (signature validity, checksum address normalization), and on each cycle calls `get_messages_and_actualize()` with a dynamic filter that discards messages older than 200 blocks or with a stale deposit root.
 

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -61,7 +61,8 @@ from metrics.transport_message_metrics import message_metrics_filter
 from providers.consensus import ConsensusClient
 from providers.keys_api import KeysAPIClient
 from transport.msg_providers.onchain_transport import (
-    DepositParser,
+    DepositV1Parser,
+    DepositV2Parser,
     OnchainTransportProvider,
     PingParser,
 )
@@ -185,7 +186,7 @@ class DepositorBot:
                     w3=self._onchain_transport_w3,
                     onchain_address=variables.ONCHAIN_TRANSPORT_ADDRESS,
                     message_schema=Schema(Or(DepositMessageSchema, PingMessageSchema)),
-                    parsers_providers=[DepositParser, PingParser],
+                    parsers_providers=[DepositV1Parser, DepositV2Parser, PingParser],
                     delegates_provider=self.w3.lido.get_guardian_delegates,
                 )
             )

--- a/src/bots/pauser.py
+++ b/src/bots/pauser.py
@@ -13,7 +13,7 @@ from blockchain.typings import Web3
 from cryptography.verify_signature import to_guardian_signature
 from metrics.metrics import UNEXPECTED_EXCEPTIONS
 from metrics.transport_message_metrics import message_metrics_filter
-from transport.msg_providers.onchain_transport import OnchainTransportProvider, PauseV3Parser, PingParser
+from transport.msg_providers.onchain_transport import OnchainTransportProvider, PauseV3Parser, PauseV4Parser, PingParser
 from transport.msg_providers.rabbit import MessageType, RabbitProvider
 from transport.msg_storage import MessageStorage
 from transport.msg_types.common import get_messages_sign_filter
@@ -57,7 +57,7 @@ class PauserBot:
                     w3=OnchainTransportProvider.create_onchain_transport_w3(),
                     onchain_address=variables.ONCHAIN_TRANSPORT_ADDRESS,
                     message_schema=Schema(Or(PauseMessageSchema, PingMessageSchema)),
-                    parsers_providers=[PauseV3Parser, PingParser],
+                    parsers_providers=[PauseV3Parser, PauseV4Parser, PingParser],
                     delegates_provider=self.w3.lido.get_guardian_delegates,
                 )
             )

--- a/src/bots/unvetter.py
+++ b/src/bots/unvetter.py
@@ -11,7 +11,7 @@ from blockchain.typings import Web3
 from cryptography.verify_signature import to_guardian_signature
 from metrics.metrics import UNEXPECTED_EXCEPTIONS
 from metrics.transport_message_metrics import message_metrics_filter
-from transport.msg_providers.onchain_transport import OnchainTransportProvider, PingParser, UnvetParser
+from transport.msg_providers.onchain_transport import OnchainTransportProvider, PingParser, UnvetV1Parser, UnvetV2Parser
 from transport.msg_providers.rabbit import MessageType, RabbitProvider
 from transport.msg_storage import MessageStorage
 from transport.msg_types.common import get_messages_sign_filter
@@ -61,7 +61,7 @@ class UnvetterBot:
                     w3=OnchainTransportProvider.create_onchain_transport_w3(),
                     onchain_address=variables.ONCHAIN_TRANSPORT_ADDRESS,
                     message_schema=Schema(Or(UnvetMessageSchema, PingMessageSchema)),
-                    parsers_providers=[UnvetParser, PingParser],
+                    parsers_providers=[UnvetV1Parser, UnvetV2Parser, PingParser],
                     delegates_provider=self.w3.lido.get_guardian_delegates,
                 )
             )

--- a/src/cryptography/verify_signature.py
+++ b/src/cryptography/verify_signature.py
@@ -59,13 +59,26 @@ def recover_vs(vs: str) -> tuple[VRS, VRS]:
 
 
 def compute_vs(v: int, s: str) -> str:
-    """Returns aggregated _vs value."""
-    if v < V_OFFSET and v not in [0, 1]:
+    """Packs ``(v, s)`` into the aggregated EIP-2098 ``_vs`` value.
+
+    ``_vs`` is ``s`` carrying the parity of ``v`` in its top bit, so the packing only round-trips
+    while ``v`` is a recovery id (0/1 or 27/28) and ``s`` is canonical — EIP-2 caps ``s`` at
+    ``n/2``, which leaves the top bit clear. Both are rejected rather than folded: a ``v`` outside
+    the recovery set would be reduced to an arbitrary parity, and an ``s`` whose top bit is already
+    set would be silently reinterpreted, so in either case a malformed input would come back out as
+    a *different*, well-formed-looking signature instead of failing.
+    """
+    if v not in (0, 1, V_OFFSET, V_OFFSET + 1):
         logger.error({'msg': 'Signature invalid v byte.', 'data': str(v)})
-        raise ValueError('Signature invalid v byte.')
+        raise ValueError(f'Signature invalid v byte: {v}.')
     if v < V_OFFSET:
         v += V_OFFSET
     _vs = bytearray.fromhex(s[2:])
+    if len(_vs) != 32:
+        raise ValueError(f'Signature s must be 32 bytes, got {len(_vs)}.')
+    if _vs[0] & 0x80:
+        logger.error({'msg': 'Signature s is non-canonical (high bit set).', 'data': s})
+        raise ValueError('Signature s is non-canonical (high bit set).')
     if not v % 2:
         _vs[0] |= 0x80
 
@@ -79,7 +92,9 @@ def compact_signature(signature: bytes) -> tuple[bytes, bytes]:
     DSMv5 verifies through ERC-1271. The bot keeps signatures in the compact ``(r, _vs)`` form
     everywhere else (RabbitMQ transport, sign filter, DSMv4 submission), so blobs are normalised on
     parse and a single representation travels downstream. The conversion is lossless: ``_vs`` is ``s``
-    with the parity of ``v`` folded into its top bit.
+    with the parity of ``v`` folded into its top bit, and blobs that could not survive the fold are
+    rejected by ``compute_vs`` rather than transformed. Raising is the intended way to drop them —
+    ``OnchainTransportProvider._parse_log`` treats a raising parser as an unparseable log.
     """
     if len(signature) != SIGNATURE_LENGTH:
         raise ValueError(f'Guardian signature must be {SIGNATURE_LENGTH} bytes, got {len(signature)}.')

--- a/src/cryptography/verify_signature.py
+++ b/src/cryptography/verify_signature.py
@@ -5,11 +5,12 @@ from eth_account import Account
 from eth_account.account import VRS
 from web3 import Web3
 
-from utils.bytes import from_hex_string_to_bytes
+from utils.bytes import bytes_to_hex_string, from_hex_string_to_bytes
 
 logger = logging.getLogger(__name__)
 
 V_OFFSET = 27
+SIGNATURE_LENGTH = 65
 
 
 def guardian_signature_bytes(r: str, vs: str) -> bytes:
@@ -69,6 +70,22 @@ def compute_vs(v: int, s: str) -> str:
         _vs[0] |= 0x80
 
     return '0x' + _vs.hex()
+
+
+def compact_signature(signature: bytes) -> tuple[bytes, bytes]:
+    """Splits a flat 65-byte ``r || s || v`` signature into the compact ``(r, _vs)`` pair.
+
+    Council v5 publishes Data Bus messages with the signature as a single ``bytes`` blob — the shape
+    DSMv5 verifies through ERC-1271. The bot keeps signatures in the compact ``(r, _vs)`` form
+    everywhere else (RabbitMQ transport, sign filter, DSMv4 submission), so blobs are normalised on
+    parse and a single representation travels downstream. The conversion is lossless: ``_vs`` is ``s``
+    with the parity of ``v`` folded into its top bit.
+    """
+    if len(signature) != SIGNATURE_LENGTH:
+        raise ValueError(f'Guardian signature must be {SIGNATURE_LENGTH} bytes, got {len(signature)}.')
+    r, s, v = signature[:32], signature[32:64], signature[64]
+    # Reuses compute_vs so the packing rule (and its v validation) has one implementation.
+    return r, from_hex_string_to_bytes(compute_vs(v, bytes_to_hex_string(s)))
 
 
 def verify_message_with_signature(data: list[Any], abi: list[str], address: str, vrs: tuple[VRS, VRS, VRS]) -> bool:

--- a/src/transport/msg_providers/onchain_transport.py
+++ b/src/transport/msg_providers/onchain_transport.py
@@ -1,6 +1,7 @@
 import abc
 import logging
 from collections.abc import Callable
+from typing import ClassVar
 
 from eth_typing import ChecksumAddress
 from eth_utils import to_bytes
@@ -12,6 +13,7 @@ from web3.types import EventData, FilterParams, LogReceipt
 from web3_multi_provider import FallbackProvider
 
 import variables
+from cryptography.verify_signature import compact_signature
 from transport.msg_providers.common import BaseMessageProvider
 from transport.msg_providers.rabbit import MessageType
 from transport.msg_types.deposit import DepositMessage
@@ -86,13 +88,13 @@ class EventParser(abc.ABC):
         self._schema = schema
         self._message_abi: dict = w3.eth.contract(abi=[EVENT_ABI]).events.Message().abi
 
+    # The event signature whose keccak is the Data Bus event id. A class attribute rather than a
+    # property because both the provider's topic filter and its parser dispatch map need it before any
+    # instance exists.
+    message_abi: ClassVar[str]
+
     @abc.abstractmethod
     def _create_message(self, parsed_data: dict, guardian: str) -> dict:
-        pass
-
-    @property
-    @abc.abstractmethod
-    def message_abi(self):
         pass
 
     def _decode_event(self, log: LogReceipt) -> EventData:
@@ -106,9 +108,104 @@ class EventParser(abc.ABC):
         return self._create_message(decoded_data, guardian)
 
 
+# Data Bus messages exist in two generations that must both be accepted for the duration of the
+# council v4 → v5 rollout, since the two council versions publish different events:
+#
+#   council v4 — MessageDepositV1 / MessagePauseV3 / MessageUnvetV1: compact `(bytes32 r, bytes32 vs)`
+#   council v5 — MessageDepositV2 / MessagePauseV4 / MessageUnvetV2: flat 65-byte `bytes` r||s||v
+#
+# Only the wire layout of the signature differs — the parsers normalise both into the compact
+# `(r, _vs)` internal form, so nothing downstream is version-aware. MessagePingV1 carries no
+# signature and is unchanged. Once every council is on v5 the V1/V3 parsers can be deleted.
+
+
+def build_deposit_message(
+    *,
+    block_number: int,
+    block_hash: bytes,
+    guardian: str,
+    deposit_root: bytes,
+    staking_module_id: int,
+    nonce: int,
+    r: bytes,
+    vs: bytes,
+    version: bytes,
+) -> DepositMessage:
+    return DepositMessage(
+        type=MessageType.DEPOSIT,
+        depositRoot=bytes_to_hex_string(deposit_root),
+        nonce=nonce,
+        blockNumber=block_number,
+        blockHash=bytes_to_hex_string(block_hash),
+        guardianAddress=guardian,
+        stakingModuleId=staking_module_id,
+        signature={
+            'r': bytes_to_hex_string(r),
+            '_vs': bytes_to_hex_string(vs),
+        },
+        app={
+            'version': _decode_version(version),
+        },
+    )
+
+
+def build_unvet_message(
+    *,
+    block_number: int,
+    block_hash: bytes,
+    guardian: str,
+    operator_ids: bytes,
+    staking_module_id: int,
+    vetted_keys_by_operator: bytes,
+    nonce: int,
+    r: bytes,
+    vs: bytes,
+    version: bytes,
+) -> UnvetMessage:
+    return UnvetMessage(
+        type=MessageType.UNVET,
+        nonce=nonce,
+        blockHash=bytes_to_hex_string(block_hash),
+        blockNumber=block_number,
+        guardianAddress=guardian,
+        stakingModuleId=staking_module_id,
+        signature={
+            'r': bytes_to_hex_string(r),
+            '_vs': bytes_to_hex_string(vs),
+        },
+        operatorIds=bytes_to_hex_string(operator_ids),
+        vettedKeysByOperator=bytes_to_hex_string(vetted_keys_by_operator),
+        app={
+            'version': _decode_version(version),
+        },
+    )
+
+
+def build_pause_message(
+    *,
+    block_number: int,
+    guardian: str,
+    r: bytes,
+    vs: bytes,
+    version: bytes,
+) -> PauseMessage:
+    return PauseMessage(
+        type=MessageType.PAUSE,
+        blockNumber=block_number,
+        guardianAddress=guardian,
+        signature={
+            'r': bytes_to_hex_string(r),
+            '_vs': bytes_to_hex_string(vs),
+        },
+        app={
+            'version': _decode_version(version),
+        },
+    )
+
+
 # event MessageDepositV1(address indexed guardianAddress, (uint256 blockNumber, bytes32 blockHash, bytes32 depositRoot,
 # uint256 stakingModuleId, uint256 nonce, (bytes32 r, bytes32 vs) signature, (bytes32 version) app) data),
-class DepositParser(EventParser):
+class DepositV1Parser(EventParser):
     DEPOSIT_V1_DATA_SCHEMA = '(uint256,bytes32,bytes32,uint256,uint256,(bytes32,bytes32),(bytes32))'
     message_abi = f'MessageDepositV1(address,{DEPOSIT_V1_DATA_SCHEMA})'
 
@@ -117,7 +214,7 @@ class DepositParser(EventParser):
 
     def _create_message(self, parsed_data: tuple, guardian: str) -> DepositMessage:
         block_number, block_hash, deposit_root, staking_module_id, nonce, (r, vs), (version,) = parsed_data
-        return DepositParser.build_message(
+        return build_deposit_message(
             block_number=block_number,
             block_hash=block_hash,
             guardian=guardian,
@@ -129,40 +226,35 @@ class DepositParser(EventParser):
             version=version,
         )
 
-    @staticmethod
-    def build_message(
-        *,
-        block_number: int,
-        block_hash: bytes,
-        guardian: str,
-        deposit_root: bytes,
-        staking_module_id: int,
-        nonce: int,
-        r: bytes,
-        vs: bytes,
-        version: bytes,
-    ) -> DepositMessage:
-        return DepositMessage(
-            type=MessageType.DEPOSIT,
-            depositRoot=bytes_to_hex_string(deposit_root),
+
+# event MessageDepositV2(address indexed guardianAddress, (uint256 blockNumber, bytes32 blockHash, bytes32 depositRoot,
+# uint256 stakingModuleId, uint256 nonce, bytes signature, (bytes32 version) app) data)
+class DepositV2Parser(EventParser):
+    DEPOSIT_V2_DATA_SCHEMA = '(uint256,bytes32,bytes32,uint256,uint256,bytes,(bytes32))'
+    message_abi = f'MessageDepositV2(address,{DEPOSIT_V2_DATA_SCHEMA})'
+
+    def __init__(self, w3: Web3):
+        super().__init__(w3, self.DEPOSIT_V2_DATA_SCHEMA)
+
+    def _create_message(self, parsed_data: tuple, guardian: str) -> DepositMessage:
+        block_number, block_hash, deposit_root, staking_module_id, nonce, signature, (version,) = parsed_data
+        r, vs = compact_signature(signature)
+        return build_deposit_message(
+            block_number=block_number,
+            block_hash=block_hash,
+            guardian=guardian,
+            deposit_root=deposit_root,
+            staking_module_id=staking_module_id,
             nonce=nonce,
-            blockNumber=block_number,
-            blockHash=bytes_to_hex_string(block_hash),
-            guardianAddress=guardian,
-            stakingModuleId=staking_module_id,
-            signature={
-                'r': bytes_to_hex_string(r),
-                '_vs': bytes_to_hex_string(vs),
-            },
-            app={
-                'version': _decode_version(version),
-            },
+            r=r,
+            vs=vs,
+            version=version,
         )
 
 
 # event MessageUnvetV1(address indexed guardianAddress, (uint256 blockNumber, bytes32 blockHash, uint256 stakingModuleId, uint256 nonce,
 # bytes operatorIds, bytes vettedKeysByOperator, (bytes32 r, bytes32 vs) signature, (bytes32 version) app) data)
-class UnvetParser(EventParser):
+class UnvetV1Parser(EventParser):
     UNVET_V1_DATA_SCHEMA = '(uint256,bytes32,uint256,uint256,bytes,bytes,(bytes32,bytes32),(bytes32))'
     message_abi = f'MessageUnvetV1(address,{UNVET_V1_DATA_SCHEMA})'
 
@@ -171,7 +263,7 @@ class UnvetParser(EventParser):
 
     def _create_message(self, parsed_data: tuple, guardian: str) -> UnvetMessage:
         block_number, block_hash, staking_module_id, nonce, operator_ids, vetted_keys_by_operator, (r, vs), (version,) = parsed_data
-        return self.build_message(
+        return build_unvet_message(
             block_number=block_number,
             block_hash=block_hash,
             guardian=guardian,
@@ -184,36 +276,30 @@ class UnvetParser(EventParser):
             version=version,
         )
 
-    @staticmethod
-    def build_message(
-        *,
-        block_number: int,
-        block_hash: bytes,
-        guardian: str,
-        operator_ids: bytes,
-        staking_module_id: int,
-        vetted_keys_by_operator: bytes,
-        nonce: int,
-        r: bytes,
-        vs: bytes,
-        version: bytes,
-    ) -> UnvetMessage:
-        return UnvetMessage(
-            type=MessageType.UNVET,
+
+# event MessageUnvetV2(address indexed guardianAddress, (uint256 blockNumber, bytes32 blockHash, uint256 stakingModuleId, uint256 nonce,
+# bytes operatorIds, bytes vettedKeysByOperator, bytes signature, (bytes32 version) app) data)
+class UnvetV2Parser(EventParser):
+    UNVET_V2_DATA_SCHEMA = '(uint256,bytes32,uint256,uint256,bytes,bytes,bytes,(bytes32))'
+    message_abi = f'MessageUnvetV2(address,{UNVET_V2_DATA_SCHEMA})'
+
+    def __init__(self, w3: Web3):
+        super().__init__(w3, self.UNVET_V2_DATA_SCHEMA)
+
+    def _create_message(self, parsed_data: tuple, guardian: str) -> UnvetMessage:
+        block_number, block_hash, staking_module_id, nonce, operator_ids, vetted_keys_by_operator, signature, (version,) = parsed_data
+        r, vs = compact_signature(signature)
+        return build_unvet_message(
+            block_number=block_number,
+            block_hash=block_hash,
+            guardian=guardian,
+            operator_ids=operator_ids,
+            staking_module_id=staking_module_id,
+            vetted_keys_by_operator=vetted_keys_by_operator,
             nonce=nonce,
-            blockHash=bytes_to_hex_string(block_hash),
-            blockNumber=block_number,
-            guardianAddress=guardian,
-            stakingModuleId=staking_module_id,
-            signature={
-                'r': bytes_to_hex_string(r),
-                '_vs': bytes_to_hex_string(vs),
-            },
-            operatorIds=bytes_to_hex_string(operator_ids),
-            vettedKeysByOperator=bytes_to_hex_string(vetted_keys_by_operator),
-            app={
-                'version': _decode_version(version),
-            },
+            r=r,
+            vs=vs,
+            version=version,
         )
 
 
@@ -246,41 +332,35 @@ class PauseV3Parser(EventParser):
     def __init__(self, w3: Web3):
         super().__init__(w3, self.PAUSE_V3_DATA_SCHEMA)
 
-    def _create_message(self, parsed_data: tuple, guardian: str) -> dict:
+    def _create_message(self, parsed_data: tuple, guardian: str) -> PauseMessage:
         block_number, block_hash, (r, vs), (version,) = parsed_data
-        return PauseMessage(
-            type=MessageType.PAUSE,
-            blockNumber=block_number,
-            guardianAddress=guardian,
-            signature={
-                'r': bytes_to_hex_string(r),
-                '_vs': bytes_to_hex_string(vs),
-            },
-            app={
-                'version': _decode_version(version),
-            },
+        return build_pause_message(
+            block_number=block_number,
+            guardian=guardian,
+            r=r,
+            vs=vs,
+            version=version,
         )
 
-    @staticmethod
-    def build_message(
-        *,
-        block_number: int,
-        guardian: str,
-        r: bytes,
-        vs: bytes,
-        version: bytes,
-    ) -> PauseMessage:
-        return PauseMessage(
-            type=MessageType.PAUSE,
-            blockNumber=block_number,
-            guardianAddress=guardian,
-            signature={
-                'r': bytes_to_hex_string(r),
-                '_vs': bytes_to_hex_string(vs),
-            },
-            app={
-                'version': _decode_version(version),
-            },
+
+# event MessagePauseV4(address indexed guardianAddress, (uint256 blockNumber, bytes32 blockHash, bytes signature,
+# (bytes32 version) app) data)
+class PauseV4Parser(EventParser):
+    PAUSE_V4_DATA_SCHEMA = '(uint256,bytes32,bytes,(bytes32))'
+    message_abi = f'MessagePauseV4(address,{PAUSE_V4_DATA_SCHEMA})'
+
+    def __init__(self, w3: Web3):
+        super().__init__(w3, self.PAUSE_V4_DATA_SCHEMA)
+
+    def _create_message(self, parsed_data: tuple, guardian: str) -> PauseMessage:
+        block_number, block_hash, signature, (version,) = parsed_data
+        r, vs = compact_signature(signature)
+        return build_pause_message(
+            block_number=block_number,
+            guardian=guardian,
+            r=r,
+            vs=vs,
+            version=version,
         )
 
 
@@ -316,7 +396,13 @@ class OnchainTransportProvider(BaseMessageProvider):
         # guardian contract on receipt. Refreshed every fetch so rotations are picked up.
         self._delegates_provider = delegates_provider
         self._delegate_map: dict[ChecksumAddress, ChecksumAddress] = {}
-        self._parsers: list[EventParser] = [provider(w3) for provider in parsers_providers]
+        # Keyed by event id (topic0) so a log is handed to exactly the parser that declared it. Trying
+        # parsers in turn until one does not raise is not safe here: the V1 and V2 layouts of the same
+        # message can both decode a given payload, which would silently yield a garbage message.
+        self._parsers_by_event_id: dict[bytes, EventParser] = {}
+        for parser_provider in parsers_providers:
+            parser = parser_provider(w3)
+            self._parsers_by_event_id[bytes(w3.keccak(text=parser.message_abi))] = parser
 
     def _fetch_messages(self) -> list:
         latest_block_number = self._w3.eth.block_number
@@ -324,7 +410,7 @@ class OnchainTransportProvider(BaseMessageProvider):
         # If block distance is 0, then skip fetching to avoid looping on a single block
         if from_block == latest_block_number:
             return []
-        event_ids = [self._w3.keccak(text=parser.message_abi) for parser in self._parsers]
+        event_ids = list(self._parsers_by_event_id)
         # Snapshot the delegate map for this fetch so _process_msg reverse-maps against the same set
         # of delegates the topic filter was built from.
         self._delegate_map = self._delegates_provider()
@@ -379,19 +465,25 @@ class OnchainTransportProvider(BaseMessageProvider):
         return parsed
 
     def _parse_log(self, log: LogReceipt) -> dict | None:
-        for parser in self._parsers:
-            try:
-                return parser.parse(log)
-            except Exception as error:
-                logger.debug(
-                    {
-                        'msg': 'Data Bus parser failed to parse log',
-                        'log': log,
-                        'error': str(error),
-                        'parser': type(parser).__name__,
-                    }
-                )
-        return None
+        event_id = bytes(log['topics'][0])
+        parser = self._parsers_by_event_id.get(event_id)
+        if parser is None:
+            # The topic filter only admits registered event ids, so this means the node returned a log
+            # the filter did not ask for.
+            logger.debug({'msg': 'Data Bus log has no parser for its event id', 'event_id': bytes_to_hex_string(event_id)})
+            return None
+        try:
+            return parser.parse(log)
+        except Exception as error:
+            logger.warning(
+                {
+                    'msg': 'Data Bus parser failed to parse log',
+                    'log': log,
+                    'error': str(error),
+                    'parser': type(parser).__name__,
+                }
+            )
+            return None
 
     @staticmethod
     def create_onchain_transport_w3() -> Web3:

--- a/tests/bots/test_pauser.py
+++ b/tests/bots/test_pauser.py
@@ -2,13 +2,13 @@ import logging
 from unittest.mock import Mock
 
 import pytest
+
 import variables
 from bots.pauser import PauserBot
 from cryptography.verify_signature import compute_vs
-from transport.msg_providers.onchain_transport import PauseV3Parser
-from utils.bytes import from_hex_string_to_bytes
-
 from tests.conftest import DSM_OWNER
+from transport.msg_providers.onchain_transport import build_pause_message
+from utils.bytes import from_hex_string_to_bytes
 
 # WARNING: These accounts, and their private keys, are publicly known.
 COUNCIL_ADDRESS = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
@@ -92,7 +92,7 @@ def get_pause_message_v3(web3):
     msg_hash = web3.solidity_keccak(['bytes32', 'uint256'], [prefix, block_number])
     signed = web3.eth.account._sign_hash(msg_hash, private_key=COUNCIL_PK)
 
-    return PauseV3Parser.build_message(
+    return build_pause_message(
         block_number=block_number,
         guardian=COUNCIL_ADDRESS,
         version=b'0x1',

--- a/tests/bots/test_unvetter.py
+++ b/tests/bots/test_unvetter.py
@@ -2,9 +2,10 @@ import logging
 from unittest.mock import Mock
 
 import pytest
+
 from bots.unvetter import UnvetterBot
 from cryptography.verify_signature import compute_vs
-from transport.msg_providers.onchain_transport import UnvetParser
+from transport.msg_providers.onchain_transport import build_unvet_message
 from transport.msg_types.common import get_messages_sign_filter
 from transport.msg_types.unvet import UnvetMessage
 from utils.bytes import from_hex_string_to_bytes
@@ -38,7 +39,7 @@ def get_unvet_message(web3) -> UnvetMessage:
     )
     signed = web3.eth.account._sign_hash(msg_hash, private_key=COUNCIL_PK)
 
-    unvet_message = UnvetParser.build_message(
+    unvet_message = build_unvet_message(
         block_number=block_number,
         block_hash=latest.hash,
         guardian=COUNCIL_ADDRESS,

--- a/tests/cryptography/test_verify_signature.py
+++ b/tests/cryptography/test_verify_signature.py
@@ -73,6 +73,25 @@ def test_compact_signature_rejects_wrong_length(length):
         compact_signature(bytes(length))
 
 
+@pytest.mark.unit
+@pytest.mark.parametrize('v', [2, 26, 29, 35, 37, 255])
+def test_compact_signature_rejects_v_outside_recovery_set(v):
+    """A v that is not a recovery id must be dropped, not reduced to an arbitrary parity."""
+    r, s = bytes(range(32)), bytes(32)
+    with pytest.raises(ValueError):
+        compact_signature(r + s + v.to_bytes(1, 'big'))
+
+
+@pytest.mark.unit
+def test_compact_signature_rejects_non_canonical_s():
+    """s with its top bit set collides with the packed v bit, so the blob must be dropped."""
+    r = bytes(range(32))
+    s = (2**255).to_bytes(32, 'big')
+    for v in (27, 28):
+        with pytest.raises(ValueError):
+            compact_signature(r + s + v.to_bytes(1, 'big'))
+
+
 def test_guardian_signature_bytes_is_r_s_v():
     # Uses a fixture message that carries explicit v and s so we can assemble the expected 65 bytes.
     dm = next(m for m in deposit_messages if 'v' in m['signature'] and 's' in m['signature'])

--- a/tests/cryptography/test_verify_signature.py
+++ b/tests/cryptography/test_verify_signature.py
@@ -1,4 +1,7 @@
+import pytest
+
 from cryptography.verify_signature import (
+    compact_signature,
     compute_vs,
     guardian_signature_bytes,
     recover_vs,
@@ -11,6 +14,7 @@ from tests.fixtures.signature_fixtures import (
 )
 from transport.msg_types.common import _vrs
 from transport.msg_types.deposit import DepositMessageSchema
+from utils.bytes import bytes_to_hex_string
 
 
 def test_deposit_schema():
@@ -37,6 +41,36 @@ def test_deposit_messages_sign_check():
             address=dm['guardianAddress'],
             vrs=vrs,
         )
+
+
+@pytest.mark.unit
+def test_compact_signature_round_trip():
+    """A 65-byte r||s||v blob must reduce to the same compact pair the council would have published."""
+    r = bytes(range(32))
+    s = (2**255 - 1).to_bytes(32, 'big')
+    for v in (27, 28):
+        compact_r, compact_vs = compact_signature(r + s + v.to_bytes(1, 'big'))
+        assert compact_r == r
+        assert bytes_to_hex_string(compact_vs) == compute_vs(v, bytes_to_hex_string(s))
+        recovered_v, recovered_s = recover_vs(bytes_to_hex_string(compact_vs))
+        assert recovered_v == v
+        assert recovered_s == int.from_bytes(s, 'big')
+
+
+@pytest.mark.unit
+def test_compact_signature_accepts_normalised_v():
+    """eth-account style v (0/1) is accepted, matching compute_vs."""
+    r, s = bytes(range(32)), bytes(32)
+    for v, expected_v in ((0, 27), (1, 28)):
+        _, compact_vs = compact_signature(r + s + v.to_bytes(1, 'big'))
+        assert recover_vs(bytes_to_hex_string(compact_vs))[0] == expected_v
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('length', [0, 64, 66])
+def test_compact_signature_rejects_wrong_length(length):
+    with pytest.raises(ValueError):
+        compact_signature(bytes(length))
 
 
 def test_guardian_signature_bytes_is_r_s_v():

--- a/tests/transport/onchain_sender.py
+++ b/tests/transport/onchain_sender.py
@@ -1,15 +1,19 @@
+from web3 import Web3
+
 from blockchain.contracts.data_bus import DataBusContract
 from transport.msg_providers.onchain_transport import (
-    DepositParser,
+    DepositV1Parser,
+    DepositV2Parser,
     PauseV3Parser,
+    PauseV4Parser,
     PingParser,
-    UnvetParser,
+    UnvetV1Parser,
+    UnvetV2Parser,
 )
 from transport.msg_types.deposit import DepositMessage
 from transport.msg_types.pause import PauseMessage
 from transport.msg_types.ping import PingMessage
 from transport.msg_types.unvet import UnvetMessage
-from web3 import Web3
 
 
 class OnchainTransportSender:
@@ -17,53 +21,65 @@ class OnchainTransportSender:
     Is used in tests to create sequence of the events emitted from the DataBus contract
     """
 
+    # Council v4 publishes the compact (r, vs) pair; council v5 publishes a flat 65-byte r||s||v blob.
     _DEFAULT_SIGNATURE = ((0).to_bytes(32), (0).to_bytes(32))
+    _DEFAULT_SIGNATURE_BYTES = bytes(65)
     _DEFAULT_BLOCK_HASH = '0x42eef33d13c4440627c3fab6e3abee85af796ae6f77dcade628b183640b519d0'
 
     def __init__(self, w3: Web3, data_bus_contract: DataBusContract):
         self._w3 = w3
         self._data_bus = data_bus_contract
 
-    def send_deposit(self, deposit_mes: DepositMessage):
-        event_id = self._w3.keccak(text=DepositParser.message_abi)
-        deposit_root, nonce, block_number, block_hash, staking_module_id, app = (
-            deposit_mes['depositRoot'],
-            deposit_mes['nonce'],
-            deposit_mes['blockNumber'],
-            deposit_mes['blockHash'],
-            deposit_mes['stakingModuleId'],
-            ((1).to_bytes(32),),
-        )
+    def send_deposit_v1(self, deposit_mes: DepositMessage):
+        event_id = self._w3.keccak(text=DepositV1Parser.message_abi)
         mes = self._w3.codec.encode(
-            types=[DepositParser.DEPOSIT_V1_DATA_SCHEMA],
-            args=[(block_number, block_hash, deposit_root, staking_module_id, nonce, self._DEFAULT_SIGNATURE, app)],
+            types=[DepositV1Parser.DEPOSIT_V1_DATA_SCHEMA],
+            args=[(*self._deposit_body(deposit_mes), self._DEFAULT_SIGNATURE, ((1).to_bytes(32),))],
+        )
+        tx = self._data_bus.functions.sendMessage(event_id, mes)
+        return tx.transact()
+
+    def send_deposit_v2(self, deposit_mes: DepositMessage):
+        event_id = self._w3.keccak(text=DepositV2Parser.message_abi)
+        mes = self._w3.codec.encode(
+            types=[DepositV2Parser.DEPOSIT_V2_DATA_SCHEMA],
+            args=[(*self._deposit_body(deposit_mes), self._DEFAULT_SIGNATURE_BYTES, ((1).to_bytes(32),))],
         )
         tx = self._data_bus.functions.sendMessage(event_id, mes)
         return tx.transact()
 
     def send_pause_v3(self, pause_mes: PauseMessage):
         pause_topic = self._w3.keccak(text=PauseV3Parser.message_abi)
-        block_number, version = pause_mes['blockNumber'], (1).to_bytes(32)
         mes = self._w3.codec.encode(
-            types=[PauseV3Parser.PAUSE_V3_DATA_SCHEMA], args=[(block_number, self._DEFAULT_BLOCK_HASH, self._DEFAULT_SIGNATURE, (version,))]
+            types=[PauseV3Parser.PAUSE_V3_DATA_SCHEMA],
+            args=[(pause_mes['blockNumber'], self._DEFAULT_BLOCK_HASH, self._DEFAULT_SIGNATURE, ((1).to_bytes(32),))],
         )
         tx = self._data_bus.functions.sendMessage(pause_topic, mes)
         return tx.transact()
 
-    def send_unvet(self, unvet_mes: UnvetMessage):
-        event_id = self._w3.keccak(text=UnvetParser.message_abi)
-        nonce, block_number, block_hash, staking_module_id, operator_ids, vetted_keys, version = (
-            unvet_mes['nonce'],
-            unvet_mes['blockNumber'],
-            unvet_mes['blockHash'],
-            unvet_mes['stakingModuleId'],
-            unvet_mes['operatorIds'],
-            unvet_mes['vettedKeysByOperator'],
-            (1).to_bytes(32),
-        )
+    def send_pause_v4(self, pause_mes: PauseMessage):
+        pause_topic = self._w3.keccak(text=PauseV4Parser.message_abi)
         mes = self._w3.codec.encode(
-            types=[UnvetParser.UNVET_V1_DATA_SCHEMA],
-            args=[(block_number, block_hash, staking_module_id, nonce, operator_ids, vetted_keys, self._DEFAULT_SIGNATURE, (version,))],
+            types=[PauseV4Parser.PAUSE_V4_DATA_SCHEMA],
+            args=[(pause_mes['blockNumber'], self._DEFAULT_BLOCK_HASH, self._DEFAULT_SIGNATURE_BYTES, ((1).to_bytes(32),))],
+        )
+        tx = self._data_bus.functions.sendMessage(pause_topic, mes)
+        return tx.transact()
+
+    def send_unvet_v1(self, unvet_mes: UnvetMessage):
+        event_id = self._w3.keccak(text=UnvetV1Parser.message_abi)
+        mes = self._w3.codec.encode(
+            types=[UnvetV1Parser.UNVET_V1_DATA_SCHEMA],
+            args=[(*self._unvet_body(unvet_mes), self._DEFAULT_SIGNATURE, ((1).to_bytes(32),))],
+        )
+        tx = self._data_bus.functions.sendMessage(event_id, mes)
+        return tx.transact()
+
+    def send_unvet_v2(self, unvet_mes: UnvetMessage):
+        event_id = self._w3.keccak(text=UnvetV2Parser.message_abi)
+        mes = self._w3.codec.encode(
+            types=[UnvetV2Parser.UNVET_V2_DATA_SCHEMA],
+            args=[(*self._unvet_body(unvet_mes), self._DEFAULT_SIGNATURE_BYTES, ((1).to_bytes(32),))],
         )
         tx = self._data_bus.functions.sendMessage(event_id, mes)
         return tx.transact()
@@ -74,3 +90,26 @@ class OnchainTransportSender:
         mes = self._w3.codec.encode(types=[PingParser.PING_V1_DATA_SCHEMA], args=[(block_number, (version,))])
         tx = self._data_bus.functions.sendMessage(event_id, mes)
         return tx.transact()
+
+    @staticmethod
+    def _deposit_body(deposit_mes: DepositMessage) -> tuple:
+        """The fields both deposit event generations share, in wire order."""
+        return (
+            deposit_mes['blockNumber'],
+            deposit_mes['blockHash'],
+            deposit_mes['depositRoot'],
+            deposit_mes['stakingModuleId'],
+            deposit_mes['nonce'],
+        )
+
+    @staticmethod
+    def _unvet_body(unvet_mes: UnvetMessage) -> tuple:
+        """The fields both unvet event generations share, in wire order."""
+        return (
+            unvet_mes['blockNumber'],
+            unvet_mes['blockHash'],
+            unvet_mes['stakingModuleId'],
+            unvet_mes['nonce'],
+            unvet_mes['operatorIds'],
+            unvet_mes['vettedKeysByOperator'],
+        )

--- a/tests/transport/test_data_bus.py
+++ b/tests/transport/test_data_bus.py
@@ -6,18 +6,21 @@ import pytest
 from eth_typing import ChecksumAddress, HexAddress, HexStr
 from schema import Or, Schema
 from web3 import Web3
-from web3.types import EventData
 
 import variables
 from blockchain.contracts.data_bus import DataBusContract
+from tests.conftest import COUNCIL_ADDRESS_1, COUNCIL_PK_1
 from tests.transport.onchain_sender import OnchainTransportSender
 from transport.msg_providers.onchain_transport import (
-    DepositParser,
+    DepositV1Parser,
+    DepositV2Parser,
     OnchainTransportProvider,
     PauseV3Parser,
+    PauseV4Parser,
     PingParser,
-    UnvetParser,
+    UnvetV1Parser,
 )
+from transport.msg_types.common import get_messages_sign_filter
 from transport.msg_types.deposit import DepositMessageSchema
 from transport.msg_types.pause import PauseMessage, PauseMessageSchema
 from transport.msg_types.ping import PingMessageSchema
@@ -29,6 +32,7 @@ _DEFAULT_DELEGATE = '0x1be2A219CBD0F18B825a4dDd580F7b3B33Bacb41'
 _ANVIL_DELEGATE = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
 _FAKE_DELEGATE = '0x4E93C8c7B06F1CEEb03A8e13B0371b35F0000000'
 _GUARDIAN_CONTRACT = '0x2C44CdDdB6a900fa2b585dd299e03d12FA4293BC'
+_ZERO_HASH = '0x0000000000000000000000000000000000000000000000000000000000000000'
 
 # Resolved at import time by pytest's parametrize decorators. The endpoint is only used when the
 # integration tests actually run (env var set); unit collection must not fail when it is unset.
@@ -58,7 +62,7 @@ def test_data_bus_provider(
         w3=web3_transaction_integration,
         onchain_address=variables.ONCHAIN_TRANSPORT_ADDRESS,
         message_schema=Schema(Or(DepositMessageSchema, PingMessageSchema)),
-        parsers_providers=[DepositParser, PingParser],
+        parsers_providers=[DepositV1Parser, DepositV2Parser, PingParser],
         delegates_provider=lambda: {Web3.to_checksum_address(_FAKE_DELEGATE): Web3.to_checksum_address(_GUARDIAN_CONTRACT)},
     )
     messages = provider.get_messages()
@@ -67,7 +71,7 @@ def test_data_bus_provider(
         w3=web3_transaction_integration,
         onchain_address=variables.ONCHAIN_TRANSPORT_ADDRESS,
         message_schema=Schema(Or(DepositMessageSchema, PingMessageSchema)),
-        parsers_providers=[DepositParser, PingParser],
+        parsers_providers=[DepositV1Parser, DepositV2Parser, PingParser],
         delegates_provider=lambda: {Web3.to_checksum_address(_DEFAULT_DELEGATE): Web3.to_checksum_address(_GUARDIAN_CONTRACT)},
     )
     messages = provider.get_messages()
@@ -95,7 +99,7 @@ def test_data_bus_provider_unvet(
         ),
     )
     onchain_sender = OnchainTransportSender(w3=web3_transaction_integration, data_bus_contract=data_bus_contract)
-    onchain_sender.send_unvet(
+    onchain_sender.send_unvet_v1(
         unvet_mes=UnvetMessage(
             type='unvet',
             blockNumber=2,
@@ -113,7 +117,7 @@ def test_data_bus_provider_unvet(
         w3=web3_transaction_integration,
         onchain_address=variables.ONCHAIN_TRANSPORT_ADDRESS,
         message_schema=Schema(Or(UnvetMessageSchema)),
-        parsers_providers=[UnvetParser],
+        parsers_providers=[UnvetV1Parser],
         delegates_provider=lambda: {Web3.to_checksum_address(_ANVIL_DELEGATE[:-1] + '7'): Web3.to_checksum_address(_GUARDIAN_CONTRACT)},
     )
     messages = provider.get_messages()
@@ -122,7 +126,7 @@ def test_data_bus_provider_unvet(
         w3=web3_transaction_integration,
         onchain_address=variables.ONCHAIN_TRANSPORT_ADDRESS,
         message_schema=Schema(Or(UnvetMessageSchema)),
-        parsers_providers=[UnvetParser],
+        parsers_providers=[UnvetV1Parser],
         delegates_provider=lambda: {Web3.to_checksum_address(_ANVIL_DELEGATE): Web3.to_checksum_address(_GUARDIAN_CONTRACT)},
     )
     messages = provider.get_messages()
@@ -170,12 +174,54 @@ def test_data_bus_provider_pause_v3(
     assert len(messages) == 1
 
 
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    'web3_provider_integration',
+    [{'endpoint': _ONCHAIN_TRANSPORT_ENDPOINT}],
+    indirect=['web3_provider_integration'],
+)
+def test_data_bus_provider_pause_v4(
+    web3_transaction_integration,
+):
+    """
+    Same round trip as pause v3, over the council v5 event that carries a flat `bytes` signature.
+    """
+    variables.ONCHAIN_TRANSPORT_ADDRESS = ChecksumAddress(HexAddress(HexStr('0x37De961D6bb5865867aDd416be07189D2Dd960e6')))
+    data_bus_contract = cast(
+        DataBusContract,
+        web3_transaction_integration.eth.contract(
+            address=variables.ONCHAIN_TRANSPORT_ADDRESS,
+            ContractFactoryClass=DataBusContract,
+        ),
+    )
+    onchain_sender = OnchainTransportSender(w3=web3_transaction_integration, data_bus_contract=data_bus_contract)
+    onchain_sender.send_pause_v4(
+        pause_mes=PauseMessage(
+            type='pause',
+            blockNumber=2,
+            guardianAddress=_ANVIL_DELEGATE,
+            app={'version': b'3.2.0'.rjust(32, b'\0')},
+        )
+    )
+    web3_transaction_integration.provider.make_request('anvil_mine', [10])
+    provider = OnchainTransportProvider(
+        w3=web3_transaction_integration,
+        onchain_address=variables.ONCHAIN_TRANSPORT_ADDRESS,
+        message_schema=Schema(Or(PauseMessageSchema)),
+        parsers_providers=[PauseV3Parser, PauseV4Parser],
+        delegates_provider=lambda: _delegate_map(delegate=_ANVIL_DELEGATE),
+    )
+    messages = provider.get_messages()
+    assert len(messages) == 1
+
+
 def _delegate_map(delegate: str = _DEFAULT_DELEGATE, guardian: str = _GUARDIAN_CONTRACT) -> dict:
     return {Web3.to_checksum_address(delegate): Web3.to_checksum_address(guardian)}
 
 
 @pytest.mark.unit
 def test_data_bus_mock_responses(web3_lido_unit):
+    """Both deposit event generations reach the storage through a single provider."""
     with mock.patch('web3.eth.Eth.chain_id', new_callable=mock.PropertyMock) as mock_chain_id:
         mock_chain_id.return_value = 1
         receipts = mock_receipts(web3_lido_unit)
@@ -183,19 +229,31 @@ def test_data_bus_mock_responses(web3_lido_unit):
         web3_lido_unit.is_connected = Mock(return_value=True)
         web3_lido_unit.eth.get_balance = Mock(return_value=1)
         web3_lido_unit.eth.get_block_number = Mock(return_value=1)
-        provider = OnchainTransportProvider(
-            w3=web3_lido_unit,
-            onchain_address=variables.ONCHAIN_TRANSPORT_ADDRESS,
-            message_schema=Schema(Or(DepositMessageSchema, PingMessageSchema)),
-            parsers_providers=[DepositParser, PingParser],
-            delegates_provider=_delegate_map,
-        )
-
-        for parser in provider._parsers:
-            parser._decode_event = Mock(side_effect=lambda x: x)
+        provider = _stubbed_provider(web3_lido_unit, [DepositV1Parser, DepositV2Parser, PingParser])
 
         messages = provider.get_messages()
         assert len(messages) == len(receipts)
+
+
+@pytest.mark.unit
+def test_parsers_are_dispatched_by_event_id(web3_lido_unit):
+    """A log must be handed to the parser that declared its event id, not to the first parser that
+    happens to decode it: the V1 layout decodes a V2 payload without raising (the offset word reads as
+    blockNumber), so a fallback chain would silently turn every council v5 message into garbage.
+    """
+    with mock.patch('web3.eth.Eth.chain_id', new_callable=mock.PropertyMock) as mock_chain_id:
+        mock_chain_id.return_value = 1
+        v1_log = _deposit_v1_log(web3_lido_unit, block_number=11, nonce=1)
+        v2_log = _deposit_v2_log(web3_lido_unit, block_number=22, nonce=2, signature=bytes(65))
+        web3_lido_unit.eth.get_logs = Mock(side_effect=[[v1_log, v2_log], None])
+        web3_lido_unit.eth.get_block_number = Mock(return_value=1)
+        # V1 first, so the removed fallback chain would have claimed the V2 log here.
+        provider = _stubbed_provider(web3_lido_unit, [DepositV1Parser, DepositV2Parser])
+
+        messages = provider.get_messages()
+
+        assert [message['blockNumber'] for message in messages] == [11, 22]
+        assert [message['nonce'] for message in messages] == [1, 2]
 
 
 @pytest.mark.unit
@@ -207,15 +265,7 @@ def test_data_bus_reverse_maps_sender_to_guardian(web3_lido_unit):
         receipts = mock_receipts(web3_lido_unit)
         web3_lido_unit.eth.get_logs = Mock(side_effect=[receipts, None])
         web3_lido_unit.eth.get_block_number = Mock(return_value=1)
-        provider = OnchainTransportProvider(
-            w3=web3_lido_unit,
-            onchain_address=variables.ONCHAIN_TRANSPORT_ADDRESS,
-            message_schema=Schema(Or(DepositMessageSchema, PingMessageSchema)),
-            parsers_providers=[DepositParser, PingParser],
-            delegates_provider=_delegate_map,
-        )
-        for parser in provider._parsers:
-            parser._decode_event = Mock(side_effect=lambda x: x)
+        provider = _stubbed_provider(web3_lido_unit, [DepositV1Parser, DepositV2Parser, PingParser])
 
         messages = provider.get_messages()
 
@@ -233,73 +283,120 @@ def test_data_bus_drops_unmapped_sender(web3_lido_unit):
         receipts = mock_receipts(web3_lido_unit)
         web3_lido_unit.eth.get_logs = Mock(side_effect=[receipts, None])
         web3_lido_unit.eth.get_block_number = Mock(return_value=1)
-        provider = OnchainTransportProvider(
-            w3=web3_lido_unit,
-            onchain_address=variables.ONCHAIN_TRANSPORT_ADDRESS,
-            message_schema=Schema(Or(DepositMessageSchema, PingMessageSchema)),
-            parsers_providers=[DepositParser, PingParser],
-            # sender in the receipts (_DEFAULT_DELEGATE) is absent from the map → all dropped.
+        # sender in the receipts (_DEFAULT_DELEGATE) is absent from the map → all dropped.
+        provider = _stubbed_provider(
+            web3_lido_unit,
+            [DepositV1Parser, DepositV2Parser, PingParser],
             delegates_provider=lambda: _delegate_map(delegate=_FAKE_DELEGATE),
         )
-        for parser in provider._parsers:
-            parser._decode_event = Mock(side_effect=lambda x: x)
 
         assert provider.get_messages() == []
 
 
-# event MessageDepositV1(address indexed guardianAddress, (uint256 blockNumber, bytes32 blockHash, bytes32 depositRoot,
-# uint256 stakingModuleId, uint256 nonce, (bytes32 r, bytes32 vs) signature, (bytes32 version) app) data),
+@pytest.mark.unit
+def test_deposit_v2_signature_passes_sign_filter(web3_lido_unit):
+    """The flat 65-byte `r || s || v` blob of a council v5 message must normalise into a compact
+    `(r, _vs)` pair the sign filter still recovers the guardian from.
+    """
+    prefix = bytes(31) + b'\x01'
+    block_number, block_hash, deposit_root, module_id, nonce = 42, bytes(32), bytes(32), 1, 7
+    msg_hash = Web3.solidity_keccak(
+        ['bytes32', 'uint256', 'bytes32', 'bytes32', 'uint256', 'uint256'],
+        [prefix, block_number, block_hash, deposit_root, module_id, nonce],
+    )
+    signed = web3_lido_unit.eth.account._sign_hash(msg_hash, private_key=COUNCIL_PK_1)
+    signature = signed.r.to_bytes(32, 'big') + signed.s.to_bytes(32, 'big') + signed.v.to_bytes(1, 'big')
 
-# event MessageDepositV1(address indexed guardianAddress, (bytes32 depositRoot, uint256 nonce, uint256 blockNumber, bytes32 blockHash,
-# bytes signature, uint256 stakingModuleId, (bytes32 version) app) data)",
+    parser = DepositV2Parser(web3_lido_unit)
+    parser._decode_event = Mock(side_effect=lambda log: log)
+    message = parser.parse(
+        _deposit_v2_log(
+            web3_lido_unit,
+            block_number=block_number,
+            nonce=nonce,
+            signature=signature,
+            sender=COUNCIL_ADDRESS_1,
+            staking_module_id=module_id,
+        )
+    )
+
+    assert DepositMessageSchema.is_valid(message)
+    assert list(filter(get_messages_sign_filter(prefix), [message]))
 
 
-def mock_receipts(w3: Web3) -> list[EventData]:
+@pytest.mark.unit
+def test_deposit_v2_rejects_malformed_signature(web3_lido_unit):
+    """A signature blob of the wrong length is dropped, not silently truncated into a valid message."""
+    with mock.patch('web3.eth.Eth.chain_id', new_callable=mock.PropertyMock) as mock_chain_id:
+        mock_chain_id.return_value = 1
+        web3_lido_unit.eth.get_logs = Mock(side_effect=[[_deposit_v2_log(web3_lido_unit, 1, 1, signature=bytes(64))], None])
+        web3_lido_unit.eth.get_block_number = Mock(return_value=1)
+        provider = _stubbed_provider(web3_lido_unit, [DepositV2Parser])
+
+        assert not provider.get_messages()
+
+
+def _stubbed_provider(w3: Web3, parsers_providers: list, delegates_provider=_delegate_map) -> OnchainTransportProvider:
+    """Provider whose parsers skip log decoding — the mock logs already carry decoded `args`."""
+    provider = OnchainTransportProvider(
+        w3=w3,
+        onchain_address=variables.ONCHAIN_TRANSPORT_ADDRESS,
+        message_schema=Schema(Or(DepositMessageSchema, PingMessageSchema)),
+        parsers_providers=parsers_providers,
+        delegates_provider=delegates_provider,
+    )
+    for parser in provider._parsers_by_event_id.values():
+        parser._decode_event = Mock(side_effect=lambda log: log)
+    return provider
+
+
+def _log(w3: Web3, message_abi: str, data: bytes, sender: str = _DEFAULT_DELEGATE) -> dict:
+    """A Data Bus log shaped just enough for the provider: topic0 selects the parser, `args` stands in
+    for what `_decode_event` would have produced."""
+    return {'topics': [w3.keccak(text=message_abi)], 'args': {'sender': sender, 'data': data}}
+
+
+def _ping_log(w3: Web3, block_number: int) -> dict:
+    return _log(w3, PingParser.message_abi, w3.codec.encode(types=[PingParser.PING_V1_DATA_SCHEMA], args=[(block_number, (_ZERO_HASH,))]))
+
+
+def _deposit_v1_log(w3: Web3, block_number: int, nonce: int, staking_module_id: int = 3) -> dict:
+    data = w3.codec.encode(
+        types=[DepositV1Parser.DEPOSIT_V1_DATA_SCHEMA],
+        args=[
+            (
+                block_number,
+                '0x42eef33d13c4440627c3fab6e3abee85af796ae6f77dcade628b183640b519d0',
+                _ZERO_HASH,
+                staking_module_id,
+                nonce,
+                ((0).to_bytes(32), (0).to_bytes(32)),
+                (_ZERO_HASH,),
+            )
+        ],
+    )
+    return _log(w3, DepositV1Parser.message_abi, data)
+
+
+def _deposit_v2_log(
+    w3: Web3,
+    block_number: int,
+    nonce: int,
+    signature: bytes,
+    sender: str = _DEFAULT_DELEGATE,
+    staking_module_id: int = 3,
+) -> dict:
+    data = w3.codec.encode(
+        types=[DepositV2Parser.DEPOSIT_V2_DATA_SCHEMA],
+        args=[(block_number, _ZERO_HASH, _ZERO_HASH, staking_module_id, nonce, signature, (_ZERO_HASH,))],
+    )
+    return _log(w3, DepositV2Parser.message_abi, data, sender=sender)
+
+
+def mock_receipts(w3: Web3) -> list[dict]:
     return [
-        EventData(
-            args={
-                'sender': _DEFAULT_DELEGATE,
-                'data': w3.codec.encode(
-                    types=[PingParser.PING_V1_DATA_SCHEMA],
-                    args=[(1, ('0x0000000000000000000000000000000000000000000000000000000000000000',))],
-                ),
-            },
-        ),
-        EventData(
-            args={
-                'sender': _DEFAULT_DELEGATE,
-                'data': w3.codec.encode(
-                    types=[DepositParser.DEPOSIT_V1_DATA_SCHEMA],
-                    args=[
-                        (
-                            2,
-                            '0x42eef33d13c4440627c3fab6e3abee85af796ae6f77dcade628b183640b519d0',
-                            '0x0000000000000000000000000000000000000000000000000000000000000000',
-                            3,
-                            40,
-                            ((0).to_bytes(32), (0).to_bytes(32)),
-                            ('0x0000000000000000000000000000000000000000000000000000000000000000',),
-                        )
-                    ],
-                ),
-            },
-        ),
-        EventData(
-            args={
-                'sender': _DEFAULT_DELEGATE,
-                'data': w3.codec.encode(
-                    types=[PingParser.PING_V1_DATA_SCHEMA],
-                    args=[(3, ('0x0000000000000000000000000000000000000000000000000000000000000000',))],
-                ),
-            },
-        ),
-        EventData(
-            args={
-                'sender': _DEFAULT_DELEGATE,
-                'data': w3.codec.encode(
-                    types=[PingParser.PING_V1_DATA_SCHEMA],
-                    args=[(4, ('0x0000000000000000000000000000000000000000000000000000000000000000',))],
-                ),
-            },
-        ),
+        _ping_log(w3, block_number=1),
+        _deposit_v1_log(w3, block_number=2, nonce=40),
+        _deposit_v2_log(w3, block_number=3, nonce=41, signature=bytes(65)),
+        _ping_log(w3, block_number=4),
     ]

--- a/tests/transport/test_data_bus.py
+++ b/tests/transport/test_data_bus.py
@@ -19,6 +19,7 @@ from transport.msg_providers.onchain_transport import (
     PauseV4Parser,
     PingParser,
     UnvetV1Parser,
+    UnvetV2Parser,
 )
 from transport.msg_types.common import get_messages_sign_filter
 from transport.msg_types.deposit import DepositMessageSchema
@@ -325,6 +326,71 @@ def test_deposit_v2_signature_passes_sign_filter(web3_lido_unit):
 
 
 @pytest.mark.unit
+def test_unvet_v2_signature_passes_sign_filter(web3_lido_unit):
+    """Same round-trip as the deposit V2 case, for unvet: the flat blob must normalise into a compact
+    pair the sign filter still recovers the guardian from. This is what pins the V2 field order —
+    a reordered schema changes the digest and only shows up as a silently dropped message.
+    """
+    prefix = bytes(31) + b'\x02'
+    block_number, block_hash, module_id, nonce = 42, bytes(32), 1, 7
+    operator_ids, vetted_keys = (1).to_bytes(8, 'big'), (2).to_bytes(16, 'big')
+    msg_hash = Web3.solidity_keccak(
+        ['bytes32', 'uint256', 'bytes32', 'uint256', 'uint256', 'bytes', 'bytes'],
+        [prefix, block_number, block_hash, module_id, nonce, operator_ids, vetted_keys],
+    )
+    signed = web3_lido_unit.eth.account._sign_hash(msg_hash, private_key=COUNCIL_PK_1)
+    signature = signed.r.to_bytes(32, 'big') + signed.s.to_bytes(32, 'big') + signed.v.to_bytes(1, 'big')
+
+    parser = UnvetV2Parser(web3_lido_unit)
+    parser._decode_event = Mock(side_effect=lambda log: log)
+    message = parser.parse(
+        _unvet_v2_log(
+            web3_lido_unit,
+            block_number=block_number,
+            nonce=nonce,
+            signature=signature,
+            sender=COUNCIL_ADDRESS_1,
+            staking_module_id=module_id,
+            operator_ids=operator_ids,
+            vetted_keys_by_operator=vetted_keys,
+        )
+    )
+
+    assert UnvetMessageSchema.is_valid(message)
+    assert list(filter(get_messages_sign_filter(prefix), [message]))
+
+
+@pytest.mark.unit
+def test_unvet_parsers_are_dispatched_by_event_id(web3_lido_unit):
+    """Both unvet generations reach the storage through one provider, each via its own parser."""
+    with mock.patch('web3.eth.Eth.chain_id', new_callable=mock.PropertyMock) as mock_chain_id:
+        mock_chain_id.return_value = 1
+        v1_log = _unvet_v1_log(web3_lido_unit, block_number=11, nonce=1)
+        v2_log = _unvet_v2_log(web3_lido_unit, block_number=22, nonce=2, signature=bytes(65))
+        web3_lido_unit.eth.get_logs = Mock(side_effect=[[v1_log, v2_log], None])
+        web3_lido_unit.eth.get_block_number = Mock(return_value=1)
+        provider = _stubbed_provider(web3_lido_unit, [UnvetV1Parser, UnvetV2Parser], message_schema=Schema(UnvetMessageSchema))
+
+        messages = provider.get_messages()
+
+        assert [message['blockNumber'] for message in messages] == [11, 22]
+        assert [message['nonce'] for message in messages] == [1, 2]
+
+
+@pytest.mark.unit
+def test_unvet_v2_rejects_malformed_signature(web3_lido_unit):
+    """A signature blob of the wrong length is dropped, not silently truncated into a valid message."""
+    with mock.patch('web3.eth.Eth.chain_id', new_callable=mock.PropertyMock) as mock_chain_id:
+        mock_chain_id.return_value = 1
+        malformed = _unvet_v2_log(web3_lido_unit, block_number=1, nonce=1, signature=bytes(64))
+        web3_lido_unit.eth.get_logs = Mock(side_effect=[[malformed], None])
+        web3_lido_unit.eth.get_block_number = Mock(return_value=1)
+        provider = _stubbed_provider(web3_lido_unit, [UnvetV2Parser], message_schema=Schema(UnvetMessageSchema))
+
+        assert not provider.get_messages()
+
+
+@pytest.mark.unit
 def test_deposit_v2_rejects_malformed_signature(web3_lido_unit):
     """A signature blob of the wrong length is dropped, not silently truncated into a valid message."""
     with mock.patch('web3.eth.Eth.chain_id', new_callable=mock.PropertyMock) as mock_chain_id:
@@ -336,12 +402,17 @@ def test_deposit_v2_rejects_malformed_signature(web3_lido_unit):
         assert not provider.get_messages()
 
 
-def _stubbed_provider(w3: Web3, parsers_providers: list, delegates_provider=_delegate_map) -> OnchainTransportProvider:
+def _stubbed_provider(
+    w3: Web3,
+    parsers_providers: list,
+    delegates_provider=_delegate_map,
+    message_schema: Schema = Schema(Or(DepositMessageSchema, PingMessageSchema)),
+) -> OnchainTransportProvider:
     """Provider whose parsers skip log decoding — the mock logs already carry decoded `args`."""
     provider = OnchainTransportProvider(
         w3=w3,
         onchain_address=variables.ONCHAIN_TRANSPORT_ADDRESS,
-        message_schema=Schema(Or(DepositMessageSchema, PingMessageSchema)),
+        message_schema=message_schema,
         parsers_providers=parsers_providers,
         delegates_provider=delegates_provider,
     )
@@ -391,6 +462,53 @@ def _deposit_v2_log(
         args=[(block_number, _ZERO_HASH, _ZERO_HASH, staking_module_id, nonce, signature, (_ZERO_HASH,))],
     )
     return _log(w3, DepositV2Parser.message_abi, data, sender=sender)
+
+
+def _unvet_v1_log(w3: Web3, block_number: int, nonce: int, staking_module_id: int = 1) -> dict:
+    data = w3.codec.encode(
+        types=[UnvetV1Parser.UNVET_V1_DATA_SCHEMA],
+        args=[
+            (
+                block_number,
+                _ZERO_HASH,
+                staking_module_id,
+                nonce,
+                (0).to_bytes(8, 'big'),
+                (0).to_bytes(16, 'big'),
+                ((0).to_bytes(32), (0).to_bytes(32)),
+                (_ZERO_HASH,),
+            )
+        ],
+    )
+    return _log(w3, UnvetV1Parser.message_abi, data)
+
+
+def _unvet_v2_log(
+    w3: Web3,
+    block_number: int,
+    nonce: int,
+    signature: bytes,
+    sender: str = _DEFAULT_DELEGATE,
+    staking_module_id: int = 1,
+    operator_ids: bytes = (0).to_bytes(8, 'big'),
+    vetted_keys_by_operator: bytes = (0).to_bytes(16, 'big'),
+) -> dict:
+    data = w3.codec.encode(
+        types=[UnvetV2Parser.UNVET_V2_DATA_SCHEMA],
+        args=[
+            (
+                block_number,
+                _ZERO_HASH,
+                staking_module_id,
+                nonce,
+                operator_ids,
+                vetted_keys_by_operator,
+                signature,
+                (_ZERO_HASH,),
+            )
+        ],
+    )
+    return _log(w3, UnvetV2Parser.message_abi, data, sender=sender)
 
 
 def mock_receipts(w3: Web3) -> list[dict]:

--- a/tests/utils/protocol_utils.py
+++ b/tests/utils/protocol_utils.py
@@ -1,5 +1,5 @@
 from cryptography.verify_signature import compute_vs
-from transport.msg_providers.onchain_transport import DepositParser
+from transport.msg_providers.onchain_transport import build_deposit_message
 from transport.msg_types.deposit import DepositMessage
 from utils.bytes import from_hex_string_to_bytes
 
@@ -20,7 +20,7 @@ def get_deposit_message(web3, account_address, pk, module_id) -> DepositMessage:
     )
     signed = web3.eth.account._sign_hash(msg_hash, private_key=pk)
 
-    return DepositParser.build_message(
+    return build_deposit_message(
         block_number=latest.number,
         block_hash=latest.hash,
         guardian=account_address,


### PR DESCRIPTION
Stacked on #367, and #368 is stacked on this one.

Council v5 publishes new Data Bus events whose guardian signature is a flat 65-byte `bytes` blob (`r ‖ s ‖ v`) instead of the compact `(bytes32 r, bytes32 vs)` pair:

| | council v4 | council v5 |
|---|---|---|
| deposit | `MessageDepositV1` | `MessageDepositV2` |
| pause | `MessagePauseV3` | `MessagePauseV4` |
| unvet | `MessageUnvetV1` | `MessageUnvetV2` |
| ping | `MessagePingV1` | `MessagePingV1` (unchanged, unsigned) |

Councils roll over one by one, so **both generations must be accepted at the same time**. The new events get their own parsers registered alongside the existing ones (`DepositParser`/`UnvetParser` renamed to `DepositV1Parser`/`UnvetV1Parser` for symmetry with the already-versioned `PauseV3Parser`).

### One internal signature representation

Parsers normalise the v5 blob back into the compact `(r, _vs)` pair via `compact_signature()`, so **nothing downstream is version-aware** — RabbitMQ transport, the sign filter and both DSM versions keep working unchanged. The conversion is lossless (`_vs` is `s` with the parity of `v` in its top bit) and reuses `compute_vs`, so the packing rule has a single implementation; it is the exact inverse of `guardian_signature_bytes` added in #367 for DSMv5 submission.

### Dispatch by event id — this part is a bug fix, not a refactor

`_parse_log` previously tried every parser until one did not raise. That is unsafe once two generations are live: **the V1 ABI layout decodes a V2 payload without raising** — the tuple's offset word is read as `blockNumber` — which was verified against the real codec:

```
V1 decodes V2 payload -> SUCCESS (blockNumber=32, garbage r/vs)
V2 decodes V1 payload -> raises InvalidPointer
```

Since `DepositV1Parser` comes first in the list, every council v5 message would have been silently turned into a garbage message that only fails later at signature verification: no error, no quorum, indistinguishable from silence. Logs are now dispatched on `topic0` to the parser that declared it. `test_parsers_are_dispatched_by_event_id` fails on the old logic with `[11, 32] != [11, 22]`.

### Tests

- topic0 dispatch (regression test for the above)
- a real signed v5 deposit survives `get_messages_sign_filter` after normalisation — proves the wire→internal conversion preserves signature validity
- malformed blob length is dropped, not truncated into a valid-looking message
- `compact_signature` round-trip against `compute_vs`/`recover_vs` for `v ∈ {0, 1, 27, 28}`
- `pause_v4` integration round trip; `OnchainTransportSender` can emit both generations

### Follow-up

`build_*_message` helpers moved to module level (both generations share them), and `EventParser.message_abi` became a `ClassVar[str]` instead of an abstract property — otherwise the three new parser classes each added pyright errors. Net pyright: 58 → 51 errors on `src/`.

**Cleanup after the on-chain rollout completes: delete the V1/V3 parsers and their tests.** Documented in `CLAUDE.md`.
