### PR TITLE
fix: unvet schema nonce, filter isolation, unvet retry cadence, send outcome reporting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,7 +251,7 @@ Unit tests (`-m unit`) are fully offline and run on every commit via pre-commit 
 
 `tests/conftest.py` provides shared fixtures including a mock `BlockData`, test council addresses, and a DSM owner account. Tests for each bot are in `tests/bots/`. Transport message schema tests are in `tests/transport/`.
 
-`MessageStorage.messages` is a class-level list shared across instances — tests that don't call `storage.clear()` will leak messages into subsequent tests.
+`MessageStorage.messages` is declared at class level but each instance rebinds it on first `get_messages_and_actualize()`, so messages don't leak across instances; a reused instance still accumulates until `storage.clear()`.
 
 Pre-commit runs the full unit test suite on every commit (`poetry run pytest -m unit`). Never use `--no-verify` to skip it.
 

--- a/src/blockchain/web3_extentions/transaction.py
+++ b/src/blockchain/web3_extentions/transaction.py
@@ -2,17 +2,18 @@
 
 import logging
 
-import variables
-from blockchain.constants import SLOT_TIME
-from blockchain.web3_extentions.private_relay import PrivateRelayClient, PrivateRelayException
 from eth_account.datastructures import SignedTransaction
 from eth_typing import ChecksumAddress
-from metrics.metrics import TX_SEND, TX_SEND_FAILURE
 from web3 import Web3
 from web3.contract.contract import ContractFunction
 from web3.exceptions import ContractLogicError, TimeExhausted
 from web3.module import Module
-from web3.types import TxParams, Wei
+from web3.types import TxParams, TxReceipt, Wei
+
+import variables
+from blockchain.constants import SLOT_TIME
+from blockchain.web3_extentions.private_relay import PrivateRelayClient, PrivateRelayException
+from metrics.metrics import TX_SEND, TX_SEND_FAILURE
 
 logger = logging.getLogger(__name__)
 
@@ -117,8 +118,7 @@ class TransactionUtils(Module):
             logger.warning({'msg': 'Transaction not included in time, still pending.', 'tx_hash': tx_hash})
             return False
 
-        logger.info({'msg': 'Sent transaction included in blockchain.', 'value': repr(tx_receipt)})
-        return True
+        return self._receipt_succeeded(tx_receipt)
 
     def classic_send(self, signed_tx: SignedTransaction, timeout_in_blocks: int) -> bool:
         try:
@@ -136,8 +136,18 @@ class TransactionUtils(Module):
             logger.warning({'msg': 'Transaction not included in time, still pending.', 'tx_hash': tx_hash.hex()})
             return False
 
