### PR TITLE
fix: unvet backlog re-verification, delegate freshness, pause preflight, pure-Python secp256k1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -537,6 +537,66 @@ files = [
 ]
 
 [[package]]
+name = "coincurve"
+version = "21.0.0"
+description = "Safest and fastest Python library for secp256k1 elliptic curve operations"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "coincurve-21.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:986727bba6cf0c5670990358dc6af9a54f8d3e257979b992a9dbd50dd82fa0dc"},
+    {file = "coincurve-21.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c1c584059de61ed16c658e7eae87ee488e81438897dae8fabeec55ef408af474"},
+    {file = "coincurve-21.0.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d4210b35c922b2b36c987a48c0b110ab20e490a2d6a92464ca654cb09e739fcc"},
+    {file = "coincurve-21.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf67332cc647ef52ef371679c76000f096843ae266ae6df5e81906eb6463186b"},
+    {file = "coincurve-21.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:997607a952913c6a4bebe86815f458e77a42467b7a75353ccdc16c3336726880"},
+    {file = "coincurve-21.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cfdd0938f284fb147aa1723a69f8794273ec673b10856b6e6f5f63fcc99d0c2e"},
+    {file = "coincurve-21.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:88c1e3f6df2f2fbe18152c789a18659ee0429dc604fc77530370c9442395f681"},
+    {file = "coincurve-21.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:530b58ed570895612ef510e28df5e8a33204b03baefb5c986e22811fa09622ef"},
+    {file = "coincurve-21.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:f920af756a98edd738c0cfa431e81e3109aeec6ffd6dffb5ed4f5b5a37aacba8"},
+    {file = "coincurve-21.0.0-cp310-cp310-win_arm64.whl", hash = "sha256:070e060d0d57b496e68e48b39d5e3245681376d122827cb8e09f33669ff8cf1b"},
+    {file = "coincurve-21.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:65ec42cab9c60d587fb6275c71f0ebc580625c377a894c4818fb2a2b583a184b"},
+    {file = "coincurve-21.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5828cd08eab928db899238874d1aab12fa1236f30fe095a3b7e26a5fc81df0a3"},
+    {file = "coincurve-21.0.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:54de1cac75182de9f71ce41415faafcaf788303e21cbd0188064e268d61625e5"},
+    {file = "coincurve-21.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:07cda058d9394bea30d57a92fdc18ee3ca6b5bc8ef776a479a2ffec917105836"},
+    {file = "coincurve-21.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9070804d7c71badfe4f0bf19b728cfe7c70c12e733938ead6b1db37920b745c0"},
+    {file = "coincurve-21.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:669ab5db393637824b226de058bb7ea0cb9a0236e1842d7b22f74d4a8a1f1ff1"},
+    {file = "coincurve-21.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:3bcd538af097b3914ec3cb654262e72e224f95f2e9c1eb7fbd75d843ae4e528e"},
+    {file = "coincurve-21.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45b6a5e6b5536e1f46f729829d99ce1f8f847308d339e8880fe7fa1646935c10"},
+    {file = "coincurve-21.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:87597cf30dfc05fa74218810776efacf8816813ab9fa6ea1490f94e9f8b15e77"},
+    {file = "coincurve-21.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:b992d1b1dac85d7f542d9acbcf245667438839484d7f2b032fd032256bcd778e"},
+    {file = "coincurve-21.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f60ad56113f08e8c540bb89f4f35f44d434311433195ffff22893ccfa335070c"},
+    {file = "coincurve-21.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1cb1cd19fb0be22e68ecb60ad950b41f18b9b02eebeffaac9391dc31f74f08f2"},
+    {file = "coincurve-21.0.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:05d7e255a697b3475d7ae7640d3bdef3d5bc98ce9ce08dd387f780696606c33b"},
+    {file = "coincurve-21.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5a366c314df7217e3357bb8c7d2cda540b0bce180705f7a0ce2d1d9e28f62ad4"},
+    {file = "coincurve-21.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1b04778b75339c6e46deb9ae3bcfc2250fbe48d1324153e4310fc4996e135715"},
+    {file = "coincurve-21.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8efcbdcd50cc219989a2662e6c6552f455efc000a15dd6ab3ebf4f9b187f41a3"},
+    {file = "coincurve-21.0.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6df44b4e3b7acdc1453ade52a52e3f8a5b53ecdd5a06bd200f1ec4b4e250f7d9"},
+    {file = "coincurve-21.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bcc0831f07cb75b91c35c13b1362e7b9dc76c376b27d01ff577bec52005e22a8"},
+    {file = "coincurve-21.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:5dd7b66b83b143f3ad3861a68fc0279167a0bae44fe3931547400b7a200e90b1"},
+    {file = "coincurve-21.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:78dbe439e8cb22389956a4f2f2312813b4bd0531a0b691d4f8e868c7b366555d"},
+    {file = "coincurve-21.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9df5ceb5de603b9caf270629996710cf5ed1d43346887bc3895a11258644b65b"},
+    {file = "coincurve-21.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:154467858d23c48f9e5ab380433bc2625027b50617400e2984cc16f5799ab601"},
+    {file = "coincurve-21.0.0-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f57f07c44d14d939bed289cdeaba4acb986bba9f729a796b6a341eab1661eedc"},
+    {file = "coincurve-21.0.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3fb03e3a388a93d31ed56a442bdec7983ea404490e21e12af76fb1dbf097082a"},
+    {file = "coincurve-21.0.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d09ba4fd9d26b00b06645fcd768c5ad44832a1fa847ebe8fb44970d3204c3cb7"},
+    {file = "coincurve-21.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1a1e7ee73bc1b3bcf14c7b0d1f44e6485785d3b53ef7b16173c36d3cefa57f93"},
+    {file = "coincurve-21.0.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ad05952b6edc593a874df61f1bc79db99d716ec48ba4302d699e14a419fe6f51"},
+    {file = "coincurve-21.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4d2bf350ced38b73db9efa1ff8fd16a67a1cb35abb2dda50d89661b531f03fd3"},
+    {file = "coincurve-21.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:54d9500c56d5499375e579c3917472ffcf804c3584dd79052a79974280985c74"},
+    {file = "coincurve-21.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:773917f075ec4b94a7a742637d303a3a082616a115c36568eb6c873a8d950d18"},
+    {file = "coincurve-21.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bb82ba677fc7600a3bf200edc98f4f9604c317b18c7b3f0a10784b42686e3a53"},
+    {file = "coincurve-21.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5001de8324c35eee95f34e011a5c3b4e7d9ae9ca4a862a93b2c89b3f467f511b"},
+    {file = "coincurve-21.0.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b4d0bb5340bcac695731bef51c3e0126f252453e2d1ae7fa1486d90eff978bf6"},
+    {file = "coincurve-21.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5a9b49789ff86f3cf86cfc8ff8c6c43bac2607720ec638e8ba471fa7e8765bd2"},
+    {file = "coincurve-21.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b85b49e192d2ca1a906a7b978bacb55d4dcb297cc2900fbbd9b9180d50878779"},
+    {file = "coincurve-21.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ad6445f0bb61b3a4404d87a857ddb2a74a642cd4d00810237641aab4d6b1a42f"},
+    {file = "coincurve-21.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:d3f017f1491491f3f2c49e5d2d3a471a872d75117bfcb804d1167061c94bd347"},
+    {file = "coincurve-21.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:500e5e38cd4cbc4ea8a5c631ce843b1d52ef19ac41128568214d150f75f1f387"},
+    {file = "coincurve-21.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:ef81ca24511a808ad0ebdb8fdaf9c5c87f12f935b3d117acccc6520ad671bcce"},
+    {file = "coincurve-21.0.0-cp39-cp39-win_arm64.whl", hash = "sha256:6ec8e859464116a3c90168cd2bd7439527d4b4b5e328b42e3c8e0475f9b0bf71"},
+    {file = "coincurve-21.0.0.tar.gz", hash = "sha256:8b37ce4265a82bebf0e796e21a769e56fdbf8420411ccbe3fafee4ed75b6a6e5"},
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -3007,4 +3067,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.12,<4.0"
-content-hash = "ec2cb7c1a5bc8e541b00d3d2055decb6df967082d0b1402f3597cf0a27f27acb"
+content-hash = "18943dbd0269b6ef8a08ef3cea5527fa5f816736bad9b8920e0484c384c48c82"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ confluent-kafka = "^2.2.0"
 web3 = "^7.8.0"
 ssz = "^0.5.0"
 json-stream = "^2.3.2"
