### PR TITLE
ORC-785: feat: execute TopUpGateway.topUp through an EDF delegation contract (LIP-37)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,10 @@ PROMETHEUS_PREFIX=depositor_bot
 ENABLE_TOP_UP=false
 # Set maximum number of validators per transaction
 MAX_VALIDATORS_PER_TOP_UP=32
+# EDF delegation contract (LIP-37) that holds TOP_UP_ROLE on TopUpGateway, with this bot's account as
+# its delegate. Top-ups are then executed through it. Leave unset to call topUp() directly, which
+# requires TOP_UP_ROLE on the bot's own account.
+# EDF_DELEGATION_CONTRACT=
 # Keys api url
 KEYS_API_URL=https://keys-api.lido.fi
 # CL url

--- a/.env.example
+++ b/.env.example
@@ -50,9 +50,10 @@ ENABLE_TOP_UP=false
 # Set maximum number of validators per transaction
 MAX_VALIDATORS_PER_TOP_UP=32
 # EDF delegation contract (LIP-37) that holds TOP_UP_ROLE on TopUpGateway, with this bot's account as
-# its delegate. Top-ups are then executed through it. Leave unset to call topUp() directly, which
-# requires TOP_UP_ROLE on the bot's own account.
-# EDF_DELEGATION_CONTRACT=
+# its delegate. Top-ups are executed through it whenever it holds the role; the bot falls back to a
+# direct topUp() call when its own account holds it instead, so the role can be migrated in either
+# direction without a restart. Leave unset to always call topUp() directly.
+# DELEGATION_CONTRACT_ADDRESS=
 # Keys api url
 KEYS_API_URL=https://keys-api.lido.fi
 # CL url

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,14 @@ The general strategy uses a cubic formula to compute a recommended gas ceiling: 
 
 `TransactionUtils.send()` (`src/blockchain/web3_extentions/transaction.py`) builds an EIP-1559 transaction with dynamic gas estimation. If `RELAY_RPC` and `AUCTION_BUNDLER_PRIVATE_KEY` are configured, it attempts Flashbots relay first, falling back to classic broadcast on `PrivateRelayException`. When `CREATE_TRANSACTIONS=false` (default), the method logs and returns `True` without broadcasting — safe for dry runs.
 
+#### Delegated execution (EDF, LIP-37)
+
+`TopUpGateway.topUp` is the **only** permissioned call the bot makes (`TOP_UP_ROLE`, AccessControl). When `EDF_DELEGATION_CONTRACT` is set, the role lives on that delegation contract and the tx is wrapped as `delegation.execute(topUpGateway, <topUp calldata>)` — `DelegationContract.wrap()` in `src/blockchain/contracts/delegation.py`. The bot's key is then the contract's *delegate*, so rotating the key is a `nominateDelegate` by the contract's owner instead of a `grantRole`/`revokeRole` on TopUpGateway. Unset → direct call, and `TOP_UP_ROLE` must be on the bot's own account.
+
+Wrapping happens **before** `transaction.check()`/gas estimation, so the dry-run simulates what actually gets mined; simulating the unwrapped call would revert with `AccessControlUnauthorizedAccount`.
+
+Deposits, pause and unvet are deliberately **not** wrapped. DSM v5 authorises `depositBufferedEther` purely from the guardian signatures in calldata — it never reads `msg.sender` — so wrapping would only add gas and couple deposits to delegate state. `pauseDeposits`/`unvetSigningKeys` do have a `msg.sender`-is-guardian branch, but the bot always holds a signed council message, so the signature path is always open to it and making its hot key a guardian delegate would let that key pause deposits with no quorum.
+
 ### Logging convention
 
 All log calls use structured dict format:
@@ -154,18 +162,22 @@ Walk the gates in order; the first one that isn't "pass" is almost always the wh
 Module-level gates (Prometheus, defined in `src/metrics/metrics.py`, set in `src/bots/depositor.py`):
 
 1. `topup_gateway_paused == 0` (and `variables.ENABLE_TOP_UP` is true — checked at startup, not a metric).
-2. `module_allocation_wei{module_id, kind="topup"} > 0`. Zero here is the single most common reason
+2. `topup_delegation_state` is `disabled` (no EDF delegation contract — direct `topUp` calls) or
+   `ready`. `not_delegate` / `terminated` / `role_missing` each make *every* top-up revert, so the bot
+   refuses to start in those states; seeing one at runtime means the delegation changed under a
+   running bot (delegate rotated or revoked, contract terminated, role removed).
+3. `module_allocation_wei{module_id, kind="topup"} > 0`. Zero here is the single most common reason
    nothing happens — the StakingRouter allocation algorithm didn't route ETH to this module at all
    this cycle.
-3. `module_stake_wei{module_id, kind="topup"}` — lowest value across candidate modules goes first.
+4. `module_stake_wei{module_id, kind="topup"}` — lowest value across candidate modules goes first.
    Only **one** module is acted on per bot iteration (`_phase_full_and_topup` returns on the first
    non-`SKIPPED` outcome), so a module that lost the priority race this cycle never gets its
    `phase_outcome`/`quorum_state` touched — those stay at whatever they were last time this module
    *was* reached. Tell "evaluated and skipped" from "not reached this cycle" by comparing
    `phase_last_run_timestamp_seconds{phase="B", module_id}` against `module_allocation_wei`'s own
    freshness (both are set every cycle regardless of whether the module becomes a candidate).
