### PR TITLE
fix: a zero DSM quorum must not block top-ups

### DIFF
--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -256,9 +256,6 @@ class DepositorBot:
         if not self.w3.lido.lido.can_deposit():
             logger.info({'msg': 'Lido.canDeposit() is false.'})
             return False
-        if self.w3.lido.deposit_security_module.get_guardian_quorum() == 0:
-            logger.info({'msg': 'Guardian quorum is not set in DSM contract (quorum == 0).'})
-            return False
         return True
 
     def _execute_actual(self) -> bool:
@@ -802,6 +799,12 @@ class DepositorBot:
         # Get the required quorum size
         min_signs_to_deposit = self.w3.lido.deposit_security_module.get_guardian_quorum()
         CURRENT_QUORUM_SIZE.labels('required').set(min_signs_to_deposit)
+
+        # Every group clears a zero threshold, so a single signature would pass as a quorum.
+        if min_signs_to_deposit == 0:
+            logger.warning({'msg': 'Guardian quorum is 0 in DSM contract — refusing to deposit.', 'module_id': module_id})
+            QUORUM.labels(module_id).set(0)
+            return None
 
         # Group messages by block hash and guardian address
         messages_by_block_hash = defaultdict(dict)

--- a/tests/bots/test_depositor.py
+++ b/tests/bots/test_depositor.py
@@ -241,9 +241,9 @@ class TestCommonPreconditions(unittest.TestCase):
         self.bot.w3.lido.lido.can_deposit = Mock(return_value=False)
         self.assertFalse(self.bot._common_preconditions())
 
-    def test_fails_when_quorum_zero(self):
+    def test_passes_when_quorum_zero_so_top_ups_are_not_blocked(self):
         self.bot.w3.lido.deposit_security_module.get_guardian_quorum = Mock(return_value=0)
-        self.assertFalse(self.bot._common_preconditions())
+        self.assertTrue(self.bot._common_preconditions())
 
 
 # ─── _publish_allocation_metrics ─────────────────────────────────────
@@ -1875,3 +1875,13 @@ def test_depositor_bot(
     db.message_storage.messages = deposit_messages
     assert db.execute(latest)
     assert web3_lido_integration.lido.staking_router.get_staking_module_nonce(module_id) == old_module_nonce + 1
+
+
+@pytest.mark.unit
+def test_zero_quorum_still_refuses_to_deposit(depositor_bot):
+    message = {'blockHash': '0x' + '43' * 32, 'guardianAddress': '0x43464Fe06c18848a2E2e913194D64c1970f4326a'}
+    depositor_bot._fetch_actual_messages = Mock(return_value=[message])
+    depositor_bot._get_module_messages_filter = Mock(return_value=lambda _: True)
+    depositor_bot.w3.lido.deposit_security_module.get_guardian_quorum = Mock(return_value=0)
+
+    assert depositor_bot._get_quorum(1) is None


### PR DESCRIPTION
Ticket: **RES-07**.

`_common_preconditions` checked the DSM guardian quorum, and its caller returns before Phase B — so a quorum of zero stopped every top-up as well, although `TopUpGateway.topUp` authorises on `TOP_UP_ROLE` and consumes no guardian signature. Its docstring says the gates are "required for ANY deposit/top-up", which is true of `can_deposit()` and not of the quorum.

The gate cannot simply be removed: `_get_quorum` returns the first group whose size is `>= min_signs_to_deposit`, so a threshold of zero lets one signature pass as a quorum. Moved it there, where it still refuses to deposit but no longer reaches the top-up path.

`can_deposit()` stays in `_common_preconditions` — bunker mode and a stopped protocol should block top-ups too.

Tests: quorum zero passes the common gate; quorum zero still yields no deposit quorum. Both fail on `develop`.

Unit suite 301 passed. Pyright 48, same as `develop`.

---

Linear: [STC-943](https://linear.app/lidofi/issue/STC-943)