+coincurve = "^21.0.0"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.15.9"

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -59,7 +59,6 @@ from metrics.metrics import (
     TOPUP_GAS_OK_LAST_RUN_TIMESTAMP,
     TOPUP_GATEWAY_PAUSED,
     TOPUP_TX_SEND,
-    UNEXPECTED_EXCEPTIONS,
 )
 from metrics.transport_message_metrics import message_metrics_filter
 from providers.consensus import ConsensusClient
@@ -72,7 +71,7 @@ from transport.msg_providers.onchain_transport import (
 )
 from transport.msg_providers.rabbit import MessageType, RabbitProvider
 from transport.msg_storage import MessageStorage
-from transport.msg_types.common import BotMessage, get_messages_sign_filter
+from transport.msg_types.common import BotMessage, get_guardian_filter, get_messages_sign_filter
 from transport.msg_types.deposit import DepositMessage, DepositMessageSchema
 from transport.msg_types.ping import PingMessageSchema, to_check_sum_address
 from transport.types import TransportType
@@ -831,24 +830,10 @@ class DepositorBot:
     def _get_message_actualize_filter(self) -> Callable[[DepositMessage], bool]:
         latest = self.w3.eth.get_block('latest')
         deposit_root = '0x' + self.w3.lido.deposit_contract.get_deposit_root().hex()
