### PR TITLE
fix: report metrics on the delegate EOA, not the guardian contract

### DIFF
--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -762,30 +762,32 @@ class DepositorBot:
 
         logger.info({'msg': 'Check guardians balances.'})
 
-        delegate_map = self.w3.lido.get_guardian_delegates()
+        guardian_contract_by_delegate_eoa = self.w3.lido.get_guardian_delegates()
         providers = [self.w3]
 
         if self._onchain_transport_w3 is not None:
             providers.append(self._onchain_transport_w3)
 
         new_values = {}
-        for delegate, guardian in delegate_map.items():
+        for delegate_eoa, guardian_contract in guardian_contract_by_delegate_eoa.items():
             for provider in providers:
-                balance = provider.eth.get_balance(delegate)
-                new_values[(delegate, guardian, provider.eth.chain_id)] = balance
+                balance = provider.eth.get_balance(delegate_eoa)
+                new_values[(delegate_eoa, guardian_contract, provider.eth.chain_id)] = balance
 
         GUARDIAN_BALANCE.clear()
-        for (delegate, guardian, chain_id), balance in new_values.items():
-            GUARDIAN_BALANCE.labels(address=delegate, guardian=guardian, chain_id=chain_id).set(balance)
+        for (delegate_eoa, guardian_contract, chain_id), balance in new_values.items():
+            GUARDIAN_BALANCE.labels(address=delegate_eoa, guardian=guardian_contract, chain_id=chain_id).set(balance)
 
     def _check_guardian_delegates(self):
-        guardians = [self.w3.to_checksum_address(g) for g in self.w3.lido.deposit_security_module.get_guardians()]
-        delegate_by_guardian = {guardian: delegate for delegate, guardian in self.w3.lido.get_guardian_delegates().items()}
+        guardian_contracts = [self.w3.to_checksum_address(g) for g in self.w3.lido.deposit_security_module.get_guardians()]
+        delegate_eoa_by_guardian_contract = {
+            guardian_contract: delegate_eoa for delegate_eoa, guardian_contract in self.w3.lido.get_guardian_delegates().items()
+        }
 
         GUARDIAN_DELEGATE.clear()
-        for guardian in guardians:
-            delegate = delegate_by_guardian.get(guardian)
-            GUARDIAN_DELEGATE.labels(guardian=guardian, delegate=delegate or ZERO_ADDRESS).set(int(delegate is not None))
+        for guardian_contract in guardian_contracts:
+            delegate_eoa = delegate_eoa_by_guardian_contract.get(guardian_contract)
+            GUARDIAN_DELEGATE.labels(guardian=guardian_contract, delegate=delegate_eoa or ZERO_ADDRESS).set(int(delegate_eoa is not None))
 
     def _select_strategy(self, module_id: int) -> DepositStrategy:
         module = self.w3.lido.staking_module(module_id)

--- a/src/bots/depositor.py
+++ b/src/bots/depositor.py
@@ -35,6 +35,7 @@ from blockchain.topup.cmv2_strategy import CMv2TopUpStrategy
 from blockchain.topup.csm02_strategy import CSM02TopUpStrategy
 from blockchain.topup.strategy import TopUpStrategy
 from blockchain.typings import Web3
