### PR TITLE
fix: bound retained deposit messages and verify signatures once

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,11 +19,16 @@ poetry run pytest tests/bots/test_depositor.py::TestDepositorBot::test_name -m u
 # Run integration tests (requires Hoodi RPC in TESTNET_WEB3_RPC_ENDPOINTS and anvil installed)
 poetry run pytest tests -m integration
 
-# Lint and format
-poetry run ruff check --fix
-poetry run ruff format
+# Lint and format — use the pre-commit hooks, NOT `poetry run ruff`.
+# The hooks pin ruff v0.15.9; the dev dependency resolves to 0.4.10, whose isort classifies
+# `schema`/`web3` as first-party and rewrites the import block of nearly every file in the repo.
+# Running `poetry run ruff check --fix` therefore produces a large unrelated diff that the pinned
+# version then leaves untouched.
+poetry run pre-commit run ruff --files <changed files>
+poetry run pre-commit run ruff-format --files <changed files>
+poetry run pre-commit run --all-files
 
-# Type check
+# Type check (48 errors are pre-existing — compare against the base commit, don't chase the total)
 poetry run pyright src/
 
 # Run a bot locally (dry mode, no transactions sent unless CREATE_TRANSACTIONS=true)
@@ -115,7 +120,12 @@ Both parser sets are registered in each bot (`parsers_providers=[...]`). **Clean
 
 Logs are dispatched to the parser that declared their event id (`topic0`), never by trying parsers until one does not raise — the V1 layout decodes a V2 payload *without* raising (the ABI offset word reads as `blockNumber`), so a fallback chain would silently turn every v5 message into garbage that only fails later, at signature verification.
 
-`MessageStorage` (`src/transport/msg_storage.py`) aggregates messages from all active transports, applies static filters (signature validity, checksum address normalization), and on each cycle calls `get_messages_and_actualize()` with a dynamic filter that discards messages older than 200 blocks or with a stale deposit root.
+`MessageStorage` (`src/transport/msg_storage.py`) aggregates messages from all active transports, applies static filters, and on each cycle calls `get_messages_and_actualize()` with a dynamic filter.
+
+The split between the two filter lists is load-bearing, not cosmetic: **static filters run once per message, on arrival; the actualize filter re-runs over the entire retained list on every call** — and `_fetch_actual_messages()` is called once per whitelisted module per cycle (`_refresh_modules_state`), plus once more per deposit attempt. So anything whose answer cannot change belongs in the static list, or it gets paid for N times per cycle per retained message.
+
+- **Static** (`DepositorBot.__init__`): metrics/type filter, checksum normalization, then **guardian signature verification** — a property of the message alone (the digest covers every signed field; the attest prefix and delegation mode are fixed for the process, both changing only on a DSM upgrade, which already requires a restart). Order matters: the sign filter must follow `to_check_sum_address`, since it compares against the recovered (checksummed) address.
+- **Actualize** (`_get_message_actualize_filter`): only checks against mutable chain state — guardian/delegate still registered, deposit root still current, and `blockNumber` within `MESSAGE_BLOCK_WINDOW` (200) of the node's head **in either direction**. The upper bound matters: `blockNumber` is inside the signed digest, so without it a guardian could sign unlimited messages for blocks the chain will never reach, each retained forever under "cannot verify yet" — unbounded storage growth that eventually pushes a cycle past `MAX_CYCLE_LIFETIME_IN_SECONDS` and kills the daemon, taking down the quorum-free top-up path with it.
 
 Quorum is formed by grouping valid messages by `blockHash`, then checking if any group has `>= guardian_quorum` unique guardian addresses.
 

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -76,6 +76,21 @@ from transport.types import TransportType
 
 logger = logging.getLogger(__name__)
 
+# A deposit message is only relevant while its `blockNumber` is within this many blocks of this node's
+# head, in either direction.
+#
+# Behind: the message is too stale to act on — the deposit root has moved and the DSM would revert.
+#
+# Ahead: this node is lagging the council's, so the message cannot be checked against a block we have
+# not seen and is kept until the chain catches up. That side needs a bound just as much as the other
+# one. `blockNumber` is part of the signed digest, so a guardian can sign messages for an arbitrarily
+# far-future block, and each one stays "unverifiable, keep it" for as long as the chain has not
+# reached it — i.e. forever. Unbounded, one guardian can grow MessageStorage without limit until the
+# per-cycle work over the retained list exceeds MAX_CYCLE_LIFETIME_IN_SECONDS and the daemon is shut
+# down, which also takes down the top-up path — a path that needs no guardian quorum and must not be
+# reachable by a single guardian.
+MESSAGE_BLOCK_WINDOW = 200
+
 
 class ModuleCandidate(NamedTuple):
     """Module candidate selected for a deposit/top-up in one bot iteration."""
