### PR TITLE
fix: skip top-ups when TOP_UP_ROLE is missing instead of reverting each cycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,8 @@ Delegation is preferred and the key is the fallback, so migrating the role in ei
 
 Startup refuses to boot only when a delegation contract *is* configured and no path can execute. `no_role` with no delegation configured is the pre-existing "role was never granted to the key" mistake — now visible on the metric, but kept a warning so upgrading a running deployment can't turn into a boot failure.
 
+An unusable path (`no_role` / `not_delegate` / `terminated`) **gates top-ups off for the iteration** — deposits, which need no role, still run. Building the tx to let it fail on the dry-run instead would cost a Keys API page, a full CL BeaconState download and the Merkle proofs every cycle, to reach a revert the three `eth_call`s in `_resolve_topup_path()` already predicted. The reason lives on `topup_execution_path` and is logged (WARN) on every transition, not per cycle.
+
 Wrapping happens **before** `transaction.check()`/gas estimation, so the dry-run simulates what actually gets mined; simulating the unwrapped call would revert with `AccessControlUnauthorizedAccount`.
 
 Deposits, pause and unvet are deliberately **not** wrapped. DSM v5 authorises `depositBufferedEther` purely from the guardian signatures in calldata — it never reads `msg.sender` — so wrapping would only add gas and couple deposits to delegate state. `pauseDeposits`/`unvetSigningKeys` do have a `msg.sender`-is-guardian branch, but the bot always holds a signed council message, so the signature path is always open to it and making its hot key a guardian delegate would let that key pause deposits with no quorum.