+from blockchain.web3_extentions.lido_contracts import ZERO_ADDRESS
 from metrics.metrics import (
     ACCOUNT_BALANCE,
     BOT_LAST_CYCLE_TIMESTAMP,
@@ -43,6 +44,7 @@ from metrics.metrics import (
     DEPOSITABLE_ETHER,
     DEPOSITS_PAUSED,
     GUARDIAN_BALANCE,
+    GUARDIAN_DELEGATE,
     MODULE_ALLOCATION,
     MODULE_CONTRACT_MISSING,
     MODULE_QUORUM_LAST_SEEN_TIMESTAMP,
@@ -240,6 +242,7 @@ class DepositorBot:
     def execute(self, block: BlockData) -> bool:
         logger.info({'msg': 'Depositor iteration start.', 'block_number': block.get('number')})
         self._check_balance()
+        self._check_guardian_delegates()
 
         result = self._execute_actual()
         BOT_LAST_CYCLE_TIMESTAMP.set(time.time())
@@ -759,21 +762,30 @@ class DepositorBot:
 
         logger.info({'msg': 'Check guardians balances.'})
 
-        guardians = self.w3.lido.deposit_security_module.get_guardians()
+        delegate_map = self.w3.lido.get_guardian_delegates()
         providers = [self.w3]
 
         if self._onchain_transport_w3 is not None:
             providers.append(self._onchain_transport_w3)
 
         new_values = {}
-        for address in guardians:
+        for delegate, guardian in delegate_map.items():
             for provider in providers:
-                balance = provider.eth.get_balance(address)
-                new_values[(address, provider.eth.chain_id)] = balance
+                balance = provider.eth.get_balance(delegate)
+                new_values[(delegate, guardian, provider.eth.chain_id)] = balance
 
         GUARDIAN_BALANCE.clear()
-        for (address, chain_id), balance in new_values.items():
-            GUARDIAN_BALANCE.labels(address=address, chain_id=chain_id).set(balance)
+        for (delegate, guardian, chain_id), balance in new_values.items():
+            GUARDIAN_BALANCE.labels(address=delegate, guardian=guardian, chain_id=chain_id).set(balance)
+
+    def _check_guardian_delegates(self):
+        guardians = [self.w3.to_checksum_address(g) for g in self.w3.lido.deposit_security_module.get_guardians()]
+        delegate_by_guardian = {guardian: delegate for delegate, guardian in self.w3.lido.get_guardian_delegates().items()}
+
+        GUARDIAN_DELEGATE.clear()
+        for guardian in guardians:
+            delegate = delegate_by_guardian.get(guardian)
+            GUARDIAN_DELEGATE.labels(guardian=guardian, delegate=delegate or ZERO_ADDRESS).set(int(delegate is not None))
 
     def _select_strategy(self, module_id: int) -> DepositStrategy:
         module = self.w3.lido.staking_module(module_id)

--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -25,25 +25,25 @@ MODULE_TX_SEND = Counter(
 DEPOSIT_MESSAGES = Gauge(
     'deposit_messages',
     'Guardians deposit messages',
-    ['address', 'module_id', 'version', 'transport', 'chain_id'],
+    ['address', 'guardian', 'module_id', 'version', 'transport', 'chain_id'],
     namespace=PROMETHEUS_PREFIX,
 )
 PAUSE_MESSAGES = Gauge(
     'pause_messages',
     'Guardians pause messages',
-    ['address', 'module_id', 'version', 'transport', 'chain_id'],
+    ['address', 'guardian', 'module_id', 'version', 'transport', 'chain_id'],
     namespace=PROMETHEUS_PREFIX,
 )
 PING_MESSAGES = Gauge(
     'ping_messages',
     'Guardians ping messages',
-    ['address', 'version', 'transport', 'chain_id'],
+    ['address', 'guardian', 'version', 'transport', 'chain_id'],
     namespace=PROMETHEUS_PREFIX,
 )
 UNVET_MESSAGES = Gauge(
     'unvet_messages',
     'Guardian unvet messages',
-    ['address', 'module_id', 'version', 'transport', 'chain_id'],
+    ['address', 'guardian', 'module_id', 'version', 'transport', 'chain_id'],
     namespace=PROMETHEUS_PREFIX,
 )
 
@@ -92,8 +92,15 @@ ACCOUNT_BALANCE = Gauge(
 
 GUARDIAN_BALANCE = Gauge(
     'guardian_balance',
-    'Balance of the guardian',
-    ['address', 'chain_id'],
+    'Balance of the guardian delegate',
+    ['address', 'guardian', 'chain_id'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
+GUARDIAN_DELEGATE = Gauge(
+    'guardian_delegate',
+    'Whether a registered guardian has an active delegate.',
+    ['guardian', 'delegate'],
     namespace=PROMETHEUS_PREFIX,
 )
 

--- a/src/metrics/transport_message_metrics.py
+++ b/src/metrics/transport_message_metrics.py
@@ -22,8 +22,8 @@ def message_metrics_filter(msg: TypedDict) -> bool:
     msg_type = msg.get('type')
     logger.info({'msg': 'Guardian message received.', 'value': msg, 'type': msg_type})
 
-    guardian = msg.get('guardianAddress')
-    address = msg.get('guardianDelegate') or guardian
+    guardian_contract = msg.get('guardianAddress')
+    sender_eoa = msg.get('guardianDelegate') or guardian_contract
     version = msg.get('app', {}).get('version')
     transport = msg.get('transport', '')
     chain_id = msg.get('chain_id', '')
@@ -37,8 +37,8 @@ def message_metrics_filter(msg: TypedDict) -> bool:
 
     if msg_type in metrics_map:
         metrics_map[msg_type].labels(
-            address=address,
-            guardian=guardian,
+            address=sender_eoa,
+            guardian=guardian_contract,
             module_id=staking_module_id,
             version=version,
             transport=transport,
@@ -47,7 +47,7 @@ def message_metrics_filter(msg: TypedDict) -> bool:
         return True
 
     if msg_type == MessageType.PING:
-        PING_MESSAGES.labels(address=address, guardian=guardian, version=version, transport=transport, chain_id=chain_id).inc()
+        PING_MESSAGES.labels(address=sender_eoa, guardian=guardian_contract, version=version, transport=transport, chain_id=chain_id).inc()
         return False
 
     logger.warning({'msg': 'Received unexpected msg type.', 'value': msg, 'type': msg_type})

--- a/src/metrics/transport_message_metrics.py
+++ b/src/metrics/transport_message_metrics.py
@@ -22,7 +22,8 @@ def message_metrics_filter(msg: TypedDict) -> bool:
     msg_type = msg.get('type')
     logger.info({'msg': 'Guardian message received.', 'value': msg, 'type': msg_type})
 
-    address = msg.get('guardianAddress')
+    guardian = msg.get('guardianAddress')
+    address = msg.get('guardianDelegate') or guardian
     version = msg.get('app', {}).get('version')
     transport = msg.get('transport', '')
     chain_id = msg.get('chain_id', '')
@@ -37,6 +38,7 @@ def message_metrics_filter(msg: TypedDict) -> bool:
     if msg_type in metrics_map:
         metrics_map[msg_type].labels(
             address=address,
+            guardian=guardian,
             module_id=staking_module_id,
             version=version,
             transport=transport,
@@ -45,7 +47,7 @@ def message_metrics_filter(msg: TypedDict) -> bool:
         return True
 
     if msg_type == MessageType.PING:
-        PING_MESSAGES.labels(address=address, version=version, transport=transport, chain_id=chain_id).inc()
+        PING_MESSAGES.labels(address=address, guardian=guardian, version=version, transport=transport, chain_id=chain_id).inc()
         return False
 
     logger.warning({'msg': 'Received unexpected msg type.', 'value': msg, 'type': msg_type})

--- a/tests/metrics/test_transport_message_metrics.py
+++ b/tests/metrics/test_transport_message_metrics.py
@@ -1,0 +1,86 @@
+import pytest
+
+from metrics.metrics import PAUSE_MESSAGES, PING_MESSAGES
+from metrics.transport_message_metrics import message_metrics_filter
+from transport.msg_providers.rabbit import MessageType
+
+GUARDIAN = '0x89e1bEBAf6857312bCDc313B93F29aB9cA98000f'
+DELEGATE = '0x43464Fe06c18848a2E2e913194D64c1970f4326a'
+
+
+def _sample(metric, **labels):
+    expected = {key: str(value) for key, value in labels.items()}
+    for family in metric.collect():
+        for sample in family.samples:
+            if sample.labels == expected:
+                return sample.value
+    return None
+
+
+def _pause_message(**extra) -> dict:
+    return {
+        'type': MessageType.PAUSE,
+        'guardianAddress': GUARDIAN,
+        'blockNumber': 1,
+        'app': {'version': '1.0.0'},
+        'transport': 'onchain',
+        'chain_id': '17000',
+        'stakingModuleId': 1,
+        **extra,
+    }
+
+
+@pytest.mark.unit
+def test_message_labelled_by_delegate():
+    assert message_metrics_filter(_pause_message(guardianDelegate=DELEGATE)) is True
+
+    assert (
+        _sample(
+            PAUSE_MESSAGES,
+            address=DELEGATE,
+            guardian=GUARDIAN,
+            module_id=1,
+            version='1.0.0',
+            transport='onchain',
+            chain_id='17000',
+        )
+        == 1
+    )
+
+
+@pytest.mark.unit
+def test_message_without_delegate_falls_back_to_guardian():
+    assert message_metrics_filter(_pause_message(transport='rabbit')) is True
+
+    assert (
+        _sample(
+            PAUSE_MESSAGES,
+            address=GUARDIAN,
+            guardian=GUARDIAN,
+            module_id=1,
+            version='1.0.0',
+            transport='rabbit',
+            chain_id='17000',
+        )
+        == 1
+    )
+
+
+@pytest.mark.unit
+def test_ping_labelled_by_delegate():
+    msg = _pause_message(type=MessageType.PING, guardianDelegate=DELEGATE)
+    msg.pop('stakingModuleId')
+
+    assert message_metrics_filter(msg) is False
+
+    assert (
+        _sample(
+            PING_MESSAGES,
+            address=DELEGATE,
+            guardian=GUARDIAN,
+            version='1.0.0',
+            transport='onchain',
+            chain_id='17000',
+        )
+        == 1
+    )


### PR DESCRIPTION
## Problem

From DSM v5 a guardian is an ERC-1271 contract: it broadcasts nothing itself, holds no ETH, and exists only on Ethereum.

- `guardian_balance` read `getGuardians()` and asked both providers — including Gnosis, where that address does not exist. Constant zero.
- The message gauges used `guardianAddress`, which the Data Bus transport has already rewritten from the Gnosis sender to the Ethereum guardian contract — so the series mixed an Ethereum address with a Gnosis `chain_id`.

Before v5 a guardian was an EOA with the same address on both chains, which is why this is new.

## Change

- `address` on `deposit/pause/unvet/ping_messages` and on `guardian_balance` is now the delegate EOA — the address that actually sends and pays.
- Both gain a `guardian` label, so a series stays attributable to its council across a delegate rotation.
- New `guardian_delegate{guardian, delegate}` (1/0): a guardian whose `getDelegate()` is zero is dropped from the delegate map and the Data Bus topic filter, so it leaves no series in any other gauge.

Below v5 the delegate map is the identity `{guardian: guardian}` — both labels hold the same address, behaviour unchanged.

Alert rules must be updated after the bots are deployed: `address` moves on both sides of the `and on(address)` join at once, so a half-deployed fleet makes the join match nothing.

## Test plan

- `pytest -m unit` — 314 passed, 3 new.
- `pyright src/` — 48 errors, unchanged from `develop`.
- Not verified on a live v5 deployment.