@@ -225,11 +240,30 @@ class DepositorBot:
                 }
             )
 
+        # Whether a message's guardian signature is valid is a property of the message alone: the
+        # digest covers every signed field, and the two inputs that are not on the message — the
+        # attest prefix and the delegation mode — are fixed for the lifetime of the process (both
+        # change only on a DSM upgrade, which already requires a restart; `dsm_version` is likewise
+        # resolved once at startup). So it is verified once, here on the ingestion path, which sees
+        # each message exactly once.
+        #
+        # It used to sit in the actualize filter instead, which re-runs over the *whole retained
+        # list* on every `_fetch_actual_messages()` call — and that is called once per whitelisted
+        # module per cycle by `_refresh_modules_state`, plus once more per deposit attempt. Every
+        # retained message therefore cost N ecrecovers per cycle instead of one ever, which is what
+        # made flooding the storage a cheap way to push a cycle past MAX_CYCLE_LIFETIME_IN_SECONDS.
+        # It also called `ATTEST_MESSAGE_PREFIX()` once per module per cycle for a constant.
         self.message_storage = MessageStorage(
             transports,
             filters=[
                 message_metrics_filter,
                 to_check_sum_address,
+                # Must come after to_check_sum_address: verification compares the address recovered
+                # from the signature, which is checksummed, against the one on the message.
+                get_messages_sign_filter(
+                    self.w3.lido.deposit_security_module.get_attest_message_prefix(),
+                    delegated=self.w3.lido.guardian_delegation_active(),
+                ),
             ],
         )
 
@@ -794,12 +828,13 @@ class DepositorBot:
                 UNEXPECTED_EXCEPTIONS.labels('unexpected_guardian_address').inc()
                 return False
 
-            if message['blockNumber'] < latest['number'] - 200:
+            head = latest['number']
+            if not head - MESSAGE_BLOCK_WINDOW <= message['blockNumber'] <= head + MESSAGE_BLOCK_WINDOW:
                 return False
 
             # Message from council is newer than depositor node latest block
-            if message['blockNumber'] > latest['number']:
-                # can't be verified, so skip
+            if message['blockNumber'] > head:
+                # can't be verified yet, so keep it until the chain catches up — bounded above
                 return True
 
             return message['depositRoot'] == deposit_root
@@ -821,9 +856,7 @@ class DepositorBot:
         return success
 
     def _fetch_actual_messages(self) -> list[BotMessage]:
-        # Fetch messages and apply filters
-        actualize_filter = self._get_message_actualize_filter()
-        prefix = self.w3.lido.deposit_security_module.get_attest_message_prefix()
-        sign_filter = get_messages_sign_filter(prefix, delegated=self.w3.lido.guardian_delegation_active())
-
-        return self.message_storage.get_messages_and_actualize(lambda x: sign_filter(x) and actualize_filter(x))
+        # Signature verification is deliberately absent here — it runs once per message on ingestion
+        # (see the MessageStorage filters in __init__). Only checks against mutable chain state belong
+        # in this filter, because it re-runs over the entire retained list on every call.
+        return self.message_storage.get_messages_and_actualize(self._get_message_actualize_filter())

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -76,19 +76,6 @@ from transport.types import TransportType
 
 logger = logging.getLogger(__name__)
 
-# A deposit message is only relevant while its `blockNumber` is within this many blocks of this node's
-# head, in either direction.
-#
-# Behind: the message is too stale to act on — the deposit root has moved and the DSM would revert.
-#
-# Ahead: this node is lagging the council's, so the message cannot be checked against a block we have
-# not seen and is kept until the chain catches up. That side needs a bound just as much as the other
-# one. `blockNumber` is part of the signed digest, so a guardian can sign messages for an arbitrarily
-# far-future block, and each one stays "unverifiable, keep it" for as long as the chain has not
-# reached it — i.e. forever. Unbounded, one guardian can grow MessageStorage without limit until the
-# per-cycle work over the retained list exceeds MAX_CYCLE_LIFETIME_IN_SECONDS and the daemon is shut
-# down, which also takes down the top-up path — a path that needs no guardian quorum and must not be
-# reachable by a single guardian.
 MESSAGE_BLOCK_WINDOW = 200
 
 