-        # {delegate_EOA: guardian_contract} at the current block. Rebuilt every cycle so a message
-        # whose signer is no longer the guardian's active delegate (rotated, revoked, terminated) is
-        # dropped — the off-chain mirror of the on-chain ERC-1271 check, which fails closed.
-        delegate_map = self.w3.lido.get_guardian_delegates()
-        guardians_list = set(delegate_map.values())
+        guardian_filter = get_guardian_filter(self.w3.lido.get_guardian_delegates())
 
         def message_filter(message: DepositMessage) -> bool:
-            delegate = message.get('guardianDelegate')
-            if delegate is not None:
-                # Data Bus message under the delegation model: the delegate that signed must still be
-                # the guardian's active delegate, and still map to the same guardian.
-                if delegate_map.get(delegate) != message['guardianAddress']:
-                    UNEXPECTED_EXCEPTIONS.labels('unexpected_guardian_address').inc()
-                    return False
-            elif message['guardianAddress'] not in guardians_list:
-                # Legacy path (e.g. RabbitMQ) that carries no delegate: the guardian must still be
-                # registered.
-                UNEXPECTED_EXCEPTIONS.labels('unexpected_guardian_address').inc()
+            if not guardian_filter(message):
                 return False
 
             if message['blockNumber'] < latest['number'] - 200:

--- a/src/bots/pauser.py
+++ b/src/bots/pauser.py
@@ -11,12 +11,11 @@ import variables
 from blockchain.executor import Executor
 from blockchain.typings import Web3
 from cryptography.verify_signature import to_guardian_signature
-from metrics.metrics import UNEXPECTED_EXCEPTIONS
 from metrics.transport_message_metrics import message_metrics_filter
 from transport.msg_providers.onchain_transport import OnchainTransportProvider, PauseV3Parser, PauseV4Parser, PingParser
 from transport.msg_providers.rabbit import MessageType, RabbitProvider
 from transport.msg_storage import MessageStorage