@@ -184,7 +186,9 @@ Module-level gates (Prometheus, defined in `src/metrics/metrics.py`, set in `src
 1. `topup_gateway_paused == 0` (and `variables.ENABLE_TOP_UP` is true — checked at startup, not a metric).
 2. `topup_execution_path` is `direct` or `delegated` — both healthy, and which one is live tells you
    where `TOP_UP_ROLE` currently sits. `not_delegate` / `terminated` / `no_role` each make *every*
-   top-up revert. Seeing one at runtime means the role assignment changed under a running bot
+   top-up revert, so each one skips the whole top-up branch (no candidate collection, no CL state
+   download) — a silent stop, visible only here and in the transition WARN, while `0x01` deposits
+   keep running. Seeing one at runtime means the role assignment changed under a running bot
    (delegate rotated or revoked, contract terminated, role removed from both identities). Resolved
    before every early return in `_execute_actual()` (alongside `topup_gateway_paused`), so it stays
    trustworthy on idle iterations — an empty buffer would otherwise freeze it at its last value.

--- a/docs/depositor-algorithm.md
+++ b/docs/depositor-algorithm.md
@@ -84,7 +84,8 @@ reuse later, and finally hands off to the two phases.
 
 6. **Phase B — full `0x01` deposits, plus top-ups to `0x02`** (`_phase_full` / `_phase_full_and_topup`)
      Full `0x01` deposits, plus `0x02` top-ups when top-ups are on
-     (`ENABLE_TOP_UP` and the TopUpGateway not paused). Top-ups off → `0x01` only;
+     (`ENABLE_TOP_UP`, the TopUpGateway not paused, and an execution path that can
+     actually send `topUp` — see `topup_execution_path`). Top-ups off → `0x01` only;
      top-ups off and deposits paused → nothing to do.
      - collect candidates: `0x01` from seed allocation (skipped while deposits
        paused), `0x02` from top-up allocation; each whitelisted, active, non-zero

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -274,15 +274,30 @@ class DepositorBot:
         # every top-up into a revert, and this metric is how that gets noticed. Costs at most four
         # `eth_call`s per iteration, on top of the per-module reads `_refresh_modules_state()` already
         # does before the same early returns.
-        # Not a gate — an unusable path still lets the tx be built and fail loudly on the dry-run,
-        # which says more than skipping early.
+        #
+        # The resolved path is also a gate. A path that cannot execute (`no_role`, `not_delegate`,
+        # `terminated`) makes every `topUp` revert with `AccessControlUnauthorizedAccount`, and
+        # letting the tx be built to find that out is not free: a Keys API page, a full CL
+        # BeaconState download (tens of MB) and the Merkle proofs, every cycle, to reach a check
+        # these three `eth_call`s have already answered. So top-ups are skipped while the path is
+        # unusable — the reason stays on `topup_execution_path` and is logged on every transition.
+        # Deposits need no role and are unaffected.
         top_up_enabled = False
         if variables.ENABLE_TOP_UP:
             _tg_paused = self.w3.lido.topup_gateway.is_paused()
             TOPUP_GATEWAY_PAUSED.set(int(_tg_paused))
+            previous_path = self._topup_path
             self._topup_path = self._resolve_topup_path()
             TOPUP_EXECUTION_PATH.state(self._topup_path)
-            top_up_enabled = not _tg_paused
+            # Logged on change only: the steady state belongs on the metric, and the path the bot
+            # booted with was already reported by `_validate_topup_delegation()`.
+            if self._topup_path is not previous_path:
+                event = {'msg': 'Top-up execution path changed.', 'path': self._topup_path, 'previous': previous_path}
+                if self._topup_path.is_executable:
+                    logger.info(event)
+                else:
+                    logger.warning({**event, 'msg': 'Top-up execution path cannot execute — top-ups skipped until the role is granted.'})
+            top_up_enabled = not _tg_paused and self._topup_path.is_executable
         else:
             TOPUP_GATEWAY_PAUSED.set(0)
 
@@ -680,7 +695,8 @@ class DepositorBot:
         Scoped to the case where delegation is configured. `NO_ROLE` without any delegation is the
         pre-existing "role was never granted to the key" misconfiguration — it is now visible on
         `topup_execution_path`, but it must not turn an upgrade of a running deployment into a boot
-        failure, so it stays a warning.
+        failure, so it stays a warning; `_execute_actual()` then skips top-ups instead of building
+        a tx per cycle that can only revert.
         """
         if not variables.ENABLE_TOP_UP:
             return

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -947,6 +947,52 @@ def test_execute_actual_routes_to_phase_full_and_topup_when_top_up_enabled(depos
 
     depositor_bot._execute_actual()
     depositor_bot._phase_full_and_topup.assert_called_once()
+    assert depositor_bot._phase_full_and_topup.call_args.args[-1] is True  # top_up_enabled
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('path', [TopUpPath.NO_ROLE, TopUpPath.NOT_DELEGATE, TopUpPath.TERMINATED])
+def test_execute_actual_unusable_topup_path_gates_topup_off(depositor_bot, path):
+    """A path that cannot execute makes every topUp revert with AccessControlUnauthorizedAccount.
+    Skip the top-up branch instead of paying a Keys API page, a full BeaconState download and the
+    Merkle proofs every cycle just to reach that revert on the dry-run."""
+    variables.ENABLE_TOP_UP = True
+    depositor_bot._resolve_topup_path = Mock(return_value=path)
+    depositor_bot._refresh_modules_state = Mock()
+    depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
+    depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
+    depositor_bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(return_value=[])
+    depositor_bot._phase_seed = Mock(return_value=PhaseOutcome.SKIPPED)
+    depositor_bot._phase_full_and_topup = Mock(return_value=PhaseOutcome.SKIPPED)
+
+    depositor_bot._execute_actual()
+
+    # Phase B still runs — 0x01 deposits need no role — but with top-ups gated off.
+    depositor_bot._phase_full_and_topup.assert_called_once()
+    assert depositor_bot._phase_full_and_topup.call_args.args[-1] is False  # top_up_enabled
+
+
+@pytest.mark.unit
+def test_execute_actual_unusable_topup_path_warns_once_per_transition(depositor_bot, caplog):
+    """The blocked path is reported on every transition and then left to `topup_execution_path` —
+    a per-cycle warning would just be the ERROR flood it replaces."""
+    variables.ENABLE_TOP_UP = True
+    depositor_bot._topup_path = TopUpPath.DIRECT
+    depositor_bot._resolve_topup_path = Mock(return_value=TopUpPath.NO_ROLE)
+    depositor_bot._refresh_modules_state = Mock()
+    depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=0)
+
+    with caplog.at_level('WARNING', logger='bots.depositor'):
+        depositor_bot._execute_actual()
+        depositor_bot._execute_actual()
+        assert len([r for r in caplog.records if 'cannot execute' in r.getMessage()]) == 1
+
+        # Role granted → recovery is logged too, and a later revocation warns again.
+        depositor_bot._resolve_topup_path = Mock(return_value=TopUpPath.DIRECT)
+        depositor_bot._execute_actual()
+        depositor_bot._resolve_topup_path = Mock(return_value=TopUpPath.NO_ROLE)
+        depositor_bot._execute_actual()
+        assert len([r for r in caplog.records if 'cannot execute' in r.getMessage()]) == 2
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

Reported from a glamsterdam devnet running the full DSM setup: the depositor bot logged one ERROR per cycle, indefinitely, for ~2.5 days. The revert decodes to `AccessControlUnauthorizedAccount(account, TOP_UP_ROLE)` from `TopUpGateway.topUp` — `getRoleMemberCount(TOP_UP_ROLE) == 0` on chain, the role was simply never granted (their side, being fixed).

The bot already knew this before doing any work: `_resolve_topup_path()` reads `TOP_UP_ROLE` + `hasRole` for both identities every cycle and publishes `topup_execution_path`. But the result was metric-only — the code deliberately let the tx be built so it would "fail loudly" on the dry-run.

So every failing cycle first paid for a Keys API page (50 keys), a full CL `BeaconState` download (~14.5 MB) and the Merkle proofs, only then reverting on a permission check three `eth_call`s had already answered. At that cadence: ~0.6 GB/h of needless CL traffic per bot.

## Change

Make the resolved path a gate (`src/bots/depositor.py`):

```python
top_up_enabled = not _tg_paused and self._topup_path.is_executable
```

- `no_role` / `not_delegate` / `terminated` → the 0x02 branch of phase B is skipped entirely: no candidate collection, no CL state download, no revert.
- `0x01` deposits and phase A are untouched — they need no role, and on the reporting devnet they were fully healthy the whole time.
- One WARN **per transition** into a blocked path (plus INFO on recovery); the steady state lives on `topup_execution_path`. A per-cycle WARN would just be the ERROR flood one level down.
- No extra RPC: the same ≤3 `eth_call`s per iteration that already ran.

### Deliberately unchanged

Startup does **not** hard-fail on `no_role` when no delegation contract is configured. That is exactly the devnet's case and it is also the pre-existing "role was never granted to the key" misconfiguration; turning it into a boot failure would make an upgrade of a running deployment with an incomplete ACL a crash loop, while deposits are perfectly healthy. Boot still refuses only when a delegation contract *is* configured and no path can execute.

Two other items from the same report — decoding known custom errors in `TransactionUtils.check`, and `TX_FAILED` aborting phase B instead of skipping the candidate — are not addressed here.

## Tests

- `test_execute_actual_unusable_topup_path_gates_topup_off` — parametrized over all three blocked paths; phase B still runs, with `top_up_enabled=False`.
- `test_execute_actual_unusable_topup_path_warns_once_per_transition` — WARN once per transition, again after recovery + a new revocation.
- Strengthened the existing positive-path test to assert `top_up_enabled is True`.

`poetry run pytest tests -m unit` — 285 passed. No new pyright/ruff findings.

Docs updated: `CLAUDE.md` (delegated execution + the top-up gate ladder) and `docs/depositor-algorithm.md`.