@@ -240,26 +227,11 @@ class DepositorBot:
                 }
             )
 
-        # Whether a message's guardian signature is valid is a property of the message alone: the
-        # digest covers every signed field, and the two inputs that are not on the message — the
-        # attest prefix and the delegation mode — are fixed for the lifetime of the process (both
-        # change only on a DSM upgrade, which already requires a restart; `dsm_version` is likewise
-        # resolved once at startup). So it is verified once, here on the ingestion path, which sees
-        # each message exactly once.
-        #
-        # It used to sit in the actualize filter instead, which re-runs over the *whole retained
-        # list* on every `_fetch_actual_messages()` call — and that is called once per whitelisted
-        # module per cycle by `_refresh_modules_state`, plus once more per deposit attempt. Every
-        # retained message therefore cost N ecrecovers per cycle instead of one ever, which is what
-        # made flooding the storage a cheap way to push a cycle past MAX_CYCLE_LIFETIME_IN_SECONDS.
-        # It also called `ATTEST_MESSAGE_PREFIX()` once per module per cycle for a constant.
         self.message_storage = MessageStorage(
             transports,
             filters=[
                 message_metrics_filter,
                 to_check_sum_address,
-                # Must come after to_check_sum_address: verification compares the address recovered
-                # from the signature, which is checksummed, against the one on the message.
                 get_messages_sign_filter(
                     self.w3.lido.deposit_security_module.get_attest_message_prefix(),
                     delegated=self.w3.lido.guardian_delegation_active(),
@@ -834,7 +806,7 @@ class DepositorBot:
 
             # Message from council is newer than depositor node latest block
             if message['blockNumber'] > head:
-                # can't be verified yet, so keep it until the chain catches up — bounded above
+                # can't be verified, so skip
                 return True
 
             return message['depositRoot'] == deposit_root
@@ -856,7 +828,4 @@ class DepositorBot:
         return success
 
     def _fetch_actual_messages(self) -> list[BotMessage]:
-        # Signature verification is deliberately absent here — it runs once per message on ingestion
-        # (see the MessageStorage filters in __init__). Only checks against mutable chain state belong
-        # in this filter, because it re-runs over the entire retained list on every call.
         return self.message_storage.get_messages_and_actualize(self._get_message_actualize_filter())

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -32,8 +32,6 @@ def _make_bot(attest_prefix: bytes | None = None):
     # delegation set it explicitly.
     w3.lido.delegation = None
     if attest_prefix is not None:
-        # The storage's sign filter is built in __init__ from these two, so they must be set before
-        # construction for a test to feed real signatures through it.
         w3.lido.deposit_security_module.get_attest_message_prefix.return_value = attest_prefix
         w3.lido.guardian_delegation_active.return_value = False
     # Skip the real ConsolidationBus backfill (needs RPC) — inject a mock indexer so top-up paths
@@ -1669,8 +1667,6 @@ def test_depositor_message_actualizer_far_future_block(setup_deposit_message, de
     deposit_message['blockNumber'] = block_data['number'] + MESSAGE_BLOCK_WINDOW + 1
     assert not list(filter(message_filter, [deposit_message]))
 
-    # `blockNumber` is inside the signed digest, so without the upper bound a guardian could sign an
-    # unlimited number of messages the chain will never reach and keep every one of them retained.
     deposit_message['blockNumber'] = block_data['number'] + 10**9
     assert not list(filter(message_filter, [deposit_message]))
 
@@ -1719,7 +1715,7 @@ def test_bad_signature_dropped_on_ingestion():
     bot = _make_bot(attest_prefix=_ATTEST_PREFIX)
     good = _signed_deposit_message()
     tampered = _signed_deposit_message()
-    tampered['nonce'] += 1  # signature no longer matches the digest
+    tampered['nonce'] += 1
 
     bot.message_storage.clear()
     bot.message_storage._transports = [_StubTransport([good, tampered])]
@@ -1732,12 +1728,7 @@ def test_bad_signature_dropped_on_ingestion():
 
 @pytest.mark.unit
 def test_retained_messages_are_not_reverified_every_cycle():
-    """Regression: verification used to re-run over the whole retained list on every call.
-
-    `_fetch_actual_messages()` is called once per whitelisted module per cycle, so re-verifying there
-    turned each retained message into N ecrecovers (and N `ATTEST_MESSAGE_PREFIX()` calls) per cycle —
-    the amplification that made flooding the storage a cheap way to stall a cycle.
-    """
+    """Verification must not re-run over the retained list on every call."""
     bot = _make_bot()
     prefix_calls = bot.w3.lido.deposit_security_module.get_attest_message_prefix
     assert prefix_calls.call_count == 1, 'the attest prefix is a constant — read once at startup'

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -4,11 +4,14 @@ from unittest import mock
 from unittest.mock import MagicMock, Mock
 
 import pytest
+from eth_account import Account
+from web3 import Web3
 from web3.types import Wei
 
 import variables
 from blockchain.contracts.staking_router import MODULE_TYPE_CMV2, MODULE_TYPE_CSM, StakingModuleInfo
-from bots.depositor import DepositorBot, PhaseOutcome, QuorumState, TopUpPath
+from bots.depositor import MESSAGE_BLOCK_WINDOW, DepositorBot, PhaseOutcome, QuorumState, TopUpPath
+from cryptography.verify_signature import compute_vs
 from tests.conftest import COUNCIL_ADDRESS_1, COUNCIL_ADDRESS_2, COUNCIL_PK_1, COUNCIL_PK_2
 from tests.utils.protocol_utils import get_deposit_message
 
@@ -20,7 +23,7 @@ def _make_digest(module_id, address, wc_type, status=0) -> StakingModuleInfo:
     return StakingModuleInfo(module_id=module_id, address=address, wc_type=wc_type, status=status)
 
 
-def _make_bot():
+def _make_bot(attest_prefix: bytes | None = None):
     """Build a DepositorBot with all-MagicMock deps. No transports → MessageStorage stays empty."""
     variables.MESSAGE_TRANSPORTS = ''
     w3 = MagicMock()
@@ -28,6 +31,11 @@ def _make_bot():
     # delegated top-up execution. Default to the direct-call configuration; tests that exercise
     # delegation set it explicitly.
     w3.lido.delegation = None
+    if attest_prefix is not None:
+        # The storage's sign filter is built in __init__ from these two, so they must be set before
+        # construction for a test to feed real signatures through it.
+        w3.lido.deposit_security_module.get_attest_message_prefix.return_value = attest_prefix
+        w3.lido.guardian_delegation_active.return_value = False
     # Skip the real ConsolidationBus backfill (needs RPC) — inject a mock indexer so top-up paths
     # are still exercised. ENABLE_TOP_UP is left untouched; tests set it as needed.
     with mock.patch.object(DepositorBot, '_build_consolidation_indexer', return_value=MagicMock()):
@@ -1648,6 +1656,101 @@ def test_depositor_message_actualizer_root(setup_deposit_message, depositor_bot,
 
     deposit_message['blockNumber'] = block_data['number'] + 100
     assert list(filter(message_filter, [deposit_message]))
+
+
+@pytest.mark.unit
+def test_depositor_message_actualizer_far_future_block(setup_deposit_message, depositor_bot, deposit_message, block_data):
+    """A blockNumber far ahead of head must be dropped, not retained as "cannot verify yet"."""
+    message_filter = depositor_bot._get_message_actualize_filter()
+
+    deposit_message['blockNumber'] = block_data['number'] + MESSAGE_BLOCK_WINDOW
+    assert list(filter(message_filter, [deposit_message])), 'edge of the window is still relevant'
+
+    deposit_message['blockNumber'] = block_data['number'] + MESSAGE_BLOCK_WINDOW + 1
+    assert not list(filter(message_filter, [deposit_message]))
+
+    # `blockNumber` is inside the signed digest, so without the upper bound a guardian could sign an
+    # unlimited number of messages the chain will never reach and keep every one of them retained.
+    deposit_message['blockNumber'] = block_data['number'] + 10**9
+    assert not list(filter(message_filter, [deposit_message]))
+
+
+# ─── Signature verification happens on ingestion, once per message ──
+
+
+_ATTEST_PREFIX = b'\x11' * 32
+_BLOCK_HASH = '0x432e218931e9b94f0702ecb1b0d084c467a86b384767ce38c4fe164463070532'
+_DEPOSIT_ROOT = '0x64dcf70a7ad7fc6b1a55db6b08b86e9d80736259916fcaef98f4710f0bac687b'
+
+
+class _StubTransport:
+    def __init__(self, messages):
+        self._messages = messages
+
+    def get_messages(self):
+        return self._messages
+
+
+def _signed_deposit_message(nonce: int = 12) -> dict:
+    """Deposit message signed by COUNCIL_1 under the v4 (non-delegated) scheme."""
+    digest = Web3.solidity_keccak(
+        ['bytes32', 'uint256', 'bytes32', 'bytes32', 'uint256', 'uint256'],
+        [_ATTEST_PREFIX, 10, _BLOCK_HASH, _DEPOSIT_ROOT, 1, nonce],
+    )
+    signed = Account.unsafe_sign_hash(digest, COUNCIL_PK_1)
+    return {
+        'type': 'deposit',
+        'blockNumber': 10,
+        'blockHash': _BLOCK_HASH,
+        'depositRoot': _DEPOSIT_ROOT,
+        'stakingModuleId': 1,
+        'nonce': nonce,
+        'guardianAddress': COUNCIL_ADDRESS_1,
+        'signature': {
+            'r': '0x' + signed.r.to_bytes(32, 'big').hex(),
+            '_vs': compute_vs(signed.v, '0x' + signed.s.to_bytes(32, 'big').hex()),
+        },
+    }
+
+
+@pytest.mark.unit
+def test_bad_signature_dropped_on_ingestion():
+    """The sign filter must be wired into the storage's static (per-message) filters."""
+    bot = _make_bot(attest_prefix=_ATTEST_PREFIX)
+    good = _signed_deposit_message()
+    tampered = _signed_deposit_message()
+    tampered['nonce'] += 1  # signature no longer matches the digest
+
+    bot.message_storage.clear()
+    bot.message_storage._transports = [_StubTransport([good, tampered])]
+    try:
+        kept = bot.message_storage.get_messages_and_actualize(lambda x: True)
+        assert [m['nonce'] for m in kept] == [good['nonce']]
+    finally:
+        bot.message_storage.clear()
+
+
+@pytest.mark.unit
+def test_retained_messages_are_not_reverified_every_cycle():
+    """Regression: verification used to re-run over the whole retained list on every call.
+
+    `_fetch_actual_messages()` is called once per whitelisted module per cycle, so re-verifying there
+    turned each retained message into N ecrecovers (and N `ATTEST_MESSAGE_PREFIX()` calls) per cycle —
+    the amplification that made flooding the storage a cheap way to stall a cycle.
+    """
+    bot = _make_bot()
+    prefix_calls = bot.w3.lido.deposit_security_module.get_attest_message_prefix
+    assert prefix_calls.call_count == 1, 'the attest prefix is a constant — read once at startup'
+
+    bot.message_storage.clear()
+    bot._get_message_actualize_filter = Mock(return_value=lambda x: True)
+    try:
+        for _ in range(5):
+            bot._fetch_actual_messages()
+    finally:
+        bot.message_storage.clear()
+
+    assert prefix_calls.call_count == 1
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

Addresses an audit finding: a current guardian can stall the depositor daemon by flooding `MessageStorage`, which takes down the **top-up path** with it. Top-ups need no guardian quorum, so this hands a single guardian availability authority it should not have. (Withholding signatures blocks deposits but not top-ups; pausing DSM via one signature doesn't stop top-ups either — they sit behind the separate `TopUpGateway.isPaused` gate.)

Two independent causes, both fixed here. Neither change alters *which* messages are accepted — only how long they are kept and how often they are checked.

## 1. No upper bound on `blockNumber`

`_get_message_actualize_filter` bounded staleness but not the future:

```python
if message['blockNumber'] > latest['number']:
    return True   # can't verify -> keep
```

Reasonable in intent: a message ahead of this node's head can't be checked against a block we haven't seen, so it's held until the chain catches up. But `blockNumber` is inside the signed digest, so a guardian can sign messages for blocks the chain will never reach — each one retained forever. Everything else expires (older than 200 blocks is dropped; in-window messages die on the `depositRoot` check), so this was the only unbounded path.

The relevance window is now symmetric, via a new `MESSAGE_BLOCK_WINDOW` constant replacing the inline `200`.

## 2. Signature verification re-ran over the whole retained list

The sign filter was composed into the **actualize** filter, which re-runs over every retained message on each call — and `_fetch_actual_messages()` is called **once per whitelisted module per cycle** by `_refresh_modules_state`, plus once more per deposit attempt. Each retained message therefore cost N ecrecovers per cycle instead of one, which is what made flooding cheap.

Whether a signature is valid is a property of the message alone: the digest covers every signed field, and the two inputs that aren't on the message — the attest prefix and the delegation mode — are fixed for the lifetime of the process (both change only on a DSM upgrade, which already requires a restart; `dsm_version` is likewise resolved once at startup).

So it moves to the **static** filter list, which sees each message exactly once. No cache or memoization needed — just the correct list. Ordering matters and is commented: it must follow `to_check_sum_address`, since verification compares against the recovered (checksummed) address.

Measured cost of what this removes, on this repo's dependency set:

```
sign filter (keccak + ecrecover):  6122.41 us/msg
actualize filter body:                0.13 us/msg
ratio:                               45823x
```

`coincurve` is absent from `poetry.lock`, so `eth_keys` falls back to the pure-Python `NativeECCBackend` — in the image too, which installs from the same lock. At 5 whitelisted modules and `MAX_CYCLE_LIFETIME_IN_SECONDS=1200`, that put the CPU threshold at roughly **39k retained messages**, well below what the report assumed. After the change the same budget is ~1.8B messages, i.e. memory is exhausted long before CPU.

Worth a separate PR: adding `coincurve` would speed up signature verification everywhere on the hot path, not just under this scenario.

(An earlier revision of this description claimed the change also stops re-reading `ATTEST_MESSAGE_PREFIX()` once per module per cycle. That was wrong — the getter is already `@lru_cache(maxsize=1)` with a constant key, so it was one eth_call ever. The saving is the ecrecovers only.)

## Tests

Three regression tests in `tests/bots/test_depositor.py`. Verified by mutation — both fixes were reverted in place, all three failed, then restored:

- `test_depositor_message_actualizer_far_future_block` — window edge, edge+1, and `+10**9`
- `test_bad_signature_dropped_on_ingestion` — the sign filter is actually wired into the static list (stub transport, real signature)
- `test_retained_messages_are_not_reverified_every_cycle` — 5 calls to `_fetch_actual_messages()`, `get_attest_message_prefix` called exactly once

`_make_bot()` gains an optional `attest_prefix` so real signatures can be fed through the filter.

Full unit suite: **284 passed**. Pyright: 48 errors before and after (all pre-existing, compared against the base commit).

## Also in this PR

- `CLAUDE.md`: the documented filter behaviour was stale ("discards messages older than 200 blocks"), and the static/actualize split is now documented as load-bearing so verification doesn't get moved back.
- `CLAUDE.md`: **the documented lint command was wrong.** The pre-commit hooks pin ruff **v0.15.9**, but the dev dependency resolves to **0.4.10**, whose isort classifies `schema`/`web3` as first-party and rewrites the import block of nearly every file. Running `poetry run ruff check --fix` as documented reformats ~29 unrelated files, which the pinned version then leaves untouched. Doc now points at the pre-commit hooks.

  Fixing the doc is the minimal change; bumping the dev dependency to `^0.15.9` is the alternative and probably the better long-term call, but that's a separate decision.

## Not addressed here

Two further items from the same finding, deliberately left out of this PR:

- Per-guardian and global caps on retained messages with deterministic eviction. Still worth having: with the window bounded, in-window flooding is limited only by arrival rate.
- `RabbitProvider._queue` (`rabbit.py:24`) is appended by the STOMP callback thread with no bound while only 1000 are drained per fetch — a second unbounded buffer, and plausibly an OOM before any cycle timeout.

Also worth noting: the finding as written scopes the attack to DSMv4/RabbitMQ, but the mechanism is transport-agnostic. A v5 guardian's delegate can post the same messages to the Data Bus, and Gnosis gas is roughly $10 per 100k events — not a meaningful barrier. `onchain_transport` is also the default in `.env.example`. Both fixes here are transport-agnostic.

`PauserBot` and `UnvetterBot` use the same sign-filter-in-actualize pattern, but their retention is bounded by the pause validity period and the nonce check respectively, so they are not exploitable the same way. Left untouched to keep this diff scoped — `PauserBot` runs every block and is the most safety-critical of the three.