-from transport.msg_types.common import get_messages_sign_filter
+from transport.msg_types.common import get_guardian_filter, get_messages_sign_filter
 from transport.msg_types.pause import PauseMessage, PauseMessageSchema
 from transport.msg_types.ping import PingMessageSchema, to_check_sum_address
 from transport.types import TransportType
@@ -93,11 +92,10 @@ class PauserBot:
     def _get_message_actualize_filter(self) -> Callable[[PauseMessage], bool]:
         current_block = self.w3.eth.get_block('latest')
         message_validity_time = self.w3.lido.deposit_security_module.get_pause_intent_validity_period_blocks()
-        guardians_list = self.w3.lido.deposit_security_module.get_guardians()
+        guardian_filter = get_guardian_filter(self.w3.lido.get_guardian_delegates())
 
         def message_filter(message: PauseMessage) -> bool:
-            if message['guardianAddress'] not in guardians_list:
-                UNEXPECTED_EXCEPTIONS.labels('unexpected_guardian_address').inc()
+            if not guardian_filter(message):
                 return False
 
             return message['blockNumber'] > current_block['number'] - message_validity_time

--- a/src/bots/unvetter.py
+++ b/src/bots/unvetter.py
@@ -157,11 +157,10 @@ class UnvetterBot:
         return result
 
     def _clear_outdated_messages(self, module_ids: set[int]) -> None:
-        """Evict messages this cycle's unvets left behind: a sent unvet advances its module nonce, so
-        every retained message below it can only revert.
+        """Evict messages left behind by this cycle's unvets: a sent unvet advances its module nonce.
 
-        Once per cycle, and without the signature filter — `receive_unvet_messages` already applied it
-        to the whole retained set, and re-applying it per message made the cycle quadratic.
+        Signatures are not re-checked — `receive_unvet_messages` already did, and doing it per message
+        made the cycle quadratic in the retained backlog.
         """
         if not module_ids or self.message_storage is None:
             return

--- a/src/bots/unvetter.py
+++ b/src/bots/unvetter.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Callable
-from typing import TypedDict, cast
+from typing import cast
 
 from schema import Or, Schema
 from web3.types import BlockData
@@ -9,12 +9,11 @@ import variables
 from blockchain.executor import Executor
 from blockchain.typings import Web3
 from cryptography.verify_signature import to_guardian_signature
-from metrics.metrics import UNEXPECTED_EXCEPTIONS
 from metrics.transport_message_metrics import message_metrics_filter
 from transport.msg_providers.onchain_transport import OnchainTransportProvider, PingParser, UnvetV1Parser, UnvetV2Parser
 from transport.msg_providers.rabbit import MessageType, RabbitProvider
 from transport.msg_storage import MessageStorage
-from transport.msg_types.common import get_messages_sign_filter
+from transport.msg_types.common import get_guardian_filter, get_messages_sign_filter
 from transport.msg_types.ping import PingMessageSchema, to_check_sum_address
 from transport.msg_types.unvet import UnvetMessage, UnvetMessageSchema
 from transport.types import TransportType
@@ -85,6 +84,7 @@ class UnvetterBot:
         for message in messages:
             self._send_unvet_message(message)
 
+        self._clear_outdated_messages({message['stakingModuleId'] for message in messages})
         return True
 
     def receive_unvet_messages(self) -> list[UnvetMessage]:
@@ -103,11 +103,10 @@ class UnvetterBot:
         for module_id in modules:
             nonces[module_id] = self.w3.lido.staking_router.get_staking_module_nonce(module_id)
 
-        guardians_list = self.w3.lido.deposit_security_module.get_guardians()
+        guardian_filter = get_guardian_filter(self.w3.lido.get_guardian_delegates())
 
         def message_filter(message: UnvetMessage) -> bool:
-            if message['guardianAddress'] not in guardians_list:
-                UNEXPECTED_EXCEPTIONS.labels('unexpected_guardian_address').inc()
+            if not guardian_filter(message):
                 return False
 
             # If message nonce is lower than in module, message is invalid
@@ -120,10 +119,6 @@ class UnvetterBot:
         module_id = message['stakingModuleId']
 
         logger.warning({'msg': f'Handle unvet message for module: {module_id}', 'value': message})
-
-        actual_nonce = self.w3.lido.staking_router.get_staking_module_nonce(module_id)
-
-        self._clear_outdated_messages_for_module(module_id, actual_nonce)
 
         operator_ids = from_hex_string_to_bytes(message['operatorIds'])
         max_operators_per_unvetting = self.w3.lido.deposit_security_module.get_max_operators_per_unvetting()
@@ -161,12 +156,20 @@ class UnvetterBot:
         logger.info({'msg': f'Transaction send. Result is {result}.', 'value': result})
         return result
 
-    def _clear_outdated_messages_for_module(self, module_id: int, nonce: int):
-        prefix = self.w3.lido.deposit_security_module.get_unvet_message_prefix()
-        is_message_signed_filter = get_messages_sign_filter(prefix, delegated=self.w3.lido.guardian_delegation_active())
+    def _clear_outdated_messages(self, module_ids: set[int]) -> None:
+        """Evict messages this cycle's unvets left behind: a sent unvet advances its module nonce, so
+        every retained message below it can only revert.
 
