### PR TITLE
fix: skip whitelisted modules the bot has no contract for

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,18 +188,22 @@ Module-level gates (Prometheus, defined in `src/metrics/metrics.py`, set in `src
    (delegate rotated or revoked, contract terminated, role removed from both identities). Resolved
    before every early return in `_execute_actual()` (alongside `topup_gateway_paused`), so it stays
    trustworthy on idle iterations — an empty buffer would otherwise freeze it at its last value.
-3. `module_allocation_wei{module_id, kind="topup"} > 0`. Zero here is the single most common reason
+3. `module_contract_missing{module_id} == 0`. 1 means the module is whitelisted but the bot holds
+   no contract for it — it was not in the StakingRouter digests when the contract cache was built at
+   startup (not deployed yet, or deployed after the bot started). The module is skipped every cycle
+   until the bot is restarted; the cache is never rebuilt at runtime.
+4. `module_allocation_wei{module_id, kind="topup"} > 0`. Zero here is the single most common reason
    nothing happens — the StakingRouter allocation algorithm didn't route ETH to this module at all
    this cycle.
-4. `module_stake_wei{module_id, kind="topup"}` — lowest value across candidate modules goes first.
+5. `module_stake_wei{module_id, kind="topup"}` — lowest value across candidate modules goes first.
    Only **one** module is acted on per bot iteration (`_phase_full_and_topup` returns on the first
    non-`SKIPPED` outcome), so a module that lost the priority race this cycle never gets its
    `phase_outcome`/`quorum_state` touched — those stay at whatever they were last time this module
    *was* reached. Tell "evaluated and skipped" from "not reached this cycle" by comparing
    `phase_last_run_timestamp_seconds{phase="B", module_id}` against `module_allocation_wei`'s own
    freshness (both are set every cycle regardless of whether the module becomes a candidate).
-5. `topup_gas_ok{module_id}` / `topup_gas_fee_wei{type}`.
-6. `phase_outcome{phase="B", module_id} != wait_distance` (TopUpGateway block distance).
+6. `topup_gas_ok{module_id}` / `topup_gas_fee_wei{type}`.
+7. `phase_outcome{phase="B", module_id} != wait_distance` (TopUpGateway block distance).
 
 Key-level gates — module_id is now known, question narrows to pubkey X. Instrumented in
 `CMv2TopUpStrategy` (`src/blockchain/topup/cmv2_strategy.py`), evaluated in this order:
@@ -230,8 +234,8 @@ module's registry contract (NodeOperatorsRegistry / CSM), based on operator stak
 submission order. That logic lives outside this repo and this repo has no metric for it — don't go
 looking for one.
 
-Check, in order: `deposits_paused`, `depositable_ether`, `module_status{module_id}` +
-`module_allocation_wei{module_id, kind="seed"}`, `quorum_state{module_id}` (deposits require a
+Check, in order: `deposits_paused`, `depositable_ether`, `module_contract_missing{module_id}`,
+`module_status{module_id}` + `module_allocation_wei{module_id, kind="seed"}`, `quorum_state{module_id}` (deposits require a
 signed guardian quorum; top-ups don't — this gate has no equivalent on the top-up path),
 `phase_outcome{phase, module_id}`.
 

--- a/src/blockchain/web3_extentions/lido_contracts.py
+++ b/src/blockchain/web3_extentions/lido_contracts.py
@@ -216,9 +216,9 @@ class LidoContracts(Module):
             )
         logger.debug({'msg': 'Loaded staking modules for whitelist.', 'ids': list(self._staking_module_cache.keys())})
 
-    def staking_module(self, module_id: int) -> StakingModuleContract:
-        """Returns the cached StakingModuleContract for the given module id."""
-        return self._staking_module_cache[module_id]
+    def staking_module(self, module_id: int) -> StakingModuleContract | None:
+        """Returns the cached StakingModuleContract for the given module id, or None if unknown."""
+        return self._staking_module_cache.get(module_id)
 
     def _load_topup_gateway(self):
         topup_gateway_address = self.lido_locator.top_up_gateway()

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -44,6 +44,7 @@ from metrics.metrics import (
     DEPOSITS_PAUSED,
     GUARDIAN_BALANCE,
     MODULE_ALLOCATION,
+    MODULE_CONTRACT_MISSING,
     MODULE_QUORUM_LAST_SEEN_TIMESTAMP,
     MODULE_STAKE,
     MODULE_STATUS,
@@ -356,6 +357,8 @@ class DepositorBot:
             }
         )
         for module_id in variables.DEPOSIT_MODULES_WHITELIST:
+            if not self._module_is_known(module_id):
+                continue
             # Probe gas-price strategy purely for metrics — gas is re-checked right before the tx is sent.
             self._select_strategy(module_id).is_gas_price_ok(module_id)
             # Route through _resolve_quorum (not a bare _get_quorum call) so QUORUM_STATE is refreshed
@@ -446,6 +449,8 @@ class DepositorBot:
             if digest['status'] != 0:  # only Active modules (replaces SR.canDeposit activity check)
                 continue
             if allocated[i] == 0:
+                continue
+            if not self._module_is_known(digest['module_id']):
                 continue
             candidates.append(
                 ModuleCandidate(
@@ -554,7 +559,12 @@ class DepositorBot:
     def _top_up_to_module(
         self, module_id: int, module_address: str, module_allocation: Wei, ensure_beacon_state: Callable[[], BeaconStateData]
     ) -> PhaseOutcome:
-        module_type = self.w3.lido.staking_module(module_id).get_type()
+        module = self.w3.lido.staking_module(module_id)
+        if module is None:
+            logger.warning({'msg': 'No contract for module, skip top-up.', 'module_id': module_id})
+            return PhaseOutcome.SKIPPED
+
+        module_type = module.get_type()
         strategy = self._select_topup_strategy(module_type)
         if strategy is None:
             logger.info(
@@ -745,9 +755,22 @@ class DepositorBot:
             GUARDIAN_BALANCE.labels(address=address, chain_id=chain_id).set(balance)
 
     def _select_strategy(self, module_id: int) -> DepositStrategy:
-        if self.w3.lido.staking_module(module_id).get_type() == MODULE_TYPE_CSM:
+        module = self.w3.lido.staking_module(module_id)
+        if module is not None and module.get_type() == MODULE_TYPE_CSM:
             return self._csm_strategy
         return self._general_strategy
+
+    def _module_is_known(self, module_id: int) -> bool:
+        known = self.w3.lido.staking_module(module_id) is not None
+        MODULE_CONTRACT_MISSING.labels(module_id).set(int(not known))
+        if not known:
+            logger.warning(
+                {
+                    'msg': 'Whitelisted module has no contract — skipped. Restart the bot once it is deployed.',
+                    'module_id': module_id,
+                }
+            )
+        return known
 
     def _get_quorum(self, module_id: int) -> list[DepositMessage] | None:
         """

--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -143,6 +143,14 @@ MODULE_STATUS = Gauge(
     namespace=PROMETHEUS_PREFIX,
 )
 
+MODULE_CONTRACT_MISSING = Gauge(
+    'module_contract_missing',
+    '1 when a whitelisted module has no contract known to the bot — not deployed at startup, or '
+    'deployed after it. The module is skipped every cycle until the bot is restarted.',
+    ['module_id'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
 # --- Phase outcomes ---
 # States must stay in sync with bots.depositor.PhaseOutcome's values — kept as plain strings here
 # rather than imported, since metrics.py has no dependency on bots/ (importing it back would cycle).
@@ -350,6 +358,7 @@ for _module_id in DEPOSIT_MODULES_WHITELIST:
         MODULE_STAKE.labels(_module_id, _kind).set(0)
     POSSIBLE_DEPOSITS_AMOUNT.labels(_module_id).set(0)
     DEPOSIT_AMOUNT_OK.labels(_module_id).set(0)
+    MODULE_CONTRACT_MISSING.labels(_module_id).set(0)
 
 # Absent Gauges are indistinguishable from "feature disabled"; 0 is more honest.
 DEPOSITS_PAUSED.set(0)

--- a/tests/blockchain/web3_extentions/test_lido_contracts.py
+++ b/tests/blockchain/web3_extentions/test_lido_contracts.py
@@ -155,3 +155,20 @@ def test_delegates_explicit_block_bypasses_cache():
 
     assert lido._guardian_contract.call_count == 2
     assert lido._delegates_cache is None
+
+
+@pytest.mark.unit
+def test_staking_module_returns_none_for_unknown_module():
+    lido = LidoContracts.__new__(LidoContracts)
+    lido._staking_module_cache = {1: Mock()}
+
+    assert lido.staking_module(6) is None
+
+
+@pytest.mark.unit
+def test_staking_module_returns_cached_contract():
+    lido = LidoContracts.__new__(LidoContracts)
+    contract = Mock()
+    lido._staking_module_cache = {1: contract}
+
+    assert lido.staking_module(1) is contract

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -141,6 +141,34 @@ class TestRefreshModulesState(unittest.TestCase):
         self.bot._get_quorum.assert_not_called()
         self.bot._select_strategy.assert_not_called()
 
+    def test_skips_module_without_contract(self):
+        self.bot.w3.lido.staking_module = Mock(side_effect=lambda module_id: None if module_id == 2 else MagicMock())
+        self.bot._get_quorum = Mock(return_value=None)
+        self.bot._select_strategy = Mock(return_value=Mock())
+
+        self.bot._refresh_modules_state()
+
+        called_ids = sorted(c.args[0] for c in self.bot._get_quorum.call_args_list)
+        self.assertEqual([1, 3], called_ids)
+
+    def test_missing_contract_metric_set_per_module(self):
+        self.bot.w3.lido.staking_module = Mock(side_effect=lambda module_id: None if module_id == 2 else MagicMock())
+        self.bot._get_quorum = Mock(return_value=None)
+        self.bot._select_strategy = Mock(return_value=Mock())
+
+        recorded = {}
+
+        def _labels(module_id):
+            child = Mock()
+            child.set = Mock(side_effect=lambda value: recorded.update({module_id: value}))
+            return child
+
+        with mock.patch('bots.depositor.MODULE_CONTRACT_MISSING') as gauge:
+            gauge.labels.side_effect = _labels
+            self.bot._refresh_modules_state()
+
+        self.assertEqual({1: 0, 2: 1, 3: 0}, recorded)
+
     def test_quorum_called_only_for_whitelisted(self):
         # Regression: previous implementation accidentally iterated all SR modules.
         variables.DEPOSIT_MODULES_WHITELIST = [1, 3]
@@ -291,6 +319,12 @@ class TestCollectCandidates(unittest.TestCase):
         # status: 0=Active (kept), 1=DepositsPaused, 2=Stopped (both skipped)
         digests = [_make_digest(1, '0xA1', 1, status=1), _make_digest(2, '0xA2', 1, status=0), _make_digest(3, '0xA3', 1, status=2)]
         cands = self.bot._collect_candidates(digests, 1, [50, 50, 50], [100, 100, 100])
+        self.assertEqual([2], [c.module_id for c in cands])
+
+    def test_filters_module_without_contract(self):
+        self.bot.w3.lido.staking_module = Mock(side_effect=lambda module_id: None if module_id == 1 else MagicMock())
+        digests = [_make_digest(1, '0xA1', 1), _make_digest(2, '0xA2', 1)]
+        cands = self.bot._collect_candidates(digests, 1, [50, 50], [100, 100])
         self.assertEqual([2], [c.module_id for c in cands])
 
     def test_builds_fields_and_stake(self):
@@ -1182,6 +1216,18 @@ def test_deposit_to_module_general_strategy_for_non_csm_module_type(depositor_bo
     depositor_bot._csm_strategy.is_gas_price_ok.assert_not_called()
 
 
+@pytest.mark.unit
+def test_deposit_to_module_general_strategy_when_module_unknown(depositor_bot):
+    depositor_bot.w3.lido.staking_module = Mock(return_value=None)
+    depositor_bot._csm_strategy.is_gas_price_ok = Mock(return_value=False)
+    depositor_bot._general_strategy.is_gas_price_ok = Mock(return_value=False)
+
+    depositor_bot._deposit_to_module(6)
+
+    depositor_bot._general_strategy.is_gas_price_ok.assert_called_once_with(6)
+    depositor_bot._csm_strategy.is_gas_price_ok.assert_not_called()
+
+
 # ─── _top_up_to_module ─────────────────────────────────────────────
 
 
@@ -1194,6 +1240,13 @@ def test_top_up_to_module_unknown_type_returns_false(depositor_bot):
     depositor_bot._select_topup_strategy = Mock(return_value=None)
 
     assert depositor_bot._top_up_to_module(1, '0xAddr', 50, Mock()) is PhaseOutcome.SKIPPED
+
+
+@pytest.mark.unit
+def test_top_up_to_module_without_contract_skips(depositor_bot):
+    depositor_bot.w3.lido.staking_module = Mock(return_value=None)
+
+    assert depositor_bot._top_up_to_module(6, '0xAddr', 50, Mock()) is PhaseOutcome.SKIPPED
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

Seen on Hoodi after a redeploy: module `6` is in `DEPOSIT_MODULES_WHITELIST` but not deployed yet.

```
File "/app/src/bots/depositor.py", line 357, in _refresh_modules_state
  self._select_strategy(module_id).is_gas_price_ok(module_id)
File "/app/src/blockchain/web3_extentions/lido_contracts.py", line 221, in staking_module
  return self._staking_module_cache[module_id]
KeyError: 6
```

The contract cache is built once at startup from the StakingRouter digests, so a module that isn't deployed simply has no entry. The `KeyError` escaped `_refresh_modules_state()`, which is **step 0** of `_execute_actual()` — before any deposit logic — so the whole iteration was aborted, every other module included.

`Executor._exception_handler` swallows the exception (by design, so one bad cycle doesn't kill the daemon), bumps `UNEXPECTED_EXCEPTIONS{type="KeyError"}` and returns `None` → falsy result → retry on the next block → same failure. Net effect: **a live process with a green healthcheck that deposits nothing, on every block, until it is restarted with the module removed from the whitelist.**

## Change

- `LidoContracts.staking_module()` returns `None` for an unknown module instead of raising.
- Two entry paths skip such a module rather than blowing up the iteration:
  - `_refresh_modules_state()` — the whitelist-driven loop (the crash above);
  - `_collect_candidates()` — covers the other direction, a module deployed *after* the bot started: present in the digests, absent from the cache. Filtering there keeps every downstream path (`_deposit_to_module`, `_top_up_to_module`) free of the case.
- New gauge `module_contract_missing{module_id}` — 1 while a whitelisted module has no contract — plus a structured warning per cycle. Previously "whitelist is ahead of the deploy" was indistinguishable from a generic exception counter.

The cache is deliberately **not** rebuilt at runtime (no `getStakingModulesCount()` polling): picking up a newly deployed module still requires a restart. The metric and the log line are what make that state visible instead of silent.

## Tests

- regression: `_refresh_modules_state` processes modules 1 and 3 when 2 has no contract (used to abort on 2);
- `module_contract_missing` set per module (0/1/0);
- `_collect_candidates` filters a digest module absent from the cache;
- `_select_strategy` falls back to the general (stricter) strategy when the type can't be read;
- `_top_up_to_module` returns `SKIPPED`;
- `staking_module()` returns `None` / the cached contract.