### PR TITLE
fix: collapse repeated Keys API records before top-up selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,9 +201,44 @@ Module-level gates (Prometheus, defined in `src/metrics/metrics.py`, set in `src
 5. `topup_gas_ok{module_id}` / `topup_gas_fee_wei{type}`.
 6. `phase_outcome{phase="B", module_id} != wait_distance` (TopUpGateway block distance).
 
+**Undocumented assumption worth knowing before changing module routing:** `CMv2TopUpStrategy`
+selects and orders candidates by validator index, which is what `CuratedModule` accepts — it imposes
+no ordering. Its sibling in the same repo, `CSModule`, instead keeps its own `topUpQueue` and reverts
+`InvalidTopUpOrder` unless the batch matches the queue head in order (`TopUpQueueOps.allocateDeposits`),
+and offers `getKeysForTopUp(maxKeyCount)` for exactly that. This strategy would revert on every
+attempt against such a module. Nothing breaks today because `_select_topup_strategy` returns a
+strategy only for `MODULE_TYPE_CMV2` and `None` (→ `SKIPPED`) otherwise, but that gate is the only
+thing holding the assumption up.
+
 Key-level gates — module_id is now known, question narrows to pubkey X. Instrumented in
 `CMv2TopUpStrategy` (`src/blockchain/topup/cmv2_strategy.py`), evaluated in this order:
 
+- `conflicting_key_record` — the Keys API returned X's pubkey more than once, so
+  `_drop_repeated_pubkeys` dropped every copy. Checked first, right after the Keys API read and
+  before the beacon load.
+
+  Why it can happen: the Keys API's primary key is `(index, operatorIndex, moduleAddress)` and `key`
+  carries **no unique constraint** (`RegistryKey` in lidofinance/lido-keys-api), so one pubkey can
+  legitimately arrive under a second key index of the same operator, or under a second operator. A
+  byte-identical row cannot arrive — that *is* the primary key.
+
+  Why every copy is dropped rather than one being picked: **not** because a wrong pick reverts — it
+  does not. `CuratedModule.allocateDeposits` only checks the pubkey against `(operatorId, keyIndex)`
+  (`_validateTopUpPublicKeys`) and both identities are genuinely on-chain, so either would pass. But
+  it caps and credits **per key** (`NodeOperatorOps.capTopUpLimitsByKeyBalance`), and only one of the
+  repeated slots belongs to the validator that actually exists; the other is a phantom key record.
+  Which is which is not derivable from the Keys API fields (`key`, `index`, `operatorIndex`), so the
+  choice cannot be made here. Skipping one validator — logged and counted — is cheaper than updating
+  the wrong key's balance record, which would not self-correct.
+
+  Why it matters at all: TopUpGateway requires strictly increasing `validatorIndices`
+  (`validatorIndex <= prevValidatorIndex` → `InvalidValidatorIndicesSortOrder`, `TopUpGateway.sol`),
+  and both rows resolve to the same validator, so one repeat reverts the module's whole batch — and
+  before that, double-counts the operator's allocation and consumes a `max_validators` slot.
+
+  Note the top-up path has no council involvement (no message type, no quorum), so a guardian
+  refusing to sign — the mechanism that guards duplicate keys on the deposit path — has no
+  equivalent here.
 - `not_in_beacon_state` / `not_active` / `slashed` / `exiting` / `beacon_consolidation_target` /
   `already_at_target_balance` — `_check_key_eligibility`.
 - `pending_consolidation_bus` — excluded by a pending ConsolidationBus request.

--- a/src/blockchain/topup/cmv2_strategy.py
+++ b/src/blockchain/topup/cmv2_strategy.py
@@ -47,6 +47,7 @@ class TopUpExclusionReason(StrEnum):
     PENDING_CONSOLIDATION_BUS = 'pending_consolidation_bus'
     OPERATOR_BUDGET_EXHAUSTED = 'operator_budget_exhausted'
     TRUNCATED_BY_MAX_VALIDATORS = 'truncated_by_max_validators'
+    CONFLICTING_KEY_RECORD = 'conflicting_key_record'
 
 
 def _pubkey_hex(pubkey: bytes) -> str:
@@ -120,6 +121,7 @@ class CMv2TopUpStrategy(TopUpStrategy):
 
         # Step 2: keys from Keys API
         keys_by_operator = keys_api.get_module_operator_used_keys(module_id, list(allocation_by_operator.keys()))
+        keys_by_operator = _drop_repeated_pubkeys(keys_by_operator, module_id)
 
         # Step 3: advance the consolidation base to finalized BEFORE the heavy SSZ load (outside the proof window).
         # Any failure here -> skip the top-up rather than risk topping up a consolidating key.
@@ -228,6 +230,38 @@ def _distribute(candidates_by_operator: dict[int, list[TopUpCandidate]], limit: 
             i = 0
             circle += 1
     return selected
+
+
+def _drop_repeated_pubkeys(keys_by_operator: dict[int, list[LidoKey]], module_id: int) -> dict[int, list[LidoKey]]:
+    """Drop every copy of a pubkey the Keys API returned more than once.
+
+    The API's primary key is (index, operatorIndex, moduleAddress) and `key` carries no unique
+    constraint, so one pubkey can arrive under several identities: a second key index of the same
+    operator, or a second operator. Both rows resolve to the same validator, and TopUpGateway
+    requires strictly increasing validatorIndices, so the whole batch would be rejected.
+
+    Every copy is dropped rather than one being picked. Nothing reverts on a wrong pick — the module
+    only checks pubkey against (operatorId, keyIndex), and both identities are genuinely on-chain —
+    but it caps and credits per key (CuratedModule.allocateDeposits ->
+    NodeOperatorOps.capTopUpLimitsByKeyBalance), and only one of the repeated slots belongs to the
+    validator that exists. Which one is not derivable from the Keys API fields, so the choice cannot
+    be made here and the rest of the batch proceeds without them.
+    """
+    counts: dict[str, int] = {}
+    for keys in keys_by_operator.values():
+        for k in keys:
+            counts[k.key] = counts.get(k.key, 0) + 1
+
+    result: dict[int, list[LidoKey]] = {}
+    for op_id, keys in keys_by_operator.items():
+        kept: list[LidoKey] = []
+        for k in keys:
+            if counts[k.key] > 1:
+                _log_excluded_key(module_id, k.operatorIndex, k.key, TopUpExclusionReason.CONFLICTING_KEY_RECORD)
+            else:
+                kept.append(k)
+        result[op_id] = kept
+    return result
 
 
 def _collect_pubkeys(keys_by_operator: dict[int, list[LidoKey]]) -> set[bytes]:

--- a/tests/blockchain/test_cmv2_strategy.py
+++ b/tests/blockchain/test_cmv2_strategy.py
@@ -23,6 +23,7 @@ from blockchain.topup.cmv2_strategy import (
     _build_candidate_if_eligible,
     _collect_pubkeys,
     _distribute,
+    _drop_repeated_pubkeys,
     _log_excluded_key,
     _select_operator_candidates,
     _take_up_to_allocation,
@@ -572,3 +573,88 @@ def test_take_up_to_allocation_logs_already_at_target_balance():
 
     assert result == []
     log_excluded.assert_called_once_with(5, 11, '0x61', 'already_at_target_balance')
+
+
+# ─── repeated Keys API records ─────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_drop_repeated_pubkeys_leaves_clean_input_untouched():
+    keys = {11: [_make_key('0xaa', 1, 11), _make_key('0xbb', 2, 11)], 12: [_make_key('0xcc', 3, 12)]}
+    assert _drop_repeated_pubkeys(keys, module_id=1) == keys
+
+
+@pytest.mark.unit
+def test_drop_repeated_pubkeys_drops_byte_identical_rows_too():
+    """The Keys API cannot produce this — (index, operatorIndex, moduleAddress) is its primary key.
+    Kept as a safety property: if a serialization bug ever duplicated a row, dropping both is the
+    safe degradation, never a batch-wide revert.
+    """
+    with patch('blockchain.topup.cmv2_strategy._log_excluded_key'):
+        result = _drop_repeated_pubkeys({11: [_make_key('0xaa', 1, 11), _make_key('0xaa', 1, 11)]}, module_id=1)
+    assert result == {11: []}
+
+
+@pytest.mark.unit
+def test_drop_repeated_pubkeys_drops_pubkey_claimed_by_two_operators():
+    """Attribution is passed on to the module as (operatorId, keyIndex), so guessing is not safe."""
+    with patch('blockchain.topup.cmv2_strategy._log_excluded_key') as log_excluded:
+        result = _drop_repeated_pubkeys({11: [_make_key('0xaa', 1, 11)], 12: [_make_key('0xaa', 4, 12)]}, module_id=1)
+
+    assert result == {11: [], 12: []}
+    assert [c.args[1:] for c in log_excluded.call_args_list] == [
+        (11, '0xaa', 'conflicting_key_record'),
+        (12, '0xaa', 'conflicting_key_record'),
+    ]
+
+
+@pytest.mark.unit
+def test_drop_repeated_pubkeys_drops_pubkey_with_two_key_indices():
+    """Same operator, same pubkey, different key index — needs no API bug: `key` has no unique
+    constraint, only (index, operatorIndex, moduleAddress) does. This is the realistic trigger.
+    """
+    with patch('blockchain.topup.cmv2_strategy._log_excluded_key'):
+        result = _drop_repeated_pubkeys({11: [_make_key('0xaa', 1, 11), _make_key('0xaa', 2, 11)]}, module_id=1)
+    assert result == {11: []}
+
+
+@pytest.mark.unit
+def test_drop_repeated_pubkeys_keeps_other_keys_of_a_conflicted_operator():
+    with patch('blockchain.topup.cmv2_strategy._log_excluded_key'):
+        result = _drop_repeated_pubkeys(
+            {11: [_make_key('0xaa', 1, 11), _make_key('0xbb', 2, 11)], 12: [_make_key('0xaa', 4, 12)]}, module_id=1
+        )
+    assert result == {11: [_make_key('0xbb', 2, 11)], 12: []}
+
+
+@pytest.mark.unit
+def test_get_topup_candidates_never_emits_duplicate_validator_index(top_up_proof_fixtures):
+    """TopUpGateway reverts a batch whose validatorIndices are not strictly increasing
+    (`validatorIndex <= prevValidatorIndex` -> InvalidValidatorIndicesSortOrder), which would deny
+    the module's whole top-up. A repeated Keys API record must not be able to produce that batch.
+    """
+    strategy, keys_api, beacon_data = _make_topup_setup(top_up_proof_fixtures)
+    witnesses = top_up_proof_fixtures['validator_witnesses']
+    key_1 = _make_key(witnesses[0]['pubkey'], 7, 11)
+    key_2 = _make_key(witnesses[1]['pubkey'], 8, 12)
+    # Operator 11 holds the same pubkey at a second key index — the shape the API's schema allows.
+    keys_api.get_module_operator_used_keys.return_value = {11: [key_1, _make_key(witnesses[0]['pubkey'], 9, 11)], 12: [key_2]}
+    # The fixture validators sit at 32 ETH, so one top-up costs ~2014 ETH. The default 16 ETH per
+    # operator would drop the repeat as OPERATOR_BUDGET_EXHAUSTED and hide the bug, so fund both.
+    big = 5_000 * 10**18
+    strategy.w3.eth.contract.return_value.get_deposits_allocation.return_value = (2 * big, [11, 12], [big, big])
+
+    consolidation_indexer = Mock()
+    consolidation_indexer.sync_base_to_finalized.return_value = 100
+    consolidation_indexer.get_filter_set.return_value = set()
+
+    result = _call_topup(strategy, keys_api, beacon_data, consolidation_indexer)
+
+    assert result is not None
+    indices = result.validator_indices
+    assert len(indices) == len(set(indices)), 'duplicate validator index reached the payload'
+    assert indices == sorted(indices), 'validator indices must be strictly increasing'
+    assert result.key_indices == [8], 'both copies of the repeated pubkey must be dropped'
+    assert result.operator_ids == [12]
+    assert result.key_indices == [8], 'both copies of the repeated pubkey must be dropped'
+    assert result.operator_ids == [12]


### PR DESCRIPTION
Addresses DEP-TOPUP-03. Branched from `develop`, independent of #381 and #382.

## The finding's mechanism is real; its scenario is not

Verified in `lidofinance/core`, `contracts/0.8.25/TopUpGateway.sol`:

```solidity
// Require validatorIndices to be strictly increasing (rejects duplicates and unsorted input).
uint256 validatorIndex = _topUps.validatorIndices[i];
if (i != 0 && validatorIndex <= prevValidatorIndex) {
    revert InvalidValidatorIndicesSortOrder();
}
```

`<=`, so equality reverts, and the docstring says it outright: *"validatorIndices is not strictly increasing (not sorted or contains duplicates)"*. Note what this rules out: **double-topping-up a validator is impossible.** The contract protects the funds; only availability is at risk.

Nothing between the Keys API response and the payload enforced pubkey uniqueness — `group_keys_by_operator` appends every row (`keys_api.py:51`), `_select_operator_candidates` builds one candidate per row, `_distribute` and the final sort preserve repeats, `build_topup_proofs` emits one entry per candidate. Two rows carrying one pubkey resolve to one validator index, so a single repeat denied the module's whole top-up every cycle for as long as the response stayed the same.

But the finding's stated trigger — *"Keys API returns the same used CMv2 key twice with identical valid fields"* — **cannot happen.** From `RegistryKey` in `lidofinance/lido-keys-api`:

```ts
[PrimaryKeyType]?: [index, operatorIndex, moduleAddress];

@PrimaryKey() index
@PrimaryKey() operatorIndex
@PrimaryKey() moduleAddress

@Property({ length: KEY_LEN }) key    // no unique constraint
```

Identical fields means an identical primary key; the storage cannot hold two such rows. What it *can* hold, because `key` is unconstrained, is the same pubkey under **a second key index of the same operator** or **a second operator**. Neither needs an API defect. The bot also makes a single un-paginated request, so it cannot fabricate repeats itself.

So the finding is right about the bug and wrong about how you get there — and the reachable path is the more mundane one.

## Fix

`_drop_repeated_pubkeys`, applied right after the Keys API read and before the beacon state load. One check: a pubkey seen more than once has every copy dropped and counted as `conflicting_key_record`.

**Why not pick one identity.** Not because a wrong pick reverts — it does not. The bot's CMv2 wrapper (`getDepositsAllocation`) corresponds to `CuratedModule`, whose `allocateDeposits` only checks the pubkey against `(operatorId, keyIndex)` via `_validateTopUpPublicKeys`; both identities are genuinely on-chain, so either would pass, and the module imposes no ordering.

It does, however, cap and credit **per key** — `NodeOperatorOps.capTopUpLimitsByKeyBalance(baseStorage, operatorIds, keyIndices, topUpLimits)` — and only one of the repeated slots belongs to the validator that actually exists; the other is a phantom key record. Which is which is not derivable from the Keys API fields (`key`, `index`, `operatorIndex`), so the choice cannot be made here. Skipping one validator — logged and counted as `conflicting_key_record` — is cheaper than updating the wrong key's balance record, which would not self-correct.

Note also `CuratedModule`'s own comment: *"StakingRouter is expected to avoid duplicate `(operatorId, keyIndex)` entries in a single request."* Our case is not that — it is one pubkey under **different** identities — so the module offers no guarantee either way here.

A possible future disambiguation, not attempted: compare the module's per-key balance record against the proven `effective_balance` from the beacon state; the real slot matches. That needs module storage reads absent from `interfaces/ICMV2.json`.

**Why no special case for byte-identical rows.** An earlier revision of this PR collapsed those to one record. That branch was unreachable, per the schema above, so it is gone; the count-based check drops such rows instead, which is the safe degradation.

**Why before the beacon load.** It also fixes the two off-chain side effects the finding did not mention: a repeat consumed the operator's allocation twice in `_take_up_to_allocation` (`remaining -= topup_amount` runs for both, since both read the same `effective_balance` from the snapshot), starving the tail of that operator's list as `operator_budget_exhausted`; and it occupied a `max_validators` slot in `_distribute`, pushing a real validator out. Neither is observable today because the revert eats the batch first — but they are why deduplicating only just before `build_topup_proofs` would not have been enough.

Mildly ironic: dedup already existed in the one place it cannot help — `_collect_pubkeys` returns a `set` and `pubkey_to_index` is a dict, so the beacon-state filter collapses repeats while the candidate list carries them.

## On "the council handles duplicate keys"

Raised in review, and worth writing down because it is right for one path and not the other.

The Council Daemon's duplicate detection expresses itself as **refusing to sign a deposit message**, which blocks the deposit. The top-up path consumes no council message at all — verified: no top-up message type anywhere in `src/transport/`, and no quorum lookup anywhere in `src/blockchain/topup/`. `topUp` is authorised by `TOP_UP_ROLE` plus a Merkle proof against the beacon root, not by a guardian quorum, because the front-running attack the DSM exists to prevent does not apply to a validator whose withdrawal credentials are already set.

So there is no signature to withhold here. Whatever the council does about duplicates, it cannot act on this path.

## On recommendation 3 ("assert validator-index uniqueness")

Not implemented as an assert: raising turns an upstream data anomaly into a dead iteration, which is the same denial by another route. It is also unreachable once pubkeys are unique, since `pubkey_to_index` is keyed by pubkey — a second filter there would be dead code. The invariant is pinned by a test instead.

## On recommendation 4 ("continue to later Phase B candidates")

Deliberately not implemented — the same fall-through considered and rejected in #382, because `get_topup_candidates` loads and hashes the full beacon state per module with no caching (~2 min), so continuing spends that budget again inside the same `MAX_CYCLE_LIFETIME_IN_SECONDS` window, and overrunning it kills the daemon.

## Tests

6 new tests. **The end-to-end one initially passed with and without the fix** — caught by the mutation check, worth recording: with the default fixture allocation (16 ETH per operator) and validators at 32 ETH, one top-up costs ~2014 ETH, so the repeat was dropped as `operator_budget_exhausted` long before it could reach the payload. It only reproduces once both operators are funded for two top-ups. Now it fails without the fix with `duplicate validator index reached the payload` on `[10035, 10035, 10044]`.

Full unit suite: **287 passed** (281 on `develop` + 6). Pyright: 48 errors before and after, all pre-existing.

## Found while verifying this, recorded in CLAUDE.md rather than fixed

`CMv2TopUpStrategy` orders candidates by validator index, which `CuratedModule` accepts because it imposes no ordering. Its sibling in the same repo, `CSModule`, instead keeps its own `topUpQueue` and reverts `InvalidTopUpOrder` unless the batch matches the queue head in order (`TopUpQueueOps.allocateDeposits`), offering `getKeysForTopUp(maxKeyCount)` for exactly that purpose. This strategy would revert on every attempt against such a module.

Nothing breaks today: `_select_topup_strategy` returns a strategy only for `MODULE_TYPE_CMV2` and `None` (→ `SKIPPED`) otherwise. But that gate is the only thing holding the assumption up, and it was written down nowhere — so it is now in CLAUDE.md next to the key-level gates.

## Follow-up worth its own issue

`RootIsTooOld` / `RootPrecedesLastTopUp` are confirmed at the contract level — the gateway checks the beacon root age against `block.timestamp` via `maxRootAge` and requires `childBlockTimestamp` newer than the last top-up. Nothing off-chain pre-checks anchor freshness while the proof takes ~2 min to build. That is the other persistent top-up failure that can hold up Phase B deposits, and it needs a different fix: bounding or re-anchoring the proof.