-        def is_unvet_message_relevant(msg: TypedDict) -> bool:
-            is_message_relevant = msg['stakingModuleId'] != module_id or int(msg['nonce']) >= nonce
-            return is_message_relevant and is_message_signed_filter(msg)
+        Once per cycle, and without the signature filter — `receive_unvet_messages` already applied it
+        to the whole retained set, and re-applying it per message made the cycle quadratic.
+        """
+        if not module_ids or self.message_storage is None:
+            return
 
-        self.message_storage.get_messages_and_actualize(is_unvet_message_relevant)
+        nonces = {module_id: self.w3.lido.staking_router.get_staking_module_nonce(module_id) for module_id in module_ids}
+
+        def is_relevant(message: UnvetMessage) -> bool:
+            nonce = nonces.get(message['stakingModuleId'])
+            return nonce is None or int(message['nonce']) >= nonce
+
+        self.message_storage.get_messages_and_actualize(is_relevant)

--- a/src/transport/msg_types/common.py
+++ b/src/transport/msg_types/common.py
@@ -22,11 +22,8 @@ BotMessage = DepositMessage | PauseMessage | UnvetMessage | PingMessage
 def get_guardian_filter(delegate_map: dict[ChecksumAddress, ChecksumAddress]) -> Callable[[BotMessage], bool]:
     """Returns a filter that checks a message still comes from a currently registered guardian.
 