-        logger.info({'msg': 'Sent transaction included in blockchain.', 'value': tx_receipt['transactionHash'].hex()})
-        return True
+        return self._receipt_succeeded(tx_receipt)
+
+    @staticmethod
+    def _receipt_succeeded(tx_receipt: TxReceipt) -> bool:
+        tx_hash = tx_receipt['transactionHash'].hex()
+        if tx_receipt['status'] == 1:
+            logger.info({'msg': 'Sent transaction included in blockchain.', 'tx_hash': tx_hash})
+            return True
+
+        TX_SEND_FAILURE.labels('reverted').inc()
+        logger.error({'msg': 'Transaction reverted on chain.', 'tx_hash': tx_hash})
+        return False
 
     def _get_priority_fee(self, percentile: int, min_priority_fee: Wei, max_priority_fee: Wei) -> Wei:
         return min(

--- a/src/blockchain/web3_extentions/transaction.py
+++ b/src/blockchain/web3_extentions/transaction.py
@@ -7,7 +7,7 @@ from blockchain.constants import SLOT_TIME
 from blockchain.web3_extentions.private_relay import PrivateRelayClient, PrivateRelayException
 from eth_account.datastructures import SignedTransaction
 from eth_typing import ChecksumAddress
-from metrics.metrics import TX_SEND
+from metrics.metrics import TX_SEND, TX_SEND_FAILURE
 from web3 import Web3
 from web3.contract.contract import ContractFunction
 from web3.exceptions import ContractLogicError, TimeExhausted
@@ -77,6 +77,7 @@ class TransactionUtils(Module):
             try:
                 status = self.relay_send(signed, timeout_in_blocks)
             except PrivateRelayException as error:
+                TX_SEND_FAILURE.labels('relay_error').inc()
                 logger.error({'msg': 'Private relay error.', 'error': repr(error)})
 
         if status:
@@ -112,6 +113,8 @@ class TransactionUtils(Module):
         try:
             tx_receipt = self.w3.eth.wait_for_transaction_receipt(tx_hash, (timeout_in_blocks + 1) * SLOT_TIME)
         except TimeExhausted:
+            TX_SEND_FAILURE.labels('not_included').inc()
+            logger.warning({'msg': 'Transaction not included in time, still pending.', 'tx_hash': tx_hash})
             return False
 
         logger.info({'msg': 'Sent transaction included in blockchain.', 'value': repr(tx_receipt)})
@@ -121,13 +124,16 @@ class TransactionUtils(Module):
         try:
             tx_hash = self.w3.eth.send_raw_transaction(signed_tx.raw_transaction)
         except Exception as error:
-            logger.error({'msg': 'Transaction reverted.', 'value': str(error)})
+            TX_SEND_FAILURE.labels('not_broadcast').inc()
+            logger.error({'msg': 'Transaction was not broadcast.', 'error': str(error)})
             return False
 
         logger.info({'msg': 'Transaction sent.', 'value': tx_hash.hex()})
         try:
             tx_receipt = self.w3.eth.wait_for_transaction_receipt(tx_hash, (timeout_in_blocks + 1) * SLOT_TIME)
         except TimeExhausted:
+            TX_SEND_FAILURE.labels('not_included').inc()
+            logger.warning({'msg': 'Transaction not included in time, still pending.', 'tx_hash': tx_hash.hex()})
             return False
 
         logger.info({'msg': 'Sent transaction included in blockchain.', 'value': tx_receipt['transactionHash'].hex()})

--- a/src/bots/unvetter.py
+++ b/src/bots/unvetter.py
@@ -1,3 +1,5 @@
+# pyright: reportTypedDictNotRequiredAccess=false
+
 import logging
 from collections.abc import Callable
 from typing import TypedDict, cast
@@ -21,6 +23,9 @@ from transport.types import TransportType
 from utils.bytes import from_hex_string_to_bytes
 
 logger = logging.getLogger(__name__)
+
+# DSM checks blockhash(blockNumber) == blockHash, and the EVM keeps only the last 256 blocks.
+MESSAGE_VALIDITY_BLOCKS = 200
 
 
 def run_unvetter(w3: Web3):
@@ -82,10 +87,8 @@ class UnvetterBot:
         messages = self.receive_unvet_messages()
         logger.info({'msg': f'Received {len(messages)} unvet messages.'})
 
-        for message in messages:
-            self._send_unvet_message(message)
-
-        return True
+        results = [self._send_unvet_message(message) for message in messages]
+        return all(results)
 
     def receive_unvet_messages(self) -> list[UnvetMessage]:
         if self.message_storage is None:
@@ -97,6 +100,7 @@ class UnvetterBot:
         return self.message_storage.get_messages_and_actualize(lambda x: sign_filter(x) and actualize_filter(x))
 
     def _get_message_actualize_filter(self) -> Callable[[UnvetMessage], bool]:
+        latest = self.w3.eth.get_block('latest')
         modules = self.w3.lido.staking_router.get_staking_module_ids()
 
         nonces = {}
@@ -108,6 +112,9 @@ class UnvetterBot:
         def message_filter(message: UnvetMessage) -> bool:
             if message['guardianAddress'] not in guardians_list:
                 UNEXPECTED_EXCEPTIONS.labels('unexpected_guardian_address').inc()
+                return False
+
+            if message['blockNumber'] < latest['number'] - MESSAGE_VALIDITY_BLOCKS:
                 return False
 
             # If message nonce is lower than in module, message is invalid

--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -15,6 +15,17 @@ TX_SEND = Counter('transactions_send', 'Amount of send transaction from bot.', [
 TX_SEND.labels('success').inc(0)
 TX_SEND.labels('failure').inc(0)
 
+TX_SEND_FAILURE = Counter(
+    'transaction_send_failures',
+    'Failed transaction sends by reason.',
+    ['reason'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
+TX_SEND_FAILURE.labels('not_broadcast').inc(0)
+TX_SEND_FAILURE.labels('not_included').inc(0)
+TX_SEND_FAILURE.labels('relay_error').inc(0)
+
 MODULE_TX_SEND = Counter(
     'transactions',
     'Amount of send transactions from depositor bot.',

--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -25,6 +25,7 @@ TX_SEND_FAILURE = Counter(
 TX_SEND_FAILURE.labels('not_broadcast').inc(0)
 TX_SEND_FAILURE.labels('not_included').inc(0)
 TX_SEND_FAILURE.labels('relay_error').inc(0)
+TX_SEND_FAILURE.labels('reverted').inc(0)
 
 MODULE_TX_SEND = Counter(
     'transactions',

--- a/src/transport/msg_storage.py
+++ b/src/transport/msg_storage.py
@@ -1,7 +1,11 @@
-from typing import Callable, List
+import logging
+from typing import Any, Callable, List
 
+from metrics.metrics import UNEXPECTED_EXCEPTIONS
 from transport.msg_providers.common import BaseMessageProvider
 from transport.msg_types.common import BotMessage
+
+logger = logging.getLogger(__name__)
 
 
 class MessageStorage:
@@ -31,9 +35,7 @@ class MessageStorage:
         """
         Fetches all messages from each transport, applies filtering, and updates the message list.
 
-        This method retrieves messages from all transports associated with the instance and filters them
-        based on both the instance’s `_filter` function and an additional `actualize_filter` function
-        provided as an argument. The filtered messages are stored in the instance's `messages` attribute.
+        A message whose filter raises is dropped, not retained — otherwise it aborts every later cycle.
 
         Args:
             actualize_filter (Callable[[BotMessage], bool]): A function that takes a `BotMessage` as an argument
@@ -44,12 +46,20 @@ class MessageStorage:
             list[BotMessage]: A list of `BotMessage` objects that pass both the instance filter and the
                                 `actualize_filter` criteria.
         """
-        messages = self.messages
+        messages = list(self.messages)
         for transport in self._transports:
-            filtered_messages = list(filter(lambda x: self._filter(x), transport.get_messages()))
-            messages.extend(filtered_messages)
-        self.messages = list(filter(lambda x: actualize_filter(x), messages))
+            messages.extend(msg for msg in transport.get_messages() if self._passes(self._filter, msg))
+        self.messages = [msg for msg in messages if self._passes(actualize_filter, msg)]
         return self.messages
+
+    @staticmethod
+    def _passes(message_filter: Callable[[Any], bool], message: Any) -> bool:
+        try:
+            return bool(message_filter(message))
+        except Exception as error:
+            UNEXPECTED_EXCEPTIONS.labels('malformed_message').inc()
+            logger.warning({'msg': 'Message dropped, filter raised.', 'value': message, 'error': str(error)})
+            return False
 
     def clear(self):
         """

--- a/src/transport/msg_types/unvet.py
+++ b/src/transport/msg_types/unvet.py
@@ -14,6 +14,7 @@ UnvetMessageSchema = Schema(
         'guardianAddress': And(str, ADDRESS_REGREX.validate),
         'signature': SignatureSchema,
         'stakingModuleId': int,
+        'nonce': int,
         'operatorIds': And(str, HEX_BYTES_REGREX.validate),
         'vettedKeysByOperator': And(str, HEX_BYTES_REGREX.validate),
     },

--- a/tests/blockchain/web3_extentions/test_transaction.py
+++ b/tests/blockchain/web3_extentions/test_transaction.py
@@ -4,13 +4,15 @@ from unittest.mock import Mock
 import pytest
 import variables
 from blockchain.web3_extentions.transaction import TransactionUtils
-from web3.exceptions import ContractLogicError
+from hexbytes import HexBytes
+from metrics.metrics import TX_SEND_FAILURE
+from web3.exceptions import ContractLogicError, TimeExhausted
 
 
 @pytest.mark.unit
 def test_get_priority_fee(web3_lido_unit):
     tu = TransactionUtils(web3_lido_unit)
-    tu.web3.eth.fee_history = Mock(return_value={'reward': [[50]]})
+    tu.w3.eth.fee_history = Mock(return_value={'reward': [[50]]})
 
     assert tu._get_priority_fee(0, 10, 30) == 30
     assert tu._get_priority_fee(0, 10, 70) == 50
@@ -59,3 +61,27 @@ def test_estimate_gas(web3_lido_unit, set_account):
     tx.estimate_gas = Mock(side_effect=ContractLogicError())
     gas_amount = web3_lido_unit.transaction._estimate_gas(tx, variables.ACCOUNT.address)
     assert gas_amount == variables.CONTRACT_GAS_LIMIT
+
+
+@pytest.mark.unit
+def test_classic_send_not_broadcast(web3_lido_unit, caplog):
+    caplog.set_level(logging.INFO)
+    web3_lido_unit.eth.send_raw_transaction = Mock(side_effect=ValueError('replacement transaction underpriced'))
+    before = TX_SEND_FAILURE.labels('not_broadcast')._value.get()
+
+    assert web3_lido_unit.transaction.classic_send(Mock(), 6) is False
+    assert TX_SEND_FAILURE.labels('not_broadcast')._value.get() == before + 1
+    assert 'Transaction was not broadcast.' in caplog.messages[-1]
+
+
+@pytest.mark.unit
+def test_classic_send_not_included(web3_lido_unit, caplog):
+    caplog.set_level(logging.INFO)
+    web3_lido_unit.eth.send_raw_transaction = Mock(return_value=HexBytes('0x2a'))
+    web3_lido_unit.eth.wait_for_transaction_receipt = Mock(side_effect=TimeExhausted())
+    before = TX_SEND_FAILURE.labels('not_included')._value.get()
+
+    assert web3_lido_unit.transaction.classic_send(Mock(), 6) is False
+    assert TX_SEND_FAILURE.labels('not_included')._value.get() == before + 1
+    assert 'Transaction not included in time, still pending.' in caplog.messages[-1]
+    assert '2a' in caplog.messages[-1]

--- a/tests/blockchain/web3_extentions/test_transaction.py
+++ b/tests/blockchain/web3_extentions/test_transaction.py
@@ -2,11 +2,12 @@ import logging
 from unittest.mock import Mock
 
 import pytest
+from hexbytes import HexBytes
+from web3.exceptions import ContractLogicError, TimeExhausted
+
 import variables
 from blockchain.web3_extentions.transaction import TransactionUtils
-from hexbytes import HexBytes
 from metrics.metrics import TX_SEND_FAILURE
-from web3.exceptions import ContractLogicError, TimeExhausted
 
 
 @pytest.mark.unit

--- a/tests/blockchain/web3_extentions/test_transaction.py
+++ b/tests/blockchain/web3_extentions/test_transaction.py
@@ -86,3 +86,23 @@ def test_classic_send_not_included(web3_lido_unit, caplog):
     assert TX_SEND_FAILURE.labels('not_included')._value.get() == before + 1
     assert 'Transaction not included in time, still pending.' in caplog.messages[-1]
     assert '2a' in caplog.messages[-1]
+
+
+@pytest.mark.unit
+def test_classic_send_reverted_receipt(web3_lido_unit, caplog):
+    caplog.set_level(logging.INFO)
+    web3_lido_unit.eth.send_raw_transaction = Mock(return_value=HexBytes('0x2a'))
+    web3_lido_unit.eth.wait_for_transaction_receipt = Mock(return_value={'status': 0, 'transactionHash': HexBytes('0x2a')})
+    before = TX_SEND_FAILURE.labels('reverted')._value.get()
+
+    assert web3_lido_unit.transaction.classic_send(Mock(), 6) is False
+    assert TX_SEND_FAILURE.labels('reverted')._value.get() == before + 1
+    assert 'Transaction reverted on chain.' in caplog.messages[-1]
+
+
+@pytest.mark.unit
+def test_classic_send_successful_receipt(web3_lido_unit):
+    web3_lido_unit.eth.send_raw_transaction = Mock(return_value=HexBytes('0x2a'))
+    web3_lido_unit.eth.wait_for_transaction_receipt = Mock(return_value={'status': 1, 'transactionHash': HexBytes('0x2a')})
+
+    assert web3_lido_unit.transaction.classic_send(Mock(), 6) is True

--- a/tests/bots/test_unvetter.py
+++ b/tests/bots/test_unvetter.py
@@ -93,3 +93,47 @@ def test_unvetter(web3_provider_integration, web3_lido_integration, caplog):
     web3_lido_integration.lido.staking_router.get_staking_module_nonce = Mock(return_value=ub.message_storage.messages[0]['nonce'] + 1)
     ub.execute(latest)
     assert not ub.message_storage.messages
+
+
+GUARDIAN = '0x3dc4cF780F2599B528F37dedB34449Fb65Ef7d4A'
+
+
+def _stubbed_bot(web3_lido_unit, sends: list[bool]) -> UnvetterBot:
+    bot = UnvetterBot(web3_lido_unit)
+    bot.prepare_transport_bus = Mock()
+    bot.receive_unvet_messages = Mock(return_value=[{'stakingModuleId': 1}] * len(sends))
+    bot._send_unvet_message = Mock(side_effect=sends)
+    return bot
+
+
+@pytest.mark.unit
+def test_execute_reports_failure_when_a_send_fails(web3_lido_unit):
+    bot = _stubbed_bot(web3_lido_unit, [True, False, True])
+
+    assert bot.execute(Mock()) is False
+    assert bot._send_unvet_message.call_count == 3
+
+
+@pytest.mark.unit
+def test_execute_reports_success_when_all_sends_succeed(web3_lido_unit):
+    assert _stubbed_bot(web3_lido_unit, [True, True]).execute(Mock()) is True
+
+
+@pytest.mark.unit
+def test_execute_reports_success_when_there_is_nothing_to_send(web3_lido_unit):
+    assert _stubbed_bot(web3_lido_unit, []).execute(Mock()) is True
+
+
+@pytest.mark.unit
+def test_actualize_filter_drops_messages_past_the_blockhash_window(web3_lido_unit):
+    bot = UnvetterBot(web3_lido_unit)
+    web3_lido_unit.eth.get_block = Mock(return_value={'number': 1_000})
+    web3_lido_unit.lido.staking_router.get_staking_module_ids = Mock(return_value=[1])
+    web3_lido_unit.lido.staking_router.get_staking_module_nonce = Mock(return_value=5)
+    web3_lido_unit.lido.deposit_security_module.get_guardians = Mock(return_value=[GUARDIAN])
+
+    message_filter = bot._get_message_actualize_filter()
+    message = {'guardianAddress': GUARDIAN, 'stakingModuleId': 1, 'nonce': 5, 'blockNumber': 900}
+
+    assert message_filter(message) is True
+    assert message_filter({**message, 'blockNumber': 700}) is False

--- a/tests/transport/test_msg_schemas.py
+++ b/tests/transport/test_msg_schemas.py
@@ -1,4 +1,5 @@
 import pytest
+
 from transport.msg_types.deposit import DepositMessageSchema
 from transport.msg_types.ping import to_check_sum_address
 from transport.msg_types.unvet import UnvetMessageSchema

--- a/tests/transport/test_msg_schemas.py
+++ b/tests/transport/test_msg_schemas.py
@@ -1,6 +1,7 @@
 import pytest
 from transport.msg_types.deposit import DepositMessageSchema
 from transport.msg_types.ping import to_check_sum_address
+from transport.msg_types.unvet import UnvetMessageSchema
 
 
 @pytest.mark.unit
@@ -56,3 +57,29 @@ def test_check_depositor_schema_negative():
         'stakingModuleId': 2,
     }
     assert not DepositMessageSchema.is_valid(msg)
+
+
+UNVET_MSG = {
+    'type': 'unvet',
+    'blockNumber': 5737984,
+    'blockHash': '0x432e218931e9b94f0702ecb1b0d084c467a86b384767ce38c4fe164463070532',
+    'guardianAddress': '0x43464Fe06c18848a2E2e913194D64c1970f4326a',
+    'stakingModuleId': 1,
+    'nonce': 16,
+    'operatorIds': '0x0000000000000001',
+    'vettedKeysByOperator': '0x00000002',
+    'signature': {
+        'r': '0xc2235eb6983f80d19158f807d5d90d93abec52034ea7184bbf164ba211f00116',
+        '_vs': '0x75354ffc9fb6e7a4b4c01c622661a1d0382ace8c4ff8024626e39ac1a6a613d0',
+    },
+}
+
+
+@pytest.mark.unit
+def test_check_unvet_schema_positive():
+    assert UnvetMessageSchema.is_valid(UNVET_MSG)
+
+
+@pytest.mark.unit
+def test_check_unvet_schema_requires_nonce():
+    assert not UnvetMessageSchema.is_valid({k: v for k, v in UNVET_MSG.items() if k != 'nonce'})

--- a/tests/transport/test_msg_storage.py
+++ b/tests/transport/test_msg_storage.py
@@ -30,3 +30,37 @@ def test_checksum_address_parsing(msg_storage: MessageStorage):
         {'guardianAddress': '0x5fd0dDbC3351d009eb3f88DE7Cd081a614C519F1'},
         {'guardianAddress': '0x3dc4cF780F2599B528F37dedB34449Fb65Ef7d4A'},
     ]
+
+
+class OneShotTransport:
+    def __init__(self, messages):
+        self._messages = messages
+
+    def get_messages(self):
+        messages, self._messages = self._messages, []
+        return messages
+
+
+VALID = {'guardianAddress': '0x3dc4cF780F2599B528F37dedB34449Fb65Ef7d4A'}
+MALFORMED = {'guardianAddress': '0x5fd0dDbC3351d009eb3f88DE7Cd081a614C519F1'}
+
+
+def _raises_on_malformed(msg):
+    if msg == MALFORMED:
+        raise KeyError('nonce')
+    return True
+
+
+@pytest.mark.unit
+def test_malformed_message_does_not_hide_valid_ones():
+    storage = MessageStorage([OneShotTransport([MALFORMED, VALID])], filters=[])
+
+    assert storage.get_messages_and_actualize(_raises_on_malformed) == [VALID]
+
+
+@pytest.mark.unit
+def test_malformed_message_is_not_retained():
+    storage = MessageStorage([OneShotTransport([MALFORMED, VALID])], filters=[])
+    storage.get_messages_and_actualize(_raises_on_malformed)
+
+    assert storage.get_messages_and_actualize(lambda x: True) == [VALID]


### PR DESCRIPTION
Tickets: **DBOT-MSG-02**, **DBOT-UNVET-TX-02**, **DEP-SEND-01**, and the diagnostics half of **TX-PREP-01**.

## DBOT-MSG-02 — one malformed message no longer stops the stream

|  | before | after |
|---|---|---|
| one malformed message | the whole cycle raises, no message is processed | only that message is dropped |
| same message, next cycle | still stored, raises again, forever | already gone |

`MessageStorage.get_messages_and_actualize` did `messages = self.messages` — an alias — so `extend` mutated storage before the reassignment. Any exception inside `filter()` skipped the assignment and left everything retained, the offending message included. `Executor` swallows the exception, so the bot polled every block and processed nothing until restart.

The list is now copied before `extend`, and each filter runs per message: a raising message is dropped, counted on `unexpected_exceptions{type="malformed_message"}` and logged.

Trigger: `UnvetMessageSchema` did not require `nonce`, which `_verification_data_unvet` and the unvetter's filter both read. The council always sends it and it is part of the signed digest, so the schema had drifted from both sides. `'nonce': int` added — though the schema alone does not close this, since `nonces[message['stakingModuleId']]` raises `KeyError` for an unknown module id with every field present.

Side effect: the class-level `messages` list is no longer mutated in place, so messages no longer leak between instances. `CLAUDE.md` updated.

## DBOT-UNVET-TX-02 — a failed unvet retries on the next block

`execute()` discarded every `_send_unvet_message` result and returned `True`, so the `Executor` took the successful-cycle path and waited `BLOCKS_BETWEEN_EXECUTION` (25 blocks, ~5 min) after a revert, a failed broadcast or a receipt timeout.

Returning `False` alone would have replaced that with a permanent one-block cadence: unvet messages had no age filter at all, so one whose `blockHash` had fallen out of the EVM's 256-block window stayed in storage failing every cycle forever. Messages older than `MESSAGE_VALIDITY_BLOCKS` are now dropped, which also stops the pointless simulations they already caused.

The pauser is unaffected — its executor interval is hard-coded to 1 block.

## DEP-SEND-01 — a reverted transaction is no longer a success

Both delivery paths returned `True` on any mined receipt. A deposit that passed simulation and then reverted — the deposit root changes on any deposit to the Ethereum contract, and the guardian signatures are bound to it — was recorded as `SENT`, so the executor backed off instead of retrying, and `TX_SEND`/`MODULE_TX_SEND` counted it as a success.

No busy-loop risk from the retry: `check()` runs an `eth_call` before every broadcast, so a persistently bad state stops at simulation without spending gas, and a revert by definition means the state moved between simulation and inclusion.

## TX-PREP-01 (diagnostics only) — a failed send says what failed

|  | before | after |
|---|---|---|
| node refused the transaction | `Transaction reverted.` | `Transaction was not broadcast.` + `transaction_send_failures{reason="not_broadcast"}` |
| broadcast ok, no receipt in time | nothing logged | `Transaction not included in time, still pending.` + tx hash + `reason="not_included"` |
| mined but reverted | counted as success | `Transaction reverted on chain.` + `reason="reverted"` |
| private relay error | logged | same, plus `reason="relay_error"` |

`TX_SEND{status}` is untouched.

TX-PREP-01 also asks for `get_transaction_count(..., 'pending')`. Not done: it trades a rare self-healing replacement for a nonce gap that wedges the wallet, it is non-deterministic across the multi-provider EL setup, and it is a no-op on the private relay path.

## Tests

Eleven added. `tests/blockchain/web3_extentions/transaction.py` had no `test_` prefix so pytest never collected it — renamed, which surfaced a stale `tu.web3` reference.

Unit suite 316 passed (304 before, 4 of those the newly collected file). Pyright 48, same as `develop`.

---

Linear: [STC-940](https://linear.app/lidofi/issue/STC-940)
