### PR TITLE
fix: an unusable top-up path must not block full deposits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ The general strategy uses a cubic formula to compute a recommended gas ceiling: 
 |---|---|
 | `delegated` | `DELEGATION_CONTRACT_ADDRESS` holds `TOP_UP_ROLE`, is not terminated, and the bot's key is its active delegate → tx wrapped as `delegation.execute(topUpGateway, <topUp calldata>)` (`DelegationContract.wrap()`) |
 | `direct` | otherwise, and the bot's own account holds the role → plain `topUp` call |
-| `not_delegate` / `terminated` / `no_role` | nothing can execute; see the gate ladder below |
+| `not_delegate` / `terminated` / `no_role` | nothing can execute, so `top_up_enabled` is false and no top-up is attempted; see the gate ladder below |
 
 Delegation is preferred and the key is the fallback, so migrating the role in either direction needs no restart timed to the `grantRole`/`revokeRole` transactions — the bot follows the role on its next cycle. Same idea as `SignerModule.process_members` in lido-oracle, which resolves the active identity from the HashConsensus member list each cycle. With the role on the delegation contract, rotating the bot's key becomes a `nominateDelegate` by the contract's owner instead of an ACL change on TopUpGateway.
 
@@ -183,11 +183,19 @@ Module-level gates (Prometheus, defined in `src/metrics/metrics.py`, set in `src
 
 1. `topup_gateway_paused == 0` (and `variables.ENABLE_TOP_UP` is true — checked at startup, not a metric).
 2. `topup_execution_path` is `direct` or `delegated` — both healthy, and which one is live tells you
-   where `TOP_UP_ROLE` currently sits. `not_delegate` / `terminated` / `no_role` each make *every*
-   top-up revert. Seeing one at runtime means the role assignment changed under a running bot
+   where `TOP_UP_ROLE` currently sits. `not_delegate` / `terminated` / `no_role` mean no top-up is
+   even attempted: `top_up_enabled` requires `TopUpPath.is_executable`, so no 0x02 candidate is
+   collected at all. Seeing one at runtime means the role assignment changed under a running bot
    (delegate rotated or revoked, contract terminated, role removed from both identities). Resolved
    before every early return in `_execute_actual()` (alongside `topup_gateway_paused`), so it stays
    trustworthy on idle iterations — an empty buffer would otherwise freeze it at its last value.
+
+   This gate is **not** just an optimisation. Attempting a top-up on an unusable path builds an
+   unwrapped `topUp` call from an account known not to hold the role, whose preflight reverts and
+   returns `TX_FAILED` — which, before this gate existed, ended Phase B before the 0x01 full
+   deposits queued behind it, and did so every block. A routine delegate rotation could therefore
+   stall guardian-authorized deposits that need no top-up authorization at all. Visibility was the
+   original argument for attempting anyway; this metric already provides it without a revert.
 3. `module_allocation_wei{module_id, kind="topup"} > 0`. Zero here is the single most common reason
    nothing happens — the StakingRouter allocation algorithm didn't route ETH to this module at all
    this cycle.

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -274,15 +274,13 @@ class DepositorBot:
         # every top-up into a revert, and this metric is how that gets noticed. Costs at most four
         # `eth_call`s per iteration, on top of the per-module reads `_refresh_modules_state()` already
         # does before the same early returns.
-        # Not a gate — an unusable path still lets the tx be built and fail loudly on the dry-run,
-        # which says more than skipping early.
         top_up_enabled = False
         if variables.ENABLE_TOP_UP:
             _tg_paused = self.w3.lido.topup_gateway.is_paused()
             TOPUP_GATEWAY_PAUSED.set(int(_tg_paused))
             self._topup_path = self._resolve_topup_path()
             TOPUP_EXECUTION_PATH.state(self._topup_path)
-            top_up_enabled = not _tg_paused
+            top_up_enabled = not _tg_paused and self._topup_path.is_executable
         else:
             TOPUP_GATEWAY_PAUSED.set(0)
 

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -1781,3 +1781,34 @@ def test_depositor_bot(
     db.message_storage.messages = deposit_messages
     assert db.execute(latest)
     assert web3_lido_integration.lido.staking_router.get_staking_module_nonce(module_id) == old_module_nonce + 1
+
+
+def _phase_b_top_up_enabled(depositor_bot, path: TopUpPath) -> bool:
+    """Drive _execute_actual to Phase B and return the top_up_enabled it was called with."""
+    variables.ENABLE_TOP_UP = True
+    depositor_bot._refresh_modules_state = Mock()
+    depositor_bot.w3.lido.lido.get_depositable_ether = Mock(return_value=100)
+    depositor_bot.w3.lido.staking_router.get_deposit_allocations = Mock(return_value=(0, [], []))
+    depositor_bot.w3.lido.staking_router.get_all_staking_module_digests = Mock(return_value=[])
+    depositor_bot._phase_seed = Mock(return_value=PhaseOutcome.SKIPPED)
+    depositor_bot._phase_full_and_topup = Mock(return_value=PhaseOutcome.SKIPPED)
+    depositor_bot._resolve_topup_path = Mock(return_value=path)
+
+    depositor_bot._execute_actual()
+
+    depositor_bot._phase_full_and_topup.assert_called_once()
+    return depositor_bot._phase_full_and_topup.call_args.args[-1]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('path', [TopUpPath.NOT_DELEGATE, TopUpPath.TERMINATED, TopUpPath.NO_ROLE])
+def test_execute_actual_disables_topup_when_path_not_executable(depositor_bot, path):
+    """An unusable path must not admit top-up candidates: the revert would preempt the 0x01
+    deposits later in the same Phase B loop, which do not need TOP_UP_ROLE at all."""
+    assert _phase_b_top_up_enabled(depositor_bot, path) is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('path', [TopUpPath.DIRECT, TopUpPath.DELEGATED])
+def test_execute_actual_enables_topup_when_path_executable(depositor_bot, path):
+    assert _phase_b_top_up_enabled(depositor_bot, path) is True


### PR DESCRIPTION
Addresses an audit finding. Branched from `develop`, independent of #381.

## Problem

Phase B iterates 0x01 full-deposit and 0x02 top-up candidates in **one list ordered by stake**, and returns on the first non-`SKIPPED` outcome. `top_up_enabled` was derived from the gateway pause state alone, ignoring the resolved execution path.

Confirmed chain, before this PR:

`top_up_enabled = not _tg_paused` (`depositor.py:291`) → 0x02 candidates collected → sort by `(stake, digest_index)` puts a 0x02 ahead of a 0x01 → `_top_up_to_module` wraps only `DELEGATED` (`:597`), so `NOT_DELEGATE`/`TERMINATED`/`NO_ROLE` build a bare `topUp` from an account **already known** not to hold the role (had it held it, `_resolve_topup_path` would have returned `DIRECT`) → `transaction.check()` reverts → `TX_FAILED` → `if outcome is not PhaseOutcome.SKIPPED: return outcome` (`:481`) ends Phase B before the 0x01 candidate.

`TX_FAILED.is_backoff` is `False`, so the Executor advances `+1` block and the whole thing repeats **every block**, indefinitely — rebuilding the Keys API / CL proof data each time to produce a call known to revert.

## Fix

```python
top_up_enabled = not _tg_paused and self._topup_path.is_executable
```

The previous behaviour was deliberate; the comment said so:

> `# Not a gate — an unusable path still lets the tx be built and fail loudly on the dry-run, which says more than skipping early.`

The intent was visibility, but `TOPUP_EXECUTION_PATH` is already set every cycle *before* every early return in `_execute_actual` — deliberately, so it stays trustworthy on idle iterations. So the reverting preflight added no observability at all; it only had the side effect on an unrelated path. Comment removed with the behaviour.

## Considered and rejected: making a failed top-up fall through

The finding's second recommendation — "continue processing independent full-deposit candidates when the top-up path is unusable" — was implemented and then reverted. Recording why, because it looks obviously right until you price it:

`_top_up_to_module` → `get_topup_candidates` → `load_beacon_state_data` (`src/blockchain/beacon_state/state.py:76`) downloads the full beacon state SSZ and hash-tree-roots **every validator on the network**, with no caching anywhere. `cmv2_strategy.py:131` documents it as `~2 min`. Letting the loop continue past a failed top-up spends that budget again inside the same `MAX_CYCLE_LIFETIME_IN_SECONDS` window — and overrunning that window kills the daemon, which is the failure mode #381 exists to prevent. Coupling the two would have been a bad trade.

It would also silently reorder a stake-priority queue on failure, against the principle already encoded in `test_0x01_distance_block_does_not_divert_to_topup`, and quietly redirect buffered ETH from top-ups into 32-ETH deposits.

**Known residual risk, accepted:** a *persistently* failing top-up can still hold up Phase B 0x01 deposits for reasons unrelated to the role. The most likely such reason is a stale proof anchor — the gateway defines `RootIsTooOld`, `RootNotFound`, `RootPrecedesLastTopUp` and `InvalidSlot`, and nothing off-chain pre-checks anchor freshness while the proof takes ~2 min to build. Worth a separate look; it needs a different fix from this one (bounding or re-anchoring the proof), not a fall-through.

## Tests

5 new tests, all parametrized over `TopUpPath`. Verified by mutation — reverting the fix failed the 3 negative cases:

- `test_execute_actual_disables_topup_when_path_not_executable[not_delegate|terminated|no_role]`
- `test_execute_actual_enables_topup_when_path_executable[direct|delegated]` — guard against the gate closing a healthy path; passes either way by design

Full unit suite: **286 passed** (281 on `develop` + 5). Pyright: 48 errors before and after, all pre-existing.

## Corrections to the finding

- **"Denial of the core deposit path" overstates it.** Phase A (seed deposits to 0x02) runs first and short-circuits before Phase B, so it is unaffected. What was blocked is specifically Phase B 0x01 full deposits.
- **No gas was burned.** `transaction.check()` is a local `transaction.call(...)`, i.e. an `eth_call`. The failure never reached the chain.
- **Restart is not a recovery — it is an escalation.** The finding lists "restarting/reconfiguring the daemon" as a remedy. With `DELEGATION_CONTRACT_ADDRESS` set and a non-executable path, `_validate_topup_delegation()` raises and the bot **does not boot**, so Phase A stops too. That is exactly the `NOT_DELEGATE`/`TERMINATED` case.
- **Recommendation 3 ("surface through metrics") already existed** — which is the argument that defeats the old code comment, but the finding did not connect the two.
- **Recommendation 4 ("re-resolve immediately before wrapping") not implemented.** It costs 3 extra `eth_call`s per attempt to shrink a millisecond race that the preflight already catches, and the tx can still be front-run by a role change in the same block. `_resolve_topup_path`'s docstring picked per-iteration over per-module for exactly this cost reason.

## Out of scope, found while reviewing this

Two unrelated gaps in `transaction.py`, both worth their own issue:

1. **A reverted transaction is reported as success.** `classic_send` and `relay_send` return `True` as soon as a receipt exists; `tx_receipt['status']` is never checked anywhere in the file. Combined with `_estimate_gas` swallowing reverts and falling back to `CONTRACT_GAS_LIMIT`, a tx that reverts on-chain burns gas and increments `TOPUP_TX_SEND{success}`.
2. **The nonce ignores pending transactions.** `get_transaction_count(address)` uses web3's default block (`latest`, verified), so after a `TimeExhausted` the next attempt reuses the same nonce. Whether it replaces the stuck tx depends on the recomputed `maxFeePerGas`; otherwise the node rejects it as underpriced.