-4. `topup_gas_ok{module_id}` / `topup_gas_fee_wei{type}`.
-5. `phase_outcome{phase="B", module_id} != wait_distance` (TopUpGateway block distance).
+5. `topup_gas_ok{module_id}` / `topup_gas_fee_wei{type}`.
+6. `phase_outcome{phase="B", module_id} != wait_distance` (TopUpGateway block distance).
 
 Key-level gates — module_id is now known, question narrows to pubkey X. Instrumented in
 `CMv2TopUpStrategy` (`src/blockchain/topup/cmv2_strategy.py`), evaluated in this order:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,9 @@ Module-level gates (Prometheus, defined in `src/metrics/metrics.py`, set in `src
 2. `topup_execution_path` is `direct` or `delegated` — both healthy, and which one is live tells you
    where `TOP_UP_ROLE` currently sits. `not_delegate` / `terminated` / `no_role` each make *every*
    top-up revert. Seeing one at runtime means the role assignment changed under a running bot
-   (delegate rotated or revoked, contract terminated, role removed from both identities).
+   (delegate rotated or revoked, contract terminated, role removed from both identities). Resolved
+   before every early return in `_execute_actual()` (alongside `topup_gateway_paused`), so it stays
+   trustworthy on idle iterations — an empty buffer would otherwise freeze it at its last value.
 3. `module_allocation_wei{module_id, kind="topup"} > 0`. Zero here is the single most common reason
    nothing happens — the StakingRouter allocation algorithm didn't route ETH to this module at all
    this cycle.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,17 @@ The general strategy uses a cubic formula to compute a recommended gas ceiling: 
 
 #### Delegated execution (EDF, LIP-37)
 
-`TopUpGateway.topUp` is the **only** permissioned call the bot makes (`TOP_UP_ROLE`, AccessControl). When `EDF_DELEGATION_CONTRACT` is set, the role lives on that delegation contract and the tx is wrapped as `delegation.execute(topUpGateway, <topUp calldata>)` — `DelegationContract.wrap()` in `src/blockchain/contracts/delegation.py`. The bot's key is then the contract's *delegate*, so rotating the key is a `nominateDelegate` by the contract's owner instead of a `grantRole`/`revokeRole` on TopUpGateway. Unset → direct call, and `TOP_UP_ROLE` must be on the bot's own account.
+`TopUpGateway.topUp` is the **only** permissioned call the bot makes (`TOP_UP_ROLE`, AccessControl). It can be sent by either identity, and **which one is used is resolved from chain state, not from configuration** — `DepositorBot._resolve_topup_path()`, once per iteration:
+
+| resolved path | condition |
+|---|---|
+| `delegated` | `DELEGATION_CONTRACT_ADDRESS` holds `TOP_UP_ROLE`, is not terminated, and the bot's key is its active delegate → tx wrapped as `delegation.execute(topUpGateway, <topUp calldata>)` (`DelegationContract.wrap()`) |
+| `direct` | otherwise, and the bot's own account holds the role → plain `topUp` call |
+| `not_delegate` / `terminated` / `no_role` | nothing can execute; see the gate ladder below |
+
+Delegation is preferred and the key is the fallback, so migrating the role in either direction needs no restart timed to the `grantRole`/`revokeRole` transactions — the bot follows the role on its next cycle. Same idea as `SignerModule.process_members` in lido-oracle, which resolves the active identity from the HashConsensus member list each cycle. With the role on the delegation contract, rotating the bot's key becomes a `nominateDelegate` by the contract's owner instead of an ACL change on TopUpGateway.
+
+Startup refuses to boot only when a delegation contract *is* configured and no path can execute. `no_role` with no delegation configured is the pre-existing "role was never granted to the key" mistake — now visible on the metric, but kept a warning so upgrading a running deployment can't turn into a boot failure.
 
 Wrapping happens **before** `transaction.check()`/gas estimation, so the dry-run simulates what actually gets mined; simulating the unwrapped call would revert with `AccessControlUnauthorizedAccount`.
 
@@ -162,10 +172,10 @@ Walk the gates in order; the first one that isn't "pass" is almost always the wh
 Module-level gates (Prometheus, defined in `src/metrics/metrics.py`, set in `src/bots/depositor.py`):
 
 1. `topup_gateway_paused == 0` (and `variables.ENABLE_TOP_UP` is true — checked at startup, not a metric).
-2. `topup_delegation_state` is `disabled` (no EDF delegation contract — direct `topUp` calls) or
-   `ready`. `not_delegate` / `terminated` / `role_missing` each make *every* top-up revert, so the bot
-   refuses to start in those states; seeing one at runtime means the delegation changed under a
-   running bot (delegate rotated or revoked, contract terminated, role removed).
+2. `topup_execution_path` is `direct` or `delegated` — both healthy, and which one is live tells you
+   where `TOP_UP_ROLE` currently sits. `not_delegate` / `terminated` / `no_role` each make *every*
+   top-up revert. Seeing one at runtime means the role assignment changed under a running bot
+   (delegate rotated or revoked, contract terminated, role removed from both identities).
 3. `module_allocation_wei{module_id, kind="topup"} > 0`. Zero here is the single most common reason
    nothing happens — the StakingRouter allocation algorithm didn't route ETH to this module at all
    this cycle.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Next cases requires bot restart:
 | ONCHAIN_TRANSPORT_RPC_ENDPOINTS   | -             | RPC endpoint for the databus RPC, Gnosis at the moment                                                                   |
 | QUORUM_RETENTION_MINUTES          | 5             | TTL of quorum collection for marking module as healthy                                                                   |
 | MAX_VALIDATORS_PER_TOP_UP         | 32            | Maximum number of validators per top-up transaction                                                                      |
-| EDF_DELEGATION_CONTRACT           | -             | EDF delegation contract (LIP-37) holding TOP_UP_ROLE, with this bot's account as its delegate. Unset → direct topUp calls |
+| DELEGATION_CONTRACT_ADDRESS        | -             | EDF delegation contract (LIP-37) holding TOP_UP_ROLE, with this bot's account as its delegate. Used for top-ups when it holds the role; the bot falls back to a direct call when its own account holds it |
 | CONSOLIDATION_BUS_ADDRESS         | -             | ConsolidationBus address override. Defaults to the hardcoded per-chain value; top-up is skipped if the chain is unknown  |
 | CONSOLIDATION_BUS_DEPLOY_BLOCK    | -             | ConsolidationBus deploy block override (must be exact-or-earlier). Used together with CONSOLIDATION_BUS_ADDRESS          |
 | CONSOLIDATION_GETLOGS_CHUNK       | 10000         | Block-range size per getLogs call when indexing ConsolidationBus events                                                  |

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Next cases requires bot restart:
 | ONCHAIN_TRANSPORT_RPC_ENDPOINTS   | -             | RPC endpoint for the databus RPC, Gnosis at the moment                                                                   |
 | QUORUM_RETENTION_MINUTES          | 5             | TTL of quorum collection for marking module as healthy                                                                   |
 | MAX_VALIDATORS_PER_TOP_UP         | 32            | Maximum number of validators per top-up transaction                                                                      |
+| EDF_DELEGATION_CONTRACT           | -             | EDF delegation contract (LIP-37) holding TOP_UP_ROLE, with this bot's account as its delegate. Unset → direct topUp calls |
 | CONSOLIDATION_BUS_ADDRESS         | -             | ConsolidationBus address override. Defaults to the hardcoded per-chain value; top-up is skipped if the chain is unknown  |
 | CONSOLIDATION_BUS_DEPLOY_BLOCK    | -             | ConsolidationBus deploy block override (must be exact-or-earlier). Used together with CONSOLIDATION_BUS_ADDRESS          |
 | CONSOLIDATION_GETLOGS_CHUNK       | 10000         | Block-range size per getLogs call when indexing ConsolidationBus events                                                  |

--- a/interfaces/DelegationContract.json
+++ b/interfaces/DelegationContract.json
@@ -1,0 +1,88 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "execute",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "result",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getDelegate",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCooldown",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isTerminated",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "NotDelegate",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ContractTerminated",
+    "type": "error"
+  }
+]

--- a/src/blockchain/contracts/delegation.py
+++ b/src/blockchain/contracts/delegation.py
@@ -1,0 +1,85 @@
+import logging
+
+from eth_typing import ChecksumAddress
+from web3.contract.contract import ContractFunction
+from web3.types import BlockIdentifier
+
+from blockchain.contracts.base_interface import ContractInterface
+from utils.bytes import from_hex_string_to_bytes
+
+logger = logging.getLogger(__name__)
+
+
+class DelegationContract(ContractInterface):
+    """An Execution Delegation Framework contract (LIP-37) the bot executes permissioned calls through.
+
+    A delegation contract is a stable on-chain identity: protocol roles are granted to it, while a
+    rotatable hot EOA — its *delegate* — performs the actual calls via `execute(target, data)`. The
+    bot uses this for `TopUpGateway.topUp`, the only permissioned call it makes (`TOP_UP_ROLE`): the
+    role sits on this contract instead of on the bot's key, so rotating the key is a delegate
+    rotation by the contract's owner rather than an ACL change on TopUpGateway.
+
+    Deposits, pause and unvet are deliberately NOT routed through here — DSM authorises those by
+    guardian signatures in calldata, so wrapping them would only add gas and a failure mode.
+
+    The same on-chain implementation also backs DSM guardians (see `GuardianContract`, which reads
+    only `getDelegate()` to reverse-map Data Bus senders). They are kept apart because the bot uses
+    them for unrelated purposes — one is our own execution identity, the other is a third party's.
+    Worth unifying once the EDF ABI is published as a package.
+    """
+
+    abi_path = './interfaces/DelegationContract.json'
+
+    def get_delegate(self, block_identifier: BlockIdentifier = 'latest') -> ChecksumAddress:
+        """Returns the currently effective delegate EOA (zero address if revoked or terminated).
+
+        During a cooldown-gated rotation the previous delegate stays effective until the nominated
+        one matures, so only this address can `execute` right now.
+        """
+        response = self.functions.getDelegate().call(block_identifier=block_identifier)
+        logger.debug(
+            {
+                'msg': 'Call `getDelegate()`.',
+                'value': response,
+                'delegation': self.address,
+                'block_identifier': repr(block_identifier),
+            }
+        )
+        return response
+
+    def is_terminated(self, block_identifier: BlockIdentifier = 'latest') -> bool:
+        """Whether the contract has been terminated — irreversible, and `execute` reverts after it."""
+        response = self.functions.isTerminated().call(block_identifier=block_identifier)
+        logger.debug(
+            {
+                'msg': 'Call `isTerminated()`.',
+                'value': response,
+                'delegation': self.address,
+                'block_identifier': repr(block_identifier),
+            }
+        )
+        return response
+
+    def wrap(self, call: ContractFunction) -> ContractFunction:
+        """Re-targets a built call so it runs with this contract as `msg.sender`.
+
+        Encodes the original call and returns `execute(originalTarget, calldata)`. The result is a
+        normal ContractFunction, so gas estimation and the `transaction.check()` dry-run simulate the
+        delegated call — which is what actually gets mined. Simulating the unwrapped call instead
+        would revert with `AccessControlUnauthorizedAccount`, since the role is held by this contract
+        and not by the bot's key.
+
+        `_encode_transaction_data()` is web3's own calldata encoder (`build_transaction` uses it) and
+        keeps the argument encoding in one place — the call has already been assembled by the target
+        contract's wrapper.
+        """
+        calldata = from_hex_string_to_bytes(call._encode_transaction_data())
+        logger.debug(
+            {
+                'msg': 'Wrap call into `execute()`.',
+                'delegation': self.address,
+                'target': call.address,
+                'function': call.fn_name,
+            }
+        )
+        return self.functions.execute(call.address, calldata)

--- a/src/blockchain/contracts/delegation.py
+++ b/src/blockchain/contracts/delegation.py
@@ -69,11 +69,11 @@ class DelegationContract(ContractInterface):
         would revert with `AccessControlUnauthorizedAccount`, since the role is held by this contract
         and not by the bot's key.
 
-        `_encode_transaction_data()` is web3's own calldata encoder (`build_transaction` uses it) and
-        keeps the argument encoding in one place — the call has already been assembled by the target
-        contract's wrapper.
+        The call has already been assembled by the target contract's wrapper, so it is re-encoded
+        here rather than rebuilt from arguments — argument encoding stays in one place.
         """
-        calldata = from_hex_string_to_bytes(call._encode_transaction_data())
+        target = self.w3.eth.contract(address=call.address, abi=call.contract_abi)
+        calldata = from_hex_string_to_bytes(target.encode_abi(call.fn_name, call.args))
         logger.debug(
             {
                 'msg': 'Wrap call into `execute()`.',

--- a/src/blockchain/contracts/topup_gateway.py
+++ b/src/blockchain/contracts/topup_gateway.py
@@ -1,10 +1,12 @@
 import logging
 from functools import lru_cache
 
-from blockchain.contracts.base_interface import ContractInterface
-from blockchain.topup.types import TopUpProofData
+from eth_typing import ChecksumAddress
 from web3.contract.contract import ContractFunction
 from web3.types import BlockIdentifier
+
+from blockchain.contracts.base_interface import ContractInterface
+from blockchain.topup.types import TopUpProofData
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +40,26 @@ class TopUpGatewayContract(ContractInterface):
     def is_block_distance_passed(self, block_identifier: BlockIdentifier = 'latest') -> bool:
         response = self.functions.isBlockDistancePassed().call(block_identifier=block_identifier)
         logger.info({'msg': 'Call `isBlockDistancePassed()`.', 'value': response, 'block_identifier': repr(block_identifier)})
+        return response
+
+    @lru_cache(maxsize=1)
+    def top_up_role(self, block_identifier: BlockIdentifier = 'latest') -> bytes:
+        """The AccessControl role required to call `topUp()`. An immutable constant, so cached."""
+        response = self.functions.TOP_UP_ROLE().call(block_identifier=block_identifier)
+        logger.info({'msg': 'Call `TOP_UP_ROLE()`.', 'value': response.hex(), 'block_identifier': repr(block_identifier)})
+        return response
+
+    def has_role(self, role: bytes, account: ChecksumAddress, block_identifier: BlockIdentifier = 'latest') -> bool:
+        response = self.functions.hasRole(role, account).call(block_identifier=block_identifier)
+        logger.info(
+            {
+                'msg': 'Call `hasRole()`.',
+                'value': response,
+                'role': role.hex(),
+                'account': account,
+                'block_identifier': repr(block_identifier),
+            }
+        )
         return response
 
     def top_up(self, module_id: int, proof_data: 'TopUpProofData') -> ContractFunction:

--- a/src/blockchain/web3_extentions/lido_contracts.py
+++ b/src/blockchain/web3_extentions/lido_contracts.py
@@ -211,7 +211,7 @@ class LidoContracts(Module):
         (DelegationFactory), not part of the protocol's address book. `None` means direct calls —
         `TOP_UP_ROLE` is then expected on the bot's own account.
         """
-        if variables.EDF_DELEGATION_CONTRACT is None:
+        if variables.DELEGATION_CONTRACT_ADDRESS is None:
             self.delegation: DelegationContract | None = None
             logger.debug({'msg': 'No EDF delegation contract configured. Top-ups will be sent as direct calls.'})
             return
@@ -219,8 +219,8 @@ class LidoContracts(Module):
         self.delegation = cast(
             DelegationContract,
             self.w3.eth.contract(
-                address=variables.EDF_DELEGATION_CONTRACT,
+                address=variables.DELEGATION_CONTRACT_ADDRESS,
                 ContractFactoryClass=DelegationContract,
             ),
         )
-        logger.debug({'msg': 'Loaded EDF delegation contract.', 'address': variables.EDF_DELEGATION_CONTRACT})
+        logger.debug({'msg': 'Loaded EDF delegation contract.', 'address': variables.DELEGATION_CONTRACT_ADDRESS})

--- a/src/blockchain/web3_extentions/lido_contracts.py
+++ b/src/blockchain/web3_extentions/lido_contracts.py
@@ -8,6 +8,7 @@ from web3.module import Module
 from web3.types import BlockIdentifier
 
 import variables
+from blockchain.contracts.delegation import DelegationContract
 from blockchain.contracts.deposit import DepositContract
 from blockchain.contracts.deposit_security_module import DepositSecurityModuleContract, DepositSecurityModuleContractV5
 from blockchain.contracts.guardian import GuardianContract
@@ -75,6 +76,7 @@ class LidoContracts(Module):
         self._load_staking_router()
         self._load_dsm()
         self._load_topup_gateway()
+        self._load_delegation()
         self._load_staking_modules()
 
     def _load_staking_router(self):
@@ -201,3 +203,24 @@ class LidoContracts(Module):
             ),
         )
         logger.debug({'msg': 'Loaded TopUpGateway.', 'address': topup_gateway_address})
+
+    def _load_delegation(self):
+        """Binds the EDF delegation contract top-ups are executed through, if one is configured.
+
+        Comes from configuration rather than LidoLocator: the contract is deployed per bot operator
+        (DelegationFactory), not part of the protocol's address book. `None` means direct calls —
+        `TOP_UP_ROLE` is then expected on the bot's own account.
+        """
+        if variables.EDF_DELEGATION_CONTRACT is None:
+            self.delegation: DelegationContract | None = None
+            logger.debug({'msg': 'No EDF delegation contract configured. Top-ups will be sent as direct calls.'})
+            return
+
+        self.delegation = cast(
+            DelegationContract,
+            self.w3.eth.contract(
+                address=variables.EDF_DELEGATION_CONTRACT,
+                ContractFactoryClass=DelegationContract,
+            ),
+        )
+        logger.debug({'msg': 'Loaded EDF delegation contract.', 'address': variables.EDF_DELEGATION_CONTRACT})

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -51,6 +51,7 @@ from metrics.metrics import (
     POSSIBLE_DEPOSITS_AMOUNT,
     QUORUM,
     QUORUM_STATE,
+    TOPUP_DELEGATION_STATE,
     TOPUP_GAS_OK,
     TOPUP_GAS_OK_LAST_RUN_TIMESTAMP,
     TOPUP_GATEWAY_PAUSED,
@@ -87,6 +88,21 @@ class ModuleCandidate(NamedTuple):
     # Amount the StakingRouter (SR-lib) allocation algorithm decided should be allocated to this module
     # from the depositable buffer sum. Needed only for top-up; unused for deposits.
     allocation: Wei
+
+
+class DelegationState(StrEnum):
+    """Whether top-ups can be executed through the configured EDF delegation contract.
+
+    Everything but DISABLED and READY blocks every top-up, so the reason is checked at startup (the
+    bot refuses to start) and re-read every cycle — a delegate can be rotated or revoked, and the
+    contract terminated, while the bot runs. Values must stay in sync with TOPUP_DELEGATION_STATE.
+    """
+
+    DISABLED = 'disabled'  # no delegation contract configured → topUp() is called directly
+    READY = 'ready'  # bot's account is the active delegate and the contract holds TOP_UP_ROLE
+    NOT_DELEGATE = 'not_delegate'  # bot's account is not (or no longer) the active delegate
+    TERMINATED = 'terminated'  # delegation contract terminated — irreversible
+    ROLE_MISSING = 'role_missing'  # contract does not hold TOP_UP_ROLE on TopUpGateway
 
 
 class QuorumState(StrEnum):
@@ -163,6 +179,7 @@ class DepositorBot:
         self._keys_api = keys_api
         self._cl = cl
         self._consolidation_indexer = self._build_consolidation_indexer()
+        self._validate_topup_delegation()
         now = datetime.now()
         self._module_last_heart_beat: dict[int, datetime] = {module_id: now for module_id in variables.DEPOSIT_MODULES_WHITELIST}
         for module_id in variables.DEPOSIT_MODULES_WHITELIST:
@@ -296,9 +313,15 @@ class DepositorBot:
         if variables.ENABLE_TOP_UP:
             _tg_paused = self.w3.lido.topup_gateway.is_paused()
             TOPUP_GATEWAY_PAUSED.set(int(_tg_paused))
+            # Refreshed every iteration, next to the gateway pause state: both are top-up subsystem
+            # gates that hold for all modules, and both must stay current even on iterations where no
+            # module ends up being topped up. Not a gate here — a broken delegation still lets the tx
+            # be built and fail loudly on the dry-run, which is more informative than skipping early.
+            TOPUP_DELEGATION_STATE.state(self._topup_delegation_state())
             top_up_enabled = not _tg_paused
         else:
             TOPUP_GATEWAY_PAUSED.set(0)
+            TOPUP_DELEGATION_STATE.state(DelegationState.DISABLED)
             top_up_enabled = False
 
         logger.info({'msg': 'Phase B start: full deposits to 0x01 + top-up to 0x02.'})
@@ -548,6 +571,11 @@ class DepositorBot:
             return PhaseOutcome.SKIPPED
 
         tx = self.w3.lido.topup_gateway.top_up(module_id, proof_data)
+        # TOP_UP_ROLE may be held by an EDF delegation contract rather than by the bot's key. Wrapping
+        # must happen before check()/send() so the dry-run and the gas estimate cover the delegated
+        # call — the unwrapped one would revert with AccessControlUnauthorizedAccount.
+        if self.w3.lido.delegation is not None:
+            tx = self.w3.lido.delegation.wrap(tx)
         success = self.w3.transaction.check(tx) and self.w3.transaction.send(tx, False, 6)
         TOPUP_TX_SEND.labels('success' if success else 'failure', module_id).inc()
         logger.info({'msg': f'Top-up tx result: {success}.', 'module_id': module_id})
@@ -588,6 +616,58 @@ class DepositorBot:
         logger.info({'msg': 'ConsolidationBus indexer cold start.', 'address': address, 'deploy_block': deploy_block})
         indexer.cold_start()
         return indexer
+
+    def _topup_delegation_state(self) -> DelegationState:
+        """Reads whether the configured EDF delegation contract can execute a top-up right now.
+
+        Two live reads per call (`TOP_UP_ROLE` is a cached constant), so it runs once per iteration
+        rather than per module. It has to be re-read rather than trusted from startup: delegate
+        rotation, revocation and termination all take effect while the bot is running, and each of
+        them turns every top-up into a revert.
+
+        In dry mode (no account) the delegate check is skipped — there is no key to compare against
+        and nothing will be sent anyway.
+        """
+        delegation = self.w3.lido.delegation
+        if delegation is None:
+            return DelegationState.DISABLED
+
+        if delegation.is_terminated():
+            return DelegationState.TERMINATED
+
+        role = self.w3.lido.topup_gateway.top_up_role()
+        if not self.w3.lido.topup_gateway.has_role(role, delegation.address):
+            return DelegationState.ROLE_MISSING
+
+        if variables.ACCOUNT is None:
+            logger.warning({'msg': 'No account configured. Skipping the EDF delegate check.', 'delegation': delegation.address})
+            return DelegationState.READY
+
+        if delegation.get_delegate() != variables.ACCOUNT.address:
+            return DelegationState.NOT_DELEGATE
+
+        return DelegationState.READY
+
+    def _validate_topup_delegation(self) -> None:
+        """Refuse to start when top-up is enabled but delegated execution is misconfigured.
+
+        Same reasoning as the ConsolidationBus indexer: a broken delegation makes every single top-up
+        revert, and a crash loop with the reason in it is far easier to notice than a bot that keeps
+        running and quietly tops up nothing.
+        """
+        if not variables.ENABLE_TOP_UP:
+            return
+
+        state = self._topup_delegation_state()
+        TOPUP_DELEGATION_STATE.state(state)
+        if state not in (DelegationState.DISABLED, DelegationState.READY):
+            account = variables.ACCOUNT.address if variables.ACCOUNT else 'not configured'
+            raise ValueError(
+                f'EDF delegation contract {variables.EDF_DELEGATION_CONTRACT} cannot execute top-ups: {state}. '
+                f'It must hold TOP_UP_ROLE on TopUpGateway, not be terminated, and have the bot account '
+                f'({account}) as its active delegate.'
+            )
+        logger.info({'msg': 'Top-up delegation checked.', 'state': state, 'delegation': variables.EDF_DELEGATION_CONTRACT})
 
     def _check_balance(self):
         if variables.ACCOUNT:

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -51,7 +51,7 @@ from metrics.metrics import (
     POSSIBLE_DEPOSITS_AMOUNT,
     QUORUM,
     QUORUM_STATE,
-    TOPUP_DELEGATION_STATE,
+    TOPUP_EXECUTION_PATH,
     TOPUP_GAS_OK,
     TOPUP_GAS_OK_LAST_RUN_TIMESTAMP,
     TOPUP_GATEWAY_PAUSED,
@@ -90,19 +90,26 @@ class ModuleCandidate(NamedTuple):
     allocation: Wei
 
 
-class DelegationState(StrEnum):
-    """Whether top-ups can be executed through the configured EDF delegation contract.
+class TopUpPath(StrEnum):
+    """How `TopUpGateway.topUp` is executed, resolved from on-chain role assignment each cycle.
 
-    Everything but DISABLED and READY blocks every top-up, so the reason is checked at startup (the
-    bot refuses to start) and re-read every cycle — a delegate can be rotated or revoked, and the
-    contract terminated, while the bot runs. Values must stay in sync with TOPUP_DELEGATION_STATE.
+    Derived from chain state rather than from configuration alone, so moving `TOP_UP_ROLE` from the
+    bot's key onto a delegation contract (or back) needs no restart timed to the `grantRole` /
+    `revokeRole` transactions — the bot follows the role. The same read also covers the case that
+    exists today without any delegation: the key simply not holding the role.
+
+    Values must stay in sync with TOPUP_EXECUTION_PATH.
     """
 
-    DISABLED = 'disabled'  # no delegation contract configured → topUp() is called directly
-    READY = 'ready'  # bot's account is the active delegate and the contract holds TOP_UP_ROLE
-    NOT_DELEGATE = 'not_delegate'  # bot's account is not (or no longer) the active delegate
-    TERMINATED = 'terminated'  # delegation contract terminated — irreversible
-    ROLE_MISSING = 'role_missing'  # contract does not hold TOP_UP_ROLE on TopUpGateway
+    DIRECT = 'direct'  # bot's own account holds TOP_UP_ROLE → call topUp() directly
+    DELEGATED = 'delegated'  # delegation contract holds it and our key is its active delegate
+    NOT_DELEGATE = 'not_delegate'  # delegation holds the role, but our key is not its delegate
+    TERMINATED = 'terminated'  # delegation holds the role but is terminated — irreversible
+    NO_ROLE = 'no_role'  # neither identity holds TOP_UP_ROLE → every top-up would revert
+
+    @property
+    def is_executable(self) -> bool:
+        return self in (TopUpPath.DIRECT, TopUpPath.DELEGATED)
 
 
 class QuorumState(StrEnum):
@@ -179,6 +186,8 @@ class DepositorBot:
         self._keys_api = keys_api
         self._cl = cl
         self._consolidation_indexer = self._build_consolidation_indexer()
+        # Resolved once here so it is never unset, then re-resolved every iteration.
+        self._topup_path = TopUpPath.DIRECT
         self._validate_topup_delegation()
         now = datetime.now()
         self._module_last_heart_beat: dict[int, datetime] = {module_id: now for module_id in variables.DEPOSIT_MODULES_WHITELIST}
@@ -313,15 +322,15 @@ class DepositorBot:
         if variables.ENABLE_TOP_UP:
             _tg_paused = self.w3.lido.topup_gateway.is_paused()
             TOPUP_GATEWAY_PAUSED.set(int(_tg_paused))
-            # Refreshed every iteration, next to the gateway pause state: both are top-up subsystem
-            # gates that hold for all modules, and both must stay current even on iterations where no
-            # module ends up being topped up. Not a gate here — a broken delegation still lets the tx
-            # be built and fail loudly on the dry-run, which is more informative than skipping early.
-            TOPUP_DELEGATION_STATE.state(self._topup_delegation_state())
+            # Resolved here, next to the gateway pause state: both are top-up subsystem gates that
+            # hold for all modules, and both must stay current even on iterations where no module ends
+            # up being topped up. Not a gate — an unusable path still lets the tx be built and fail
+            # loudly on the dry-run, which says more than skipping early.
+            self._topup_path = self._resolve_topup_path()
+            TOPUP_EXECUTION_PATH.state(self._topup_path)
             top_up_enabled = not _tg_paused
         else:
             TOPUP_GATEWAY_PAUSED.set(0)
-            TOPUP_DELEGATION_STATE.state(DelegationState.DISABLED)
             top_up_enabled = False
 
         logger.info({'msg': 'Phase B start: full deposits to 0x01 + top-up to 0x02.'})
@@ -571,11 +580,12 @@ class DepositorBot:
             return PhaseOutcome.SKIPPED
 
         tx = self.w3.lido.topup_gateway.top_up(module_id, proof_data)
-        # TOP_UP_ROLE may be held by an EDF delegation contract rather than by the bot's key. Wrapping
-        # must happen before check()/send() so the dry-run and the gas estimate cover the delegated
-        # call — the unwrapped one would revert with AccessControlUnauthorizedAccount.
-        if self.w3.lido.delegation is not None:
-            tx = self.w3.lido.delegation.wrap(tx)
+        # When TOP_UP_ROLE sits on the delegation contract rather than on the bot's key, wrapping must
+        # happen before check()/send() so the dry-run and the gas estimate cover the delegated call —
+        # the unwrapped one would revert with AccessControlUnauthorizedAccount.
+        delegation = self.w3.lido.delegation
+        if delegation is not None and self._topup_path is TopUpPath.DELEGATED:
+            tx = delegation.wrap(tx)
         success = self.w3.transaction.check(tx) and self.w3.transaction.send(tx, False, 6)
         TOPUP_TX_SEND.labels('success' if success else 'failure', module_id).inc()
         logger.info({'msg': f'Top-up tx result: {success}.', 'module_id': module_id})
@@ -617,57 +627,76 @@ class DepositorBot:
         indexer.cold_start()
         return indexer
 
-    def _topup_delegation_state(self) -> DelegationState:
-        """Reads whether the configured EDF delegation contract can execute a top-up right now.
+    def _resolve_topup_path(self) -> TopUpPath:
+        """Resolves how `topUp` must be sent, from who currently holds `TOP_UP_ROLE`.
 
-        Two live reads per call (`TOP_UP_ROLE` is a cached constant), so it runs once per iteration
-        rather than per module. It has to be re-read rather than trusted from startup: delegate
-        rotation, revocation and termination all take effect while the bot is running, and each of
-        them turns every top-up into a revert.
+        Delegation is preferred when it is usable, and the bot's own key is the fallback — so during
+        a migration either order of the `grantRole`/`revokeRole` pair keeps working, and neither
+        direction needs a restart timed to a block. Re-resolved every cycle and never carried over:
+        a delegate can be rotated or revoked, and the contract terminated, under a running bot, and
+        each of those turns every top-up into a revert.
 
-        In dry mode (no account) the delegate check is skipped — there is no key to compare against
-        and nothing will be sent anyway.
+        At most three reads (`TOP_UP_ROLE` is a cached constant), so it runs once per iteration
+        rather than once per module.
+
+        In dry mode (no account) there is no key to compare against and nothing gets sent, so the
+        identity checks are skipped rather than failing the bot.
         """
+        gateway = self.w3.lido.topup_gateway
+        role = gateway.top_up_role()
         delegation = self.w3.lido.delegation
-        if delegation is None:
-            return DelegationState.DISABLED
+        blocked: TopUpPath | None = None
 
-        if delegation.is_terminated():
-            return DelegationState.TERMINATED
+        if delegation is not None and gateway.has_role(role, delegation.address):
+            if delegation.is_terminated():
+                blocked = TopUpPath.TERMINATED
+            elif variables.ACCOUNT is None or delegation.get_delegate() == variables.ACCOUNT.address:
+                return TopUpPath.DELEGATED
+            else:
+                blocked = TopUpPath.NOT_DELEGATE
+            logger.warning(
+                {
+                    'msg': 'Delegation contract holds TOP_UP_ROLE but cannot be used. Falling back to a direct call.',
+                    'reason': blocked,
+                    'delegation': delegation.address,
+                }
+            )
 
-        role = self.w3.lido.topup_gateway.top_up_role()
-        if not self.w3.lido.topup_gateway.has_role(role, delegation.address):
-            return DelegationState.ROLE_MISSING
+        if variables.ACCOUNT is None or gateway.has_role(role, variables.ACCOUNT.address):
+            return TopUpPath.DIRECT
 
-        if variables.ACCOUNT is None:
-            logger.warning({'msg': 'No account configured. Skipping the EDF delegate check.', 'delegation': delegation.address})
-            return DelegationState.READY
-
-        if delegation.get_delegate() != variables.ACCOUNT.address:
-            return DelegationState.NOT_DELEGATE
-
-        return DelegationState.READY
+        return blocked or TopUpPath.NO_ROLE
 
     def _validate_topup_delegation(self) -> None:
-        """Refuse to start when top-up is enabled but delegated execution is misconfigured.
+        """Refuse to start when a delegation contract is configured but no path can execute a top-up.
 
-        Same reasoning as the ConsolidationBus indexer: a broken delegation makes every single top-up
-        revert, and a crash loop with the reason in it is far easier to notice than a bot that keeps
-        running and quietly tops up nothing.
+        Same reasoning as the ConsolidationBus indexer: nothing would ever be topped up, and a crash
+        loop carrying the reason is far easier to notice than a bot that keeps running quietly.
+
+        Scoped to the case where delegation is configured. `NO_ROLE` without any delegation is the
+        pre-existing "role was never granted to the key" misconfiguration — it is now visible on
+        `topup_execution_path`, but it must not turn an upgrade of a running deployment into a boot
+        failure, so it stays a warning.
         """
         if not variables.ENABLE_TOP_UP:
             return
 
-        state = self._topup_delegation_state()
-        TOPUP_DELEGATION_STATE.state(state)
-        if state not in (DelegationState.DISABLED, DelegationState.READY):
-            account = variables.ACCOUNT.address if variables.ACCOUNT else 'not configured'
-            raise ValueError(
-                f'EDF delegation contract {variables.EDF_DELEGATION_CONTRACT} cannot execute top-ups: {state}. '
-                f'It must hold TOP_UP_ROLE on TopUpGateway, not be terminated, and have the bot account '
-                f'({account}) as its active delegate.'
-            )
-        logger.info({'msg': 'Top-up delegation checked.', 'state': state, 'delegation': variables.EDF_DELEGATION_CONTRACT})
+        self._topup_path = self._resolve_topup_path()
+        TOPUP_EXECUTION_PATH.state(self._topup_path)
+        if self._topup_path.is_executable:
+            logger.info({'msg': 'Top-up execution path resolved.', 'path': self._topup_path})
+            return
+
+        account = variables.ACCOUNT.address if variables.ACCOUNT else 'not configured'
+        message = (
+            f'No usable path for TopUpGateway.topUp: {self._topup_path}. TOP_UP_ROLE must be held either by the '
+            f'bot account ({account}) or by delegation contract {variables.DELEGATION_CONTRACT_ADDRESS}, which '
+            f'must then be un-terminated with that account as its active delegate.'
+        )
+        if variables.DELEGATION_CONTRACT_ADDRESS is None:
+            logger.warning({'msg': message})
+            return
+        raise ValueError(message)
 
     def _check_balance(self):
         if variables.ACCOUNT:

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -266,6 +266,26 @@ class DepositorBot:
         deposits_paused = self.w3.lido.deposit_security_module.is_deposits_paused()
         DEPOSITS_PAUSED.set(int(deposits_paused))
 
+        # Top-up subsystem gates, resolved for the same reason DEPOSITS_PAUSED is read here: both hold
+        # for all modules and both are what an operator watches to see the bot can still act, so they
+        # must not freeze at their last value on the iterations that return early below — an empty
+        # buffer is the common idle state, and it would pin them indefinitely. A delegate can be
+        # rotated or revoked, and the delegation contract terminated, under a running bot; each turns
+        # every top-up into a revert, and this metric is how that gets noticed. Costs at most four
+        # `eth_call`s per iteration, on top of the per-module reads `_refresh_modules_state()` already
+        # does before the same early returns.
+        # Not a gate — an unusable path still lets the tx be built and fail loudly on the dry-run,
+        # which says more than skipping early.
+        top_up_enabled = False
+        if variables.ENABLE_TOP_UP:
+            _tg_paused = self.w3.lido.topup_gateway.is_paused()
+            TOPUP_GATEWAY_PAUSED.set(int(_tg_paused))
+            self._topup_path = self._resolve_topup_path()
+            TOPUP_EXECUTION_PATH.state(self._topup_path)
+            top_up_enabled = not _tg_paused
+        else:
+            TOPUP_GATEWAY_PAUSED.set(0)
+
         # Read depositable ether once; if 0 — nothing to do this iteration.
         depositable_ether = self.w3.lido.lido.get_depositable_ether()
         DEPOSITABLE_ETHER.set(depositable_ether)
@@ -316,23 +336,7 @@ class DepositorBot:
                 return outcome.is_backoff
 
         # Phase B: full deposits (0x01) + top-ups (0x02), gated independently inside the phase —
-        # 0x01 while deposits are not paused, 0x02 while top-up is enabled and the gateway is not paused.
-
-        top_up_enabled = False
-        if variables.ENABLE_TOP_UP:
-            _tg_paused = self.w3.lido.topup_gateway.is_paused()
-            TOPUP_GATEWAY_PAUSED.set(int(_tg_paused))
-            # Resolved here, next to the gateway pause state: both are top-up subsystem gates that
-            # hold for all modules, and both must stay current even on iterations where no module ends
-            # up being topped up. Not a gate — an unusable path still lets the tx be built and fail
-            # loudly on the dry-run, which says more than skipping early.
-            self._topup_path = self._resolve_topup_path()
-            TOPUP_EXECUTION_PATH.state(self._topup_path)
-            top_up_enabled = not _tg_paused
-        else:
-            TOPUP_GATEWAY_PAUSED.set(0)
-            top_up_enabled = False
-
+        # 0x01 while deposits are not paused, 0x02 while `top_up_enabled` (resolved above).
         logger.info({'msg': 'Phase B start: full deposits to 0x01 + top-up to 0x02.'})
         outcome = self._phase_full_and_topup(depositable_ether, seed_allocated, seed_new, digests, deposits_paused, top_up_enabled)
 

--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -124,15 +124,15 @@ TOPUP_GATEWAY_PAUSED = Gauge(
     namespace=PROMETHEUS_PREFIX,
 )
 
-# States must stay in sync with bots.depositor.DelegationState's values (see note on PHASE_OUTCOME).
-# `disabled` means EDF_DELEGATION_CONTRACT is unset — top-ups go out as direct calls, which is a
-# valid configuration, not a fault. The other non-ready states each block every top-up, so they are
-# distinguished here: a bare "tx failed" counter cannot tell a delegation problem from a revert
-# inside topUp() itself.
-TOPUP_DELEGATION_STATE = Enum(
-    'topup_delegation_state',
-    'Whether the EDF delegation contract can currently execute top-ups.',
-    states=['disabled', 'ready', 'not_delegate', 'terminated', 'role_missing'],
+# States must stay in sync with bots.depositor.TopUpPath's values (see note on PHASE_OUTCOME).
+# `direct` and `delegated` are both healthy — which one is live tells you whether TOP_UP_ROLE
+# currently sits on the bot's key or on the delegation contract, i.e. whether a migration has taken
+# effect. The rest each block every top-up, and they are distinguished here because a bare "tx
+# failed" counter cannot tell a role/delegate problem from a revert inside topUp() itself.
+TOPUP_EXECUTION_PATH = Enum(
+    'topup_execution_path',
+    'How TopUpGateway.topUp is executed, resolved from on-chain TOP_UP_ROLE assignment.',
+    states=['direct', 'delegated', 'not_delegate', 'terminated', 'no_role'],
     namespace=PROMETHEUS_PREFIX,
 )
 

--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -124,6 +124,18 @@ TOPUP_GATEWAY_PAUSED = Gauge(
     namespace=PROMETHEUS_PREFIX,
 )
 
+# States must stay in sync with bots.depositor.DelegationState's values (see note on PHASE_OUTCOME).
+# `disabled` means EDF_DELEGATION_CONTRACT is unset — top-ups go out as direct calls, which is a
+# valid configuration, not a fault. The other non-ready states each block every top-up, so they are
+# distinguished here: a bare "tx failed" counter cannot tell a delegation problem from a revert
+# inside topUp() itself.
+TOPUP_DELEGATION_STATE = Enum(
+    'topup_delegation_state',
+    'Whether the EDF delegation contract can currently execute top-ups.',
+    states=['disabled', 'ready', 'not_delegate', 'terminated', 'role_missing'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
 MODULE_STATUS = Gauge(
     'module_status',
     'Staking module status from StakingRouter digest. 0=active 1=deposits_paused 2=stopped',

--- a/src/variables.py
+++ b/src/variables.py
@@ -117,14 +117,19 @@ GAS_ADDENDUM = Web3.to_wei(*os.getenv('GAS_ADDENDUM', '6 gwei').split(' '))
 ENABLE_TOP_UP = os.getenv('ENABLE_TOP_UP', 'false').lower() == 'true'
 MAX_VALIDATORS_PER_TOP_UP = int(os.getenv('MAX_VALIDATORS_PER_TOP_UP', 32))
 
-# EDF delegation contract (LIP-37) holding TOP_UP_ROLE on TopUpGateway, with this bot's account as
-# its delegate. When set, top-ups are executed through it so the role can live on a stable address
-# and the bot's hot key can be rotated without an ACL change on TopUpGateway. When unset, topUp() is
-# called directly and TOP_UP_ROLE must be granted to the bot's account itself.
+# EDF delegation contract (LIP-37) that can hold TOP_UP_ROLE on TopUpGateway, with this bot's account
+# as its delegate. Keeping the role on a stable address is what lets the hot key be rotated without an
+# ACL change on TopUpGateway.
+# This is a candidate, not a switch: which identity actually sends topUp() is resolved from who holds
+# the role on-chain each cycle (DepositorBot._resolve_topup_path), so the role can be migrated in
+# either direction without a restart. Unset → always a direct call, and the role must be on the
+# bot's own account.
 # Only top-ups are routed this way: deposits, pause and unvet are authorised by guardian signatures
 # in calldata, so DSM does not care who sends them.
-_edf_delegation_contract = os.getenv('EDF_DELEGATION_CONTRACT')
-EDF_DELEGATION_CONTRACT: ChecksumAddress | None = Web3.to_checksum_address(_edf_delegation_contract) if _edf_delegation_contract else None
+_delegation_contract_address = os.getenv('DELEGATION_CONTRACT_ADDRESS')
+DELEGATION_CONTRACT_ADDRESS: ChecksumAddress | None = (
+    Web3.to_checksum_address(_delegation_contract_address) if _delegation_contract_address else None
+)
 
 # Consolidation indexer (ConsolidationBus).
 # Top-up filters out keys that participate in a pending ConsolidationBus request.
@@ -187,7 +192,7 @@ PUBLIC_ENV_VARS = {
     'DEPOSIT_TO_FIRST_HEALTHY_MODULE_ONLY': DEPOSIT_TO_FIRST_HEALTHY_MODULE_ONLY,
     'ENABLE_TOP_UP': ENABLE_TOP_UP,
     'MAX_VALIDATORS_PER_TOP_UP': MAX_VALIDATORS_PER_TOP_UP,
-    'EDF_DELEGATION_CONTRACT': EDF_DELEGATION_CONTRACT,
+    'DELEGATION_CONTRACT_ADDRESS': DELEGATION_CONTRACT_ADDRESS,
     'CONSOLIDATION_BUS_ADDRESS': CONSOLIDATION_BUS_ADDRESS,
     'CONSOLIDATION_BUS_DEPLOY_BLOCK': CONSOLIDATION_BUS_DEPLOY_BLOCK,
     'CONSOLIDATION_GETLOGS_CHUNK': CONSOLIDATION_GETLOGS_CHUNK,

--- a/src/variables.py
+++ b/src/variables.py
@@ -117,6 +117,15 @@ GAS_ADDENDUM = Web3.to_wei(*os.getenv('GAS_ADDENDUM', '6 gwei').split(' '))
 ENABLE_TOP_UP = os.getenv('ENABLE_TOP_UP', 'false').lower() == 'true'
 MAX_VALIDATORS_PER_TOP_UP = int(os.getenv('MAX_VALIDATORS_PER_TOP_UP', 32))
 
+# EDF delegation contract (LIP-37) holding TOP_UP_ROLE on TopUpGateway, with this bot's account as
+# its delegate. When set, top-ups are executed through it so the role can live on a stable address
+# and the bot's hot key can be rotated without an ACL change on TopUpGateway. When unset, topUp() is
+# called directly and TOP_UP_ROLE must be granted to the bot's account itself.
+# Only top-ups are routed this way: deposits, pause and unvet are authorised by guardian signatures
+# in calldata, so DSM does not care who sends them.
+_edf_delegation_contract = os.getenv('EDF_DELEGATION_CONTRACT')
+EDF_DELEGATION_CONTRACT: ChecksumAddress | None = Web3.to_checksum_address(_edf_delegation_contract) if _edf_delegation_contract else None
+
 # Consolidation indexer (ConsolidationBus).
 # Top-up filters out keys that participate in a pending ConsolidationBus request.
 # LidoLocator does not expose the Bus, so its address + deploy block are hardcoded per chain
@@ -178,6 +187,7 @@ PUBLIC_ENV_VARS = {
     'DEPOSIT_TO_FIRST_HEALTHY_MODULE_ONLY': DEPOSIT_TO_FIRST_HEALTHY_MODULE_ONLY,
     'ENABLE_TOP_UP': ENABLE_TOP_UP,
     'MAX_VALIDATORS_PER_TOP_UP': MAX_VALIDATORS_PER_TOP_UP,
+    'EDF_DELEGATION_CONTRACT': EDF_DELEGATION_CONTRACT,
     'CONSOLIDATION_BUS_ADDRESS': CONSOLIDATION_BUS_ADDRESS,
     'CONSOLIDATION_BUS_DEPLOY_BLOCK': CONSOLIDATION_BUS_DEPLOY_BLOCK,
     'CONSOLIDATION_GETLOGS_CHUNK': CONSOLIDATION_GETLOGS_CHUNK,

--- a/tests/blockchain/contracts/test_delegation.py
+++ b/tests/blockchain/contracts/test_delegation.py
@@ -63,9 +63,9 @@ def test_wrap_preserves_the_original_target_and_calldata(contracts, proof_data):
 
     wrapped = delegation.wrap(original)
 
-    target, calldata = delegation.decode_function_input(wrapped._encode_transaction_data())[1].values()
+    target, calldata = wrapped.args
     assert target == GATEWAY_ADDRESS
-    assert calldata == bytes.fromhex(original._encode_transaction_data()[2:])
+    assert calldata == bytes.fromhex(gateway.encode_abi(original.fn_name, original.args)[2:])
 
 
 @pytest.mark.unit
@@ -76,7 +76,7 @@ def test_wrapped_calldata_decodes_back_to_the_original_top_up_args(contracts, pr
     original = gateway.top_up(module_id, proof_data)
 
     wrapped = delegation.wrap(original)
-    _, inner_calldata = delegation.decode_function_input(wrapped._encode_transaction_data())[1].values()
+    _, inner_calldata = wrapped.args
     fn, args = gateway.decode_function_input(Web3.to_hex(inner_calldata))
 
     assert fn.fn_name == 'topUp'

--- a/tests/blockchain/contracts/test_delegation.py
+++ b/tests/blockchain/contracts/test_delegation.py
@@ -1,0 +1,95 @@
+"""Delegated execution wrapping, checked against the real ABIs (no RPC — encoding only)."""
+
+import pytest
+from web3 import Web3
+
+from blockchain.contracts.delegation import DelegationContract
+from blockchain.contracts.topup_gateway import TopUpGatewayContract
+from blockchain.topup.types import TopUpProofData, ValidatorWitness
+
+DELEGATION_ADDRESS = '0x1111111111111111111111111111111111111111'
+GATEWAY_ADDRESS = '0x2222222222222222222222222222222222222222'
+
+
+@pytest.fixture
+def proof_data() -> TopUpProofData:
+    return TopUpProofData(
+        child_block_timestamp=1_700_000_000,
+        slot=9_999,
+        proposer_index=7,
+        witnesses=[
+            ValidatorWitness(
+                proofs=[b'\x11' * 32, b'\x22' * 32],
+                pubkey=b'\xab' * 48,
+                effective_balance=32_000_000_000,
+                activation_eligibility_epoch=1,
+                activation_epoch=2,
+                exit_epoch=2**64 - 1,
+                withdrawable_epoch=2**64 - 1,
+                slashed=False,
+            )
+        ],
+        validator_indices=[42],
+        key_indices=[3],
+        operator_ids=[5],
+        pending_balances_gwei=[0],
+    )
+
+
+@pytest.fixture
+def contracts() -> tuple[DelegationContract, TopUpGatewayContract]:
+    w3 = Web3()
+    delegation = w3.eth.contract(address=DELEGATION_ADDRESS, ContractFactoryClass=DelegationContract)
+    gateway = w3.eth.contract(address=GATEWAY_ADDRESS, ContractFactoryClass=TopUpGatewayContract)
+    return delegation, gateway
+
+
+@pytest.mark.unit
+def test_wrap_targets_the_delegation_contract(contracts, proof_data):
+    delegation, gateway = contracts
+
+    wrapped = delegation.wrap(gateway.top_up(1, proof_data))
+
+    assert wrapped.address == DELEGATION_ADDRESS
+    assert wrapped.fn_name == 'execute'
+
+
+@pytest.mark.unit
+def test_wrap_preserves_the_original_target_and_calldata(contracts, proof_data):
+    """execute(target, data) must carry the gateway address and the untouched topUp() calldata —
+    otherwise the delegated call would hit the wrong contract or mangle the proof."""
+    delegation, gateway = contracts
+    original = gateway.top_up(1, proof_data)
+
+    wrapped = delegation.wrap(original)
+
+    target, calldata = delegation.decode_function_input(wrapped._encode_transaction_data())[1].values()
+    assert target == GATEWAY_ADDRESS
+    assert calldata == bytes.fromhex(original._encode_transaction_data()[2:])
+
+
+@pytest.mark.unit
+def test_wrapped_calldata_decodes_back_to_the_original_top_up_args(contracts, proof_data):
+    """Round-trip through execute() to prove no argument is lost or re-ordered on the way in."""
+    delegation, gateway = contracts
+    module_id = 3
+    original = gateway.top_up(module_id, proof_data)
+
+    wrapped = delegation.wrap(original)
+    _, inner_calldata = delegation.decode_function_input(wrapped._encode_transaction_data())[1].values()
+    fn, args = gateway.decode_function_input(Web3.to_hex(inner_calldata))
+
+    assert fn.fn_name == 'topUp'
+    decoded = args['_topUps']
+    assert decoded['moduleId'] == module_id
+    assert decoded['keyIndices'] == proof_data.key_indices
+    assert decoded['operatorIds'] == proof_data.operator_ids
+    assert decoded['validatorIndices'] == proof_data.validator_indices
+    assert decoded['beaconRootData'] == {
+        'childBlockTimestamp': proof_data.child_block_timestamp,
+        'slot': proof_data.slot,
+        'proposerIndex': proof_data.proposer_index,
+    }
+    assert decoded['pendingBalanceGwei'] == proof_data.pending_balances_gwei
+    assert decoded['validatorWitness'][0]['pubkey'] == proof_data.witnesses[0].pubkey
+    assert decoded['validatorWitness'][0]['proofValidator'] == proof_data.witnesses[0].proofs

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -826,6 +826,43 @@ def test_execute_actual_reports_depositable_ether_even_when_zero(depositor_bot):
 
 
 @pytest.mark.unit
+def test_execute_actual_refreshes_topup_path_on_empty_buffer(depositor_bot):
+    """The empty buffer is the common idle state, so resolving the path after that early return
+    would pin `topup_execution_path` at its last value while a delegate rotation, revocation or
+    termination goes unnoticed — the exact failure the metric exists to surface."""
+    variables.ENABLE_TOP_UP = True
+    depositor_bot._refresh_modules_state = Mock()
+    depositor_bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(return_value=[])
+    depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=0)
+    depositor_bot._resolve_topup_path = Mock(return_value=TopUpPath.NOT_DELEGATE)
+
+    with mock.patch('bots.depositor.TOPUP_EXECUTION_PATH') as metric:
+        assert depositor_bot._execute_actual() is False
+
+    depositor_bot._resolve_topup_path.assert_called_once()
+    metric.state.assert_called_once_with(TopUpPath.NOT_DELEGATE)
+    assert depositor_bot._topup_path is TopUpPath.NOT_DELEGATE
+
+
+@pytest.mark.unit
+def test_execute_actual_refreshes_topup_path_when_phase_a_short_circuits(depositor_bot):
+    """Same reason, for the other early return: a Phase A deposit ends the iteration before Phase B."""
+    variables.ENABLE_TOP_UP = True
+    depositor_bot._refresh_modules_state = Mock()
+    depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
+    depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
+    depositor_bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(return_value=[])
+    depositor_bot._phase_seed = Mock(return_value=PhaseOutcome.SENT)
+    depositor_bot._phase_full_and_topup = Mock()
+    depositor_bot._resolve_topup_path = Mock(return_value=TopUpPath.TERMINATED)
+
+    assert depositor_bot._execute_actual() is True
+    depositor_bot._phase_full_and_topup.assert_not_called()
+    depositor_bot._resolve_topup_path.assert_called_once()
+    assert depositor_bot._topup_path is TopUpPath.TERMINATED
+
+
+@pytest.mark.unit
 def test_execute_actual_phase_a_deposit_short_circuits(depositor_bot):
     """Phase A SENT → _execute_actual returns backoff=True, phase B not called."""
     depositor_bot._refresh_modules_state = Mock()

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -8,7 +8,7 @@ from web3.types import Wei
 
 import variables
 from blockchain.contracts.staking_router import MODULE_TYPE_CMV2, MODULE_TYPE_CSM, StakingModuleInfo
-from bots.depositor import DepositorBot, PhaseOutcome, QuorumState
+from bots.depositor import DelegationState, DepositorBot, PhaseOutcome, QuorumState
 from tests.conftest import COUNCIL_ADDRESS_1, COUNCIL_ADDRESS_2, COUNCIL_PK_1, COUNCIL_PK_2
 from tests.utils.protocol_utils import get_deposit_message
 
@@ -23,11 +23,16 @@ def _make_digest(module_id, address, wc_type, status=0) -> StakingModuleInfo:
 def _make_bot():
     """Build a DepositorBot with all-MagicMock deps. No transports → MessageStorage stays empty."""
     variables.MESSAGE_TRANSPORTS = ''
+    w3 = MagicMock()
+    # w3.lido is a MagicMock, so `delegation` would auto-create a truthy child and silently turn on
+    # delegated top-up execution. Default to the direct-call configuration; tests that exercise
+    # delegation set it explicitly.
+    w3.lido.delegation = None
     # Skip the real ConsolidationBus backfill (needs RPC) — inject a mock indexer so top-up paths
     # are still exercised. ENABLE_TOP_UP is left untouched; tests set it as needed.
     with mock.patch.object(DepositorBot, '_build_consolidation_indexer', return_value=MagicMock()):
         bot = DepositorBot(
-            w3=MagicMock(),
+            w3=w3,
             sender=MagicMock(),
             base_deposit_strategy=MagicMock(),
             csm_strategy=MagicMock(),
@@ -776,6 +781,10 @@ def depositor_bot(
         variables.MESSAGE_TRANSPORTS = ''
         variables.DEPOSIT_MODULES_WHITELIST = [1, 2]
         web3_lido_unit.eth.get_block = Mock(return_value=block_data)
+        # w3.lido is a Mock, so `delegation` would auto-create a truthy child and silently turn on
+        # delegated execution. Default to the direct-call configuration; tests that need delegation
+        # set it explicitly. Must be set before construction — startup validation reads it.
+        web3_lido_unit.lido.delegation = None
         # Skip the real ConsolidationBus backfill (needs RPC) — inject a mock indexer.
         with mock.patch.object(DepositorBot, '_build_consolidation_indexer', return_value=MagicMock()):
             bot = DepositorBot(
@@ -1278,6 +1287,142 @@ def test_build_consolidation_indexer_raises_when_top_up_enabled_but_bus_unconfig
     bot = _make_bot()
     with mock.patch.object(variables, 'get_consolidation_bus_config', return_value=(None, None)), pytest.raises(ValueError):
         bot._build_consolidation_indexer()
+
+
+# ─── delegated top-up execution ────────────────────────────────────
+
+
+def _delegation_mock(bot, *, delegate, terminated=False, has_role=True):
+    """Attach a delegation contract mock in a given on-chain state."""
+    delegation = Mock()
+    delegation.address = '0xDe1e9a710000000000000000000000000000BEEF'
+    delegation.is_terminated = Mock(return_value=terminated)
+    delegation.get_delegate = Mock(return_value=delegate)
+    delegation.wrap = Mock(side_effect=lambda call: ('wrapped', call))
+    bot.w3.lido.delegation = delegation
+    bot.w3.lido.topup_gateway.top_up_role = Mock(return_value=b'\x01' * 32)
+    bot.w3.lido.topup_gateway.has_role = Mock(return_value=has_role)
+    return delegation
+
+
+@pytest.fixture
+def account(monkeypatch):
+    acc = Mock()
+    acc.address = '0xB07B07B07B07B07B07B07B07B07B07B07B07B07B'
+    monkeypatch.setattr(variables, 'ACCOUNT', acc)
+    return acc
+
+
+@pytest.mark.unit
+def test_delegation_state_disabled_when_not_configured(depositor_bot):
+    assert depositor_bot._topup_delegation_state() is DelegationState.DISABLED
+
+
+@pytest.mark.unit
+def test_delegation_state_ready_when_bot_is_active_delegate(depositor_bot, account):
+    _delegation_mock(depositor_bot, delegate=account.address)
+    assert depositor_bot._topup_delegation_state() is DelegationState.READY
+
+
+@pytest.mark.unit
+def test_delegation_state_not_delegate_after_rotation(depositor_bot, account):
+    """Delegate rotated away from the bot's key — every top-up would revert with NotDelegate."""
+    _delegation_mock(depositor_bot, delegate='0x0000000000000000000000000000000000000001')
+    assert depositor_bot._topup_delegation_state() is DelegationState.NOT_DELEGATE
+
+
+@pytest.mark.unit
+def test_delegation_state_terminated(depositor_bot, account):
+    _delegation_mock(depositor_bot, delegate=account.address, terminated=True)
+    assert depositor_bot._topup_delegation_state() is DelegationState.TERMINATED
+
+
+@pytest.mark.unit
+def test_delegation_state_role_missing(depositor_bot, account):
+    _delegation_mock(depositor_bot, delegate=account.address, has_role=False)
+    assert depositor_bot._topup_delegation_state() is DelegationState.ROLE_MISSING
+
+
+@pytest.mark.unit
+def test_delegation_state_ready_in_dry_mode_without_account(depositor_bot, monkeypatch):
+    """No key to compare against and nothing gets sent — don't block startup on the delegate check."""
+    monkeypatch.setattr(variables, 'ACCOUNT', None)
+    delegation = _delegation_mock(depositor_bot, delegate='0x0000000000000000000000000000000000000001')
+
+    assert depositor_bot._topup_delegation_state() is DelegationState.READY
+    delegation.get_delegate.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    'kwargs',
+    [
+        {'delegate': '0x0000000000000000000000000000000000000001'},  # not the delegate
+        {'delegate': None, 'terminated': True},
+        {'delegate': None, 'has_role': False},
+    ],
+)
+def test_validate_topup_delegation_refuses_to_start_on_misconfiguration(depositor_bot, account, kwargs):
+    kwargs['delegate'] = kwargs['delegate'] or account.address
+    _delegation_mock(depositor_bot, **kwargs)
+    with mock.patch.object(variables, 'ENABLE_TOP_UP', True), pytest.raises(ValueError, match='cannot execute top-ups'):
+        depositor_bot._validate_topup_delegation()
+
+
+@pytest.mark.unit
+def test_validate_topup_delegation_passes_when_ready(depositor_bot, account):
+    _delegation_mock(depositor_bot, delegate=account.address)
+    with mock.patch.object(variables, 'ENABLE_TOP_UP', True):
+        depositor_bot._validate_topup_delegation()  # does not raise
+
+
+@pytest.mark.unit
+def test_validate_topup_delegation_skipped_when_top_up_disabled(depositor_bot, account):
+    """A broken delegation is irrelevant while top-up is off — don't block the deposit-only bot."""
+    delegation = _delegation_mock(depositor_bot, delegate=account.address, terminated=True)
+    with mock.patch.object(variables, 'ENABLE_TOP_UP', False):
+        depositor_bot._validate_topup_delegation()
+    delegation.is_terminated.assert_not_called()
+
+
+@pytest.mark.unit
+def test_top_up_to_module_sends_direct_call_when_delegation_not_configured(depositor_bot):
+    tx = Mock(name='tx')
+    _stub_topup_happy_path(depositor_bot, tx)
+
+    assert depositor_bot._top_up_to_module(1, '0xAddr', 50) is PhaseOutcome.SENT
+    depositor_bot.w3.transaction.check.assert_called_once_with(tx)
+    depositor_bot.w3.transaction.send.assert_called_once_with(tx, False, 6)
+
+
+@pytest.mark.unit
+def test_top_up_to_module_wraps_call_before_dry_run_when_delegated(depositor_bot, account):
+    """The wrapped tx — not the bare topUp — must reach check() and send(): the direct call would
+    revert with AccessControlUnauthorizedAccount, since the role is held by the delegation contract."""
+    tx = Mock(name='tx')
+    _stub_topup_happy_path(depositor_bot, tx)
+    delegation = _delegation_mock(depositor_bot, delegate=account.address)
+
+    assert depositor_bot._top_up_to_module(1, '0xAddr', 50) is PhaseOutcome.SENT
+
+    delegation.wrap.assert_called_once_with(tx)
+    depositor_bot.w3.transaction.check.assert_called_once_with(('wrapped', tx))
+    depositor_bot.w3.transaction.send.assert_called_once_with(('wrapped', tx), False, 6)
+
+
+def _stub_topup_happy_path(bot, tx):
+    """Stub everything _top_up_to_module needs up to building the tx."""
+    mock_module = Mock()
+    mock_module.get_type.return_value = MODULE_TYPE_CMV2
+    bot.w3.lido.staking_module = Mock(return_value=mock_module)
+    strategy = Mock()
+    strategy.is_gas_price_ok = Mock(return_value=True)
+    strategy.get_topup_candidates = Mock(return_value=['proof'])
+    bot._select_topup_strategy = Mock(return_value=strategy)
+    bot.w3.lido.topup_gateway.get_max_validators_per_top_up = Mock(return_value=10)
+    bot.w3.lido.topup_gateway.top_up = Mock(return_value=tx)
+    bot.w3.transaction.check = Mock(return_value=True)
+    bot.w3.transaction.send = Mock(return_value=True)
 
 
 # ─── _select_topup_strategy ────────────────────────────────────────

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -8,7 +8,7 @@ from web3.types import Wei
 
 import variables
 from blockchain.contracts.staking_router import MODULE_TYPE_CMV2, MODULE_TYPE_CSM, StakingModuleInfo
-from bots.depositor import DelegationState, DepositorBot, PhaseOutcome, QuorumState
+from bots.depositor import DepositorBot, PhaseOutcome, QuorumState, TopUpPath
 from tests.conftest import COUNCIL_ADDRESS_1, COUNCIL_ADDRESS_2, COUNCIL_PK_1, COUNCIL_PK_2
 from tests.utils.protocol_utils import get_deposit_message
 
@@ -1289,20 +1289,32 @@ def test_build_consolidation_indexer_raises_when_top_up_enabled_but_bus_unconfig
         bot._build_consolidation_indexer()
 
 
-# ─── delegated top-up execution ────────────────────────────────────
+# ─── top-up execution path (direct vs delegated) ───────────────────
 
 
-def _delegation_mock(bot, *, delegate, terminated=False, has_role=True):
-    """Attach a delegation contract mock in a given on-chain state."""
+def _delegation_mock(bot, *, delegate, terminated=False, delegation_has_role=True, account_has_role=True):
+    """Attach a delegation contract mock plus a role table for (delegation, bot account)."""
     delegation = Mock()
     delegation.address = '0xDe1e9a710000000000000000000000000000BEEF'
     delegation.is_terminated = Mock(return_value=terminated)
     delegation.get_delegate = Mock(return_value=delegate)
     delegation.wrap = Mock(side_effect=lambda call: ('wrapped', call))
     bot.w3.lido.delegation = delegation
-    bot.w3.lido.topup_gateway.top_up_role = Mock(return_value=b'\x01' * 32)
-    bot.w3.lido.topup_gateway.has_role = Mock(return_value=has_role)
+    _role_table(bot, {delegation.address: delegation_has_role}, account_has_role)
     return delegation
+
+
+def _role_table(bot, holders: dict, account_has_role=True):
+    """Stub TOP_UP_ROLE lookups: holders maps address → hasRole, bot account handled separately."""
+    role = b'\x01' * 32
+    bot.w3.lido.topup_gateway.top_up_role = Mock(return_value=role)
+
+    def has_role(_role, address):
+        if variables.ACCOUNT is not None and address == variables.ACCOUNT.address:
+            return account_has_role
+        return holders.get(address, False)
+
+    bot.w3.lido.topup_gateway.has_role = Mock(side_effect=has_role)
 
 
 @pytest.fixture
@@ -1314,70 +1326,110 @@ def account(monkeypatch):
 
 
 @pytest.mark.unit
-def test_delegation_state_disabled_when_not_configured(depositor_bot):
-    assert depositor_bot._topup_delegation_state() is DelegationState.DISABLED
+def test_path_direct_when_no_delegation_configured(depositor_bot, account):
+    _role_table(depositor_bot, {}, account_has_role=True)
+    assert depositor_bot._resolve_topup_path() is TopUpPath.DIRECT
 
 
 @pytest.mark.unit
-def test_delegation_state_ready_when_bot_is_active_delegate(depositor_bot, account):
+def test_path_no_role_when_nobody_holds_the_role(depositor_bot, account):
+    """Pre-existing misconfiguration that used to be invisible: role never granted to the key."""
+    _role_table(depositor_bot, {}, account_has_role=False)
+    assert depositor_bot._resolve_topup_path() is TopUpPath.NO_ROLE
+
+
+@pytest.mark.unit
+def test_path_delegated_when_delegation_holds_role_and_bot_is_delegate(depositor_bot, account):
     _delegation_mock(depositor_bot, delegate=account.address)
-    assert depositor_bot._topup_delegation_state() is DelegationState.READY
+    assert depositor_bot._resolve_topup_path() is TopUpPath.DELEGATED
 
 
 @pytest.mark.unit
-def test_delegation_state_not_delegate_after_rotation(depositor_bot, account):
-    """Delegate rotated away from the bot's key — every top-up would revert with NotDelegate."""
-    _delegation_mock(depositor_bot, delegate='0x0000000000000000000000000000000000000001')
-    assert depositor_bot._topup_delegation_state() is DelegationState.NOT_DELEGATE
+def test_path_prefers_delegation_over_direct_when_both_hold_the_role(depositor_bot, account):
+    """The overlap state mid-migration: both identities hold the role. Delegation wins, so the
+    cutover is complete as soon as the grant lands — revoking from the key changes nothing."""
+    _delegation_mock(depositor_bot, delegate=account.address, account_has_role=True)
+    assert depositor_bot._resolve_topup_path() is TopUpPath.DELEGATED
 
 
 @pytest.mark.unit
-def test_delegation_state_terminated(depositor_bot, account):
-    _delegation_mock(depositor_bot, delegate=account.address, terminated=True)
-    assert depositor_bot._topup_delegation_state() is DelegationState.TERMINATED
+def test_path_direct_when_delegation_has_no_role_yet(depositor_bot, account):
+    """Before the grant lands: delegation is configured but the key still carries the role."""
+    _delegation_mock(depositor_bot, delegate=account.address, delegation_has_role=False)
+    assert depositor_bot._resolve_topup_path() is TopUpPath.DIRECT
 
 
 @pytest.mark.unit
-def test_delegation_state_role_missing(depositor_bot, account):
-    _delegation_mock(depositor_bot, delegate=account.address, has_role=False)
-    assert depositor_bot._topup_delegation_state() is DelegationState.ROLE_MISSING
-
-
-@pytest.mark.unit
-def test_delegation_state_ready_in_dry_mode_without_account(depositor_bot, monkeypatch):
-    """No key to compare against and nothing gets sent — don't block startup on the delegate check."""
-    monkeypatch.setattr(variables, 'ACCOUNT', None)
-    delegation = _delegation_mock(depositor_bot, delegate='0x0000000000000000000000000000000000000001')
-
-    assert depositor_bot._topup_delegation_state() is DelegationState.READY
-    delegation.get_delegate.assert_not_called()
+@pytest.mark.parametrize(
+    'kwargs,expected',
+    [
+        ({'delegate': '0x0000000000000000000000000000000000000001'}, TopUpPath.NOT_DELEGATE),
+        ({'delegate': None, 'terminated': True}, TopUpPath.TERMINATED),
+    ],
+)
+def test_path_reports_delegation_fault_when_direct_is_not_available(depositor_bot, account, kwargs, expected):
+    kwargs['delegate'] = kwargs['delegate'] or account.address
+    _delegation_mock(depositor_bot, account_has_role=False, **kwargs)
+    assert depositor_bot._resolve_topup_path() is expected
 
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
     'kwargs',
     [
-        {'delegate': '0x0000000000000000000000000000000000000001'},  # not the delegate
+        {'delegate': '0x0000000000000000000000000000000000000001'},  # delegate rotated away
         {'delegate': None, 'terminated': True},
-        {'delegate': None, 'has_role': False},
     ],
 )
-def test_validate_topup_delegation_refuses_to_start_on_misconfiguration(depositor_bot, account, kwargs):
+def test_path_falls_back_to_direct_when_delegation_is_broken(depositor_bot, account, kwargs):
+    """A revoked delegate or a terminated contract must not strand the bot while its own key still
+    holds the role — this is what removes the need for a restart timed to the role transactions."""
     kwargs['delegate'] = kwargs['delegate'] or account.address
-    _delegation_mock(depositor_bot, **kwargs)
-    with mock.patch.object(variables, 'ENABLE_TOP_UP', True), pytest.raises(ValueError, match='cannot execute top-ups'):
+    _delegation_mock(depositor_bot, account_has_role=True, **kwargs)
+    assert depositor_bot._resolve_topup_path() is TopUpPath.DIRECT
+
+
+@pytest.mark.unit
+def test_path_direct_in_dry_mode_without_account(depositor_bot, monkeypatch):
+    """No key to compare against and nothing gets sent — don't block on identity checks."""
+    monkeypatch.setattr(variables, 'ACCOUNT', None)
+    _role_table(depositor_bot, {}, account_has_role=False)
+    assert depositor_bot._resolve_topup_path() is TopUpPath.DIRECT
+
+
+@pytest.mark.unit
+def test_validate_refuses_to_start_when_delegation_configured_but_no_path_works(depositor_bot, account):
+    _delegation_mock(depositor_bot, delegate='0x0000000000000000000000000000000000000001', account_has_role=False)
+    with (
+        mock.patch.object(variables, 'ENABLE_TOP_UP', True),
+        mock.patch.object(variables, 'DELEGATION_CONTRACT_ADDRESS', '0xDe1e9a710000000000000000000000000000BEEF'),
+        pytest.raises(ValueError, match='No usable path'),
+    ):
         depositor_bot._validate_topup_delegation()
 
 
 @pytest.mark.unit
-def test_validate_topup_delegation_passes_when_ready(depositor_bot, account):
-    _delegation_mock(depositor_bot, delegate=account.address)
-    with mock.patch.object(variables, 'ENABLE_TOP_UP', True):
+def test_validate_only_warns_when_no_role_and_no_delegation_configured(depositor_bot, account):
+    """Pre-existing deployments must not turn an upgrade into a boot failure."""
+    _role_table(depositor_bot, {}, account_has_role=False)
+    with (
+        mock.patch.object(variables, 'ENABLE_TOP_UP', True),
+        mock.patch.object(variables, 'DELEGATION_CONTRACT_ADDRESS', None),
+    ):
         depositor_bot._validate_topup_delegation()  # does not raise
+    assert depositor_bot._topup_path is TopUpPath.NO_ROLE
 
 
 @pytest.mark.unit
-def test_validate_topup_delegation_skipped_when_top_up_disabled(depositor_bot, account):
+def test_validate_passes_and_records_path_when_executable(depositor_bot, account):
+    _delegation_mock(depositor_bot, delegate=account.address)
+    with mock.patch.object(variables, 'ENABLE_TOP_UP', True):
+        depositor_bot._validate_topup_delegation()
+    assert depositor_bot._topup_path is TopUpPath.DELEGATED
+
+
+@pytest.mark.unit
+def test_validate_skipped_when_top_up_disabled(depositor_bot, account):
     """A broken delegation is irrelevant while top-up is off — don't block the deposit-only bot."""
     delegation = _delegation_mock(depositor_bot, delegate=account.address, terminated=True)
     with mock.patch.object(variables, 'ENABLE_TOP_UP', False):
@@ -1386,9 +1438,10 @@ def test_validate_topup_delegation_skipped_when_top_up_disabled(depositor_bot, a
 
 
 @pytest.mark.unit
-def test_top_up_to_module_sends_direct_call_when_delegation_not_configured(depositor_bot):
+def test_top_up_to_module_sends_direct_call_on_the_direct_path(depositor_bot):
     tx = Mock(name='tx')
     _stub_topup_happy_path(depositor_bot, tx)
+    depositor_bot._topup_path = TopUpPath.DIRECT
 
     assert depositor_bot._top_up_to_module(1, '0xAddr', 50) is PhaseOutcome.SENT
     depositor_bot.w3.transaction.check.assert_called_once_with(tx)
@@ -1396,12 +1449,13 @@ def test_top_up_to_module_sends_direct_call_when_delegation_not_configured(depos
 
 
 @pytest.mark.unit
-def test_top_up_to_module_wraps_call_before_dry_run_when_delegated(depositor_bot, account):
+def test_top_up_to_module_wraps_call_before_dry_run_on_the_delegated_path(depositor_bot, account):
     """The wrapped tx — not the bare topUp — must reach check() and send(): the direct call would
     revert with AccessControlUnauthorizedAccount, since the role is held by the delegation contract."""
     tx = Mock(name='tx')
     _stub_topup_happy_path(depositor_bot, tx)
     delegation = _delegation_mock(depositor_bot, delegate=account.address)
+    depositor_bot._topup_path = TopUpPath.DELEGATED
 
     assert depositor_bot._top_up_to_module(1, '0xAddr', 50) is PhaseOutcome.SENT
 


### PR DESCRIPTION
Closes ORC-785.

`TopUpGateway.topUp` is the **only** permissioned call the bot makes (`TOP_UP_ROLE`, AccessControl). Today that role is granted to the bot's hot key, so rotating the key requires an ACL change on TopUpGateway by the role admin. This PR lets the role live on an EDF delegation contract (LIP-37) instead, with the bot's key as its delegate — rotating the key then becomes a `nominateDelegate` by the delegation contract's owner, with no ACL change.

## The path is resolved from chain state, not from config

`DepositorBot._resolve_topup_path()`, once per iteration:

| resolved path | condition |
|---|---|
| `delegated` | `DELEGATION_CONTRACT_ADDRESS` holds `TOP_UP_ROLE`, is not terminated, and the bot's key is its active delegate → `delegation.execute(topUpGateway, <topUp calldata>)` |
| `direct` | otherwise, and the bot's own account holds the role → plain `topUp` call |
| `not_delegate` / `terminated` / `no_role` | nothing can execute — surfaced on `topup_execution_path` |

Delegation is preferred, the bot's own key is the fallback. So the `grantRole`/`revokeRole` pair can land in either order and **neither direction of the migration needs a restart timed to a block** — the bot follows the role on its next cycle. Same idea as `SignerModule.process_members` in [lido-oracle#967](https://github.com/lidofinance/lido-oracle/pull/967), which resolves the oracle's active identity from the HashConsensus member list each cycle; the input here is just simpler (one `hasRole` read).

A delegate rotated away, revoked, or a terminated contract no longer strands the bot while its own key still holds the role — it falls back and logs why.

## What's here

- `interfaces/DelegationContract.json` + `src/blockchain/contracts/delegation.py`. `wrap()` re-targets an already-built `ContractFunction` via the public `Contract.encode_abi()`, so argument encoding stays in `TopUpGatewayContract.top_up()` only — one source of truth for the proof tuple.
- Wrapping happens **before** `transaction.check()` and gas estimation. The part worth reviewing closely: dry-running the *unwrapped* call would revert with `AccessControlUnauthorizedAccount` (the role is on the contract, not the key), `check()` would return `False`, and the bot would silently stop topping up rather than fail visibly.
- Startup refuses to boot when a delegation contract **is** configured and no path can execute. `no_role` with no delegation configured is the pre-existing "role was never granted to the key" mistake — now visible on the metric, but kept a warning so upgrading a running deployment can't turn into a boot failure.
- `topup_execution_path` (Prometheus Enum) is re-resolved every iteration: a delegate can be rotated or revoked, and the contract terminated, under a running bot, and each turns every top-up into a revert that a bare tx-failure counter can't distinguish from a revert inside `topUp()` itself.
- Naming follows lido-oracle: `DELEGATION_CONTRACT_ADDRESS`, same operators configure both services.

## Deposits, pause and unvet stay direct calls

Deliberate, and documented in `CLAUDE.md` so it doesn't get re-litigated:

- **`depositBufferedEther`** — DSM v5 takes the guardian from calldata (`sig.guardian`) and never reads `msg.sender`; see `_verifySignatures` in `contracts/0.8.9/DepositSecurityModule.sol` in [core#1921](https://github.com/lidofinance/core/pull/1921). Wrapping changes no contract-side check, adds gas to the most gas-sensitive tx the bot sends (it is compared against a computed ceiling, so extra gas narrows the window in which deposits happen at all), and couples deposits to delegate state. Core's own integration test submits it from an arbitrary EOA: `dsm.connect(submitter).depositBufferedEther(...)`.
- **`pauseDeposits` / `unvetSigningKeys`** — these *do* keep an `if (!_isGuardian(msg.sender))` branch that skips signature verification, so EDF works there mechanically. But the bot's only input is an already-signed guardian message, so the signature path is always open to it, and using the `msg.sender` path would require the bot's hot key to be a guardian delegate — a key that could then pause Lido deposits and unvet operator keys with no council quorum.

## Verification

- 265 unit tests pass. Wrapping is checked against the real ABIs: the wrapped calldata is decoded back and asserted to round-trip to the original `topUp` arguments. Path resolution is covered for every state including the mid-migration overlap (both identities hold the role → delegation wins) and both fallback cases.
- pyright: 48 errors, identical to the pre-change baseline (verified by stashing and re-running, not by eye).
- The hand-written ABI is checked against [`IDelegationContract.sol`](https://github.com/lidofinance/execution-delegation-framework/blob/main/src/interfaces/IDelegationContract.sol) on `main`: `execute(address,bytes) payable returns (bytes)`, `getDelegate()`, `getCooldown()`, `isTerminated()`, `owner()`, `NotDelegate()`, `ContractTerminated()` all match. Kept minimal on purpose — the bot's ABI declares only what the bot may call, so it cannot accidentally reach `terminate()`.
- Docs: README variable table, `.env.example`, and the CLAUDE.md top-up gate ladder gains `topup_execution_path` as a module-level gate.

## Not covered: no integration test yet

Unit coverage only, and this is **not** blocked on a missing deployment — `DelegationFactory` is live on Hoodi at [`0x76Af23C7e71004038BeE4a1ceba8c441f4cA239b`](https://github.com/lidofinance/execution-delegation-framework/blob/main/artifacts/hoodi/deploy-hoodi.json) and verified to have bytecode.

The reason it is separate: Hoodi still runs **DSM v4**, where every delegation path in this stack is a deliberate no-op, so a plain Hoodi fork would verify none of it. A meaningful e2e has to run against a fork with core's EDF upgrade applied — the same recipe as core's own EDF job, `MODE=forking NETWORK=hoodi UPGRADE=true STEPS_FILE=upgrade/steps-edf-mock.json`. Tracked separately; it covers this PR and #367/#374 together.

## Deployment dependencies

1. A delegation contract must be deployed for this bot and granted `TOP_UP_ROLE`. It should be **its own** contract, not a shared `dsm-guardian-NN` one: a contract's single delegate key can exercise every role that contract holds, and core#1921's manifest shows contracts are per-identity and reused across applications (each `oracle-member-NN` sits on all four oracle committees). Reusing a guardian's contract would hand the bot's key guardian authority — the ability to pause deposits and unvet keys with no quorum.
2. Ask for **`cooldown > 0`**. Every `delegationContracts` entry in core#1921 is configured with `"cooldown": 0`. Cooldown is make-before-break — during it the current delegate stays effective and the nominee is not yet accepted — so a non-zero value gives a predictable rotation window in which the old key still works. With `0`, rotation is an instant cutover.
3. Note the contract rejects `owner == delegate` (`OwnerCannotBeDelegate`), so the bot's key cannot also be the contract's owner.

Nothing in this PR is active until (1) happens; with the variable unset the bot calls `topUp` directly, exactly as today.