-    ``delegate_map`` is ``{delegate_EOA: guardian_contract}`` at the current block. A Data Bus message
-    under delegation carries ``guardianDelegate``, which must still be that guardian's active delegate
-    — the off-chain mirror of the on-chain ERC-1271 check, so a rotated, revoked or terminated
-    delegate is dropped instead of being retried until its nonce goes stale. A message without a
-    delegate (e.g. RabbitMQ) is only checked for guardian registration.
+    ``delegate_map`` is ``{delegate_EOA: guardian_contract}``. Under delegation the signer must still
+    be the guardian's active delegate — the off-chain mirror of the on-chain ERC-1271 check.
     """
     guardians = set(delegate_map.values())
 

--- a/src/transport/msg_types/common.py
+++ b/src/transport/msg_types/common.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from typing import Any, cast
 
 from eth_account.account import VRS
+from eth_typing import ChecksumAddress
 
 from cryptography.verify_signature import recover_vs, verify_message_with_signature
 from metrics.metrics import UNEXPECTED_EXCEPTIONS
@@ -16,6 +17,31 @@ from utils.bytes import from_hex_string_to_bytes
 logger = logging.getLogger(__name__)
 
 BotMessage = DepositMessage | PauseMessage | UnvetMessage | PingMessage
+
+
+def get_guardian_filter(delegate_map: dict[ChecksumAddress, ChecksumAddress]) -> Callable[[BotMessage], bool]:
+    """Returns a filter that checks a message still comes from a currently registered guardian.
+
+    ``delegate_map`` is ``{delegate_EOA: guardian_contract}`` at the current block. A Data Bus message
+    under delegation carries ``guardianDelegate``, which must still be that guardian's active delegate
+    — the off-chain mirror of the on-chain ERC-1271 check, so a rotated, revoked or terminated
+    delegate is dropped instead of being retried until its nonce goes stale. A message without a
+    delegate (e.g. RabbitMQ) is only checked for guardian registration.
+    """
+    guardians = set(delegate_map.values())
+
+    def guardian_filter(message: BotMessage) -> bool:
+        delegate = cast(dict, message).get('guardianDelegate')
+        if delegate is not None:
+            if delegate_map.get(delegate) == message['guardianAddress']:
+                return True
+        elif message['guardianAddress'] in guardians:
+            return True
+
+        UNEXPECTED_EXCEPTIONS.labels('unexpected_guardian_address').inc()
+        return False
+
+    return guardian_filter
 
 
 def get_messages_sign_filter(prefix: bytes, delegated: bool = False) -> Callable:

--- a/tests/bots/test_pauser.py
+++ b/tests/bots/test_pauser.py
@@ -20,7 +20,7 @@ def pause_bot(web3_lido_unit, block_data):
     web3_lido_unit.eth.get_block = Mock(return_value=block_data)
     variables.MESSAGE_TRANSPORTS = ''
     web3_lido_unit.lido.deposit_security_module.get_pause_intent_validity_period_blocks = Mock(return_value=10)
-    web3_lido_unit.lido.deposit_security_module.get_guardians = Mock(return_value=[COUNCIL_ADDRESS])
+    web3_lido_unit.lido.get_guardian_delegates = Mock(return_value={COUNCIL_ADDRESS: COUNCIL_ADDRESS})
     yield PauserBot(web3_lido_unit)
 
 
@@ -156,7 +156,7 @@ def test_pauser_bot(web3_lido_integration, web3_provider_integration, add_accoun
     # Create PauserBot
     pb = PauserBot(web3_lido_integration)
     pb._get_message_actualize_filter = Mock(return_value=lambda x: True)
-    web3_lido_integration.lido.deposit_security_module.get_guardians = Mock(return_value=[COUNCIL_ADDRESS])
+    web3_lido_integration.lido.get_guardian_delegates = Mock(return_value={COUNCIL_ADDRESS: COUNCIL_ADDRESS})
 
     # Execute without messages - verify module is active
     pb.execute(latest)
@@ -185,3 +185,22 @@ def test_pauser_bot(web3_lido_integration, web3_provider_integration, add_accoun
     pb.message_storage.messages = [pause_message]
     pb.execute(latest)
     assert not pb.message_storage.messages, 'Messages should be cleared after module is paused'
+
+
+GUARDIAN = '0x3dc4cF780F2599B528F37dedB34449Fb65Ef7d4A'
+DELEGATE = '0x5fd0dDbC3351d009eb3f88DE7Cd081a614C519F1'
+REVOKED_DELEGATE = '0x43464Fe06c18848a2E2e913194D64c1970f4326a'
+
+
+@pytest.mark.unit
+def test_actualize_filter_drops_revoked_delegate(web3_lido_unit):
+    bot = PauserBot(web3_lido_unit)
+    web3_lido_unit.eth.get_block = Mock(return_value={'number': 100})
+    web3_lido_unit.lido.deposit_security_module.get_pause_intent_validity_period_blocks = Mock(return_value=10)
+    web3_lido_unit.lido.get_guardian_delegates = Mock(return_value={DELEGATE: GUARDIAN})
+
+    message_filter = bot._get_message_actualize_filter()
+    message = {'guardianAddress': GUARDIAN, 'guardianDelegate': DELEGATE, 'blockNumber': 95}
+
+    assert message_filter(message) is True
+    assert message_filter({**message, 'guardianDelegate': REVOKED_DELEGATE}) is False

--- a/tests/bots/test_unvetter.py
+++ b/tests/bots/test_unvetter.py
@@ -117,8 +117,6 @@ def _unvet_message(nonce: int = 5, module_id: int = 1) -> dict:
 
 @pytest.mark.unit
 def test_storage_is_actualized_once_per_cycle(web3_lido_unit):
-    """One actualization for the whole cycle, not one per message — the latter re-verified every
-    retained signature on every message, making the cycle quadratic."""
     bot = UnvetterBot(web3_lido_unit)
     bot.prepare_transport_bus = Mock()
     bot.message_storage = Mock()

--- a/tests/bots/test_unvetter.py
+++ b/tests/bots/test_unvetter.py
@@ -80,7 +80,7 @@ def test_unvetter(web3_provider_integration, web3_lido_integration, caplog):
     ub._get_message_actualize_filter = Mock(return_value=lambda x: True)
 
     ub.execute(latest)
-    web3_lido_integration.lido.deposit_security_module.get_guardians = Mock(return_value=[COUNCIL_ADDRESS])
+    web3_lido_integration.lido.get_guardian_delegates = Mock(return_value={COUNCIL_ADDRESS: COUNCIL_ADDRESS})
     ub.message_storage.messages = [get_unvet_message(web3_lido_integration)]
 
     caplog.set_level(logging.INFO)
@@ -93,3 +93,69 @@ def test_unvetter(web3_provider_integration, web3_lido_integration, caplog):
     web3_lido_integration.lido.staking_router.get_staking_module_nonce = Mock(return_value=ub.message_storage.messages[0]['nonce'] + 1)
     ub.execute(latest)
     assert not ub.message_storage.messages
+
+
+GUARDIAN = '0x3dc4cF780F2599B528F37dedB34449Fb65Ef7d4A'
+DELEGATE = '0x5fd0dDbC3351d009eb3f88DE7Cd081a614C519F1'
+REVOKED_DELEGATE = '0x43464Fe06c18848a2E2e913194D64c1970f4326a'
+
+
+def _unvet_message(nonce: int = 5, module_id: int = 1) -> dict:
+    return {
+        'type': 'unvet',
+        'blockNumber': 1,
+        'blockHash': '0x' + '22' * 32,
+        'guardianAddress': GUARDIAN,
+        'guardianDelegate': DELEGATE,
+        'stakingModuleId': module_id,
+        'nonce': nonce,
+        'operatorIds': '0x0000000000000001',
+        'vettedKeysByOperator': '0x00000002',
+        'signature': {'r': '0x' + '11' * 32, '_vs': '0x' + '22' * 32},
+    }
+
+
+@pytest.mark.unit
+def test_storage_is_actualized_once_per_cycle(web3_lido_unit):
+    """One actualization for the whole cycle, not one per message — the latter re-verified every
+    retained signature on every message, making the cycle quadratic."""
+    bot = UnvetterBot(web3_lido_unit)
+    bot.prepare_transport_bus = Mock()
+    bot.message_storage = Mock()
+    bot.receive_unvet_messages = Mock(return_value=[_unvet_message() for _ in range(20)])
+    web3_lido_unit.lido.deposit_security_module.get_max_operators_per_unvetting = Mock(return_value=100)
+    web3_lido_unit.lido.guardian_delegation_active = Mock(return_value=False)
+    web3_lido_unit.lido.staking_router.get_staking_module_nonce = Mock(return_value=6)
+    web3_lido_unit.transaction = Mock()
+    web3_lido_unit.transaction.check = Mock(return_value=False)
+
+    bot.execute(Mock())
+
+    assert bot.message_storage.get_messages_and_actualize.call_count == 1
+
+
+@pytest.mark.unit
+def test_outdated_messages_are_evicted_by_nonce(web3_lido_unit):
+    bot = UnvetterBot(web3_lido_unit)
+    bot.message_storage = Mock()
+    web3_lido_unit.lido.staking_router.get_staking_module_nonce = Mock(return_value=6)
+
+    bot._clear_outdated_messages({1})
+    (is_relevant,) = bot.message_storage.get_messages_and_actualize.call_args.args
+
+    assert is_relevant(_unvet_message(nonce=6)) is True
+    assert is_relevant(_unvet_message(nonce=5)) is False
+    assert is_relevant(_unvet_message(nonce=0, module_id=2)) is True  # module untouched this cycle
+
+
+@pytest.mark.unit
+def test_actualize_filter_drops_revoked_delegate(web3_lido_unit):
+    bot = UnvetterBot(web3_lido_unit)
+    web3_lido_unit.lido.staking_router.get_staking_module_ids = Mock(return_value=[1])
+    web3_lido_unit.lido.staking_router.get_staking_module_nonce = Mock(return_value=5)
+    web3_lido_unit.lido.get_guardian_delegates = Mock(return_value={DELEGATE: GUARDIAN})
+
+    message_filter = bot._get_message_actualize_filter()
+
+    assert message_filter(_unvet_message()) is True
+    assert message_filter({**_unvet_message(), 'guardianDelegate': REVOKED_DELEGATE}) is False


### PR DESCRIPTION
Tickets: **RES-06**, **DB-EDF-PAUSE-AUTH-02**, **DBOT-UNVET-TX-04**.

## RES-06 — the unvet cycle was quadratic in the retained backlog

`_send_unvet_message` called `_clear_outdated_messages_for_module` for every message, and that ran the signature filter over the whole retained list — N messages cost N² signature checks plus an RPC each. Clearing now runs once per cycle and only compares nonces; signatures were already verified in `receive_unvet_messages` and cannot change.

**secp256k1 ran in pure Python.** `coincurve` was not in the lock, so `eth-keys` fell back to `NativeECCBackend` for every signature check in every bot. Measured on the unvet digest: `ecrecover` 5570 µs → 67 µs. No code change; `eth-keys` selects the backend on import.

Together, a 376-message backlog goes from ~829 s to ~0.1 s.

Lock regenerated with Poetry 1.8.4 — the Dockerfile pins 1.8.2, which cannot read the `lock-version = "2.1"` a Poetry 2.x rewrite produces. The diff is the `coincurve` entry only.

## DB-EDF-PAUSE-AUTH-02 — revoked delegates and blind pause broadcasts

**Retained messages outlived their delegate.** The Data Bus topic filter stops fetching from a revoked delegate, but messages already in storage kept passing the pauser's and unvetter's filters, which only checked guardian registration. Both now use the depositor's delegate-freshness check, extracted as `get_guardian_filter`.

**The pauser broadcast without simulating.** It was the only bot doing so, although `send()` already pays for an `estimate_gas` round-trip and then discards the result — `_estimate_gas` falls back to `CONTRACT_GAS_LIMIT` on a revert and broadcasts anyway. A pause intent only ages further past its validity window between simulation and inclusion, so a simulated revert cannot be a false negative.

## DBOT-UNVET-TX-04 — a delivered payload was replayed

Eviction keyed only on the module nonce, assuming a successful unvet always advances it. A module that treats the payload as a no-op — every requested vetted count already equal to the current one — accepts it and leaves the nonce where it was, so the same message passed the filter and was broadcast again on every later cycle until it aged out. An honest council can produce such a payload from a Keys API snapshot that lags an unvet it already submitted itself.

A delivered payload is now dropped on its own, which holds whether or not the nonce moved — so this does not depend on confirming the module-side behaviour. Rejecting all-no-op vectors before broadcast would need `totalVettedKeys` per operator, an RPC per message, to duplicate a check the module already performs.

## Tests

Six added, all failing on `develop`: one actualization per cycle for 20 messages, eviction by nonce, delivered payload evicted without a nonce change, revoked delegate dropped (unvetter and pauser), pause not broadcast when simulation reverts.

Unit suite 306 passed. Pyright 45 errors vs 48 on `develop`.

---

Linear: [STC-941](https://linear.app/lidofi/issue/STC-941